### PR TITLE
feat(v0.6): content-freshness badges on every built page (#57)

### DIFF
--- a/llmwiki/build.py
+++ b/llmwiki/build.py
@@ -33,12 +33,14 @@ import shutil
 import subprocess
 import sys
 from collections import defaultdict
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
 
 import markdown
 
 from llmwiki import REPO_ROOT
+from llmwiki.freshness import freshness_badge, load_freshness_config
 
 # ─── paths ─────────────────────────────────────────────────────────────────
 
@@ -211,6 +213,29 @@ def get_tools_list(meta: dict[str, Any]) -> list[str]:
 def short_started(meta: dict[str, Any]) -> str:
     s = str(meta.get("started", ""))
     return s[:16].replace("T", " ")
+
+
+# ─── freshness (content staleness) ────────────────────────────────────────
+# Cached once per build so every page sees the same "now" and the same
+# thresholds. Populated lazily by render_freshness().
+_FRESHNESS_CONFIG: Optional[tuple[int, int]] = None
+_BUILD_NOW: Optional[datetime] = None
+
+
+def render_freshness(meta: dict[str, Any]) -> str:
+    """Render a freshness badge for a page's frontmatter using cached config.
+
+    Thresholds come from ``config.json`` (freshness.green_days /
+    yellow_days) or the module defaults. Build-time "now" is cached the
+    first call so the whole site renders with one consistent clock.
+    """
+    global _FRESHNESS_CONFIG, _BUILD_NOW
+    if _FRESHNESS_CONFIG is None:
+        _FRESHNESS_CONFIG = load_freshness_config()
+    if _BUILD_NOW is None:
+        _BUILD_NOW = datetime.utcnow()
+    green, yellow = _FRESHNESS_CONFIG
+    return freshness_badge(meta, now=_BUILD_NOW, green_days=green, yellow_days=yellow)
 
 
 # ─── html template helpers ─────────────────────────────────────────────────
@@ -462,6 +487,7 @@ def render_session(
     if meta.get("tool_calls"):
         bits.append(f'{html.escape(str(meta["tool_calls"]))} tools')
     bits.append(f'<span class="muted">{reading_min} min read</span>')
+    bits.append(render_freshness(meta))
     meta_strip = " · ".join(bits) if bits else ""
 
     tools_list = get_tools_list(meta)
@@ -541,10 +567,12 @@ def render_project_page(
         umsgs = meta.get("user_messages", "")
         tcalls = meta.get("tool_calls", "")
         href = f"../sessions/{project_slug}/{p.stem}.html"
+        badge = render_freshness(meta)
         return f"""  <a class="card" href="{href}">
     <div class="card-title">{html.escape(str(slug))}</div>
     <div class="card-meta">{html.escape(str(date))} · {html.escape(str(model))}</div>
     <div class="card-stats muted">{html.escape(str(umsgs))} messages · {html.escape(str(tcalls))} tool calls</div>
+    <div class="card-badge">{badge}</div>
   </a>"""
 
     cards_main = "\n".join(card(p, m) for p, m, _ in main_sessions)
@@ -607,10 +635,18 @@ def render_projects_index(
     for project, sessions in sorted(groups.items(), key=lambda x: -len(x[1])):
         main_count = sum(1 for p, _, _ in sessions if "subagent" not in p.name)
         sub_count = len(sessions) - main_count
+        # Freshness reflects the newest session in the project.
+        newest_meta = max(
+            (m for _, m, _ in sessions),
+            key=lambda m: str(m.get("ended") or m.get("started") or m.get("date") or ""),
+            default={},
+        )
+        badge = render_freshness(newest_meta)
         cards.append(
             f"""  <a class="card" href="{html.escape(project)}.html">
     <div class="card-title">{html.escape(project)}</div>
     <div class="card-meta">{main_count} main · {sub_count} sub-agent</div>
+    <div class="card-badge">{badge}</div>
   </a>"""
         )
 
@@ -1058,6 +1094,31 @@ kbd { display: inline-block; padding: 2px 6px; font-family: var(--mono); font-si
 .card-title { font-weight: 600; font-size: 0.95rem; margin-bottom: 4px; color: var(--text); }
 .card-meta { font-size: 0.82rem; color: var(--text-secondary); }
 .card-stats { font-size: 0.78rem; margin-top: 6px; }
+.card-badge { margin-top: 8px; }
+
+/* Content-freshness badge (#57) */
+.freshness {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 2px 10px; border-radius: 999px;
+  font-size: 0.72rem; font-weight: 600; white-space: nowrap;
+  border: 1px solid;
+}
+.freshness::before {
+  content: ""; width: 6px; height: 6px; border-radius: 50%;
+  background: currentColor;
+}
+.fresh-green   { color: #15803d; background: #dcfce7; border-color: #86efac; }
+.fresh-yellow  { color: #b45309; background: #fef3c7; border-color: #fcd34d; }
+.fresh-red     { color: #b91c1c; background: #fee2e2; border-color: #fca5a5; }
+.fresh-unknown { color: #6b7280; background: #f3f4f6; border-color: #d1d5db; }
+:root[data-theme="dark"] .fresh-green   { color: #86efac; background: #052e16; border-color: #065f46; }
+:root[data-theme="dark"] .fresh-yellow  { color: #fcd34d; background: #3a2a06; border-color: #78350f; }
+:root[data-theme="dark"] .fresh-red     { color: #fca5a5; background: #3a0a0a; border-color: #7f1d1d; }
+:root[data-theme="dark"] .fresh-unknown { color: #9ca3af; background: #1f2937; border-color: #374151; }
+@media print {
+  .freshness { background: #fff !important; color: #000 !important; border-color: #ccc !important; }
+  .freshness::before { background: #000 !important; }
+}
 
 /* Sub-agent collapsible */
 .sub-section { margin-top: 32px; }

--- a/llmwiki/freshness.py
+++ b/llmwiki/freshness.py
@@ -1,0 +1,158 @@
+"""Content-freshness badges — v0.6 (#57).
+
+Computes the age of a page (in days) from its frontmatter and returns a
+color-coded badge rendered as HTML. Ages are bucketed into:
+
+- ``fresh-green``  — updated ≤ ``green_days`` ago (default 14)
+- ``fresh-yellow`` — updated ≤ ``yellow_days`` ago (default 60)
+- ``fresh-red``    — updated > ``yellow_days`` ago
+- ``fresh-unknown`` — no resolvable timestamp OR clock skew (future)
+
+Thresholds can be overridden via ``config.json``::
+
+    {
+      "freshness": {
+        "green_days": 14,
+        "yellow_days": 60
+      }
+    }
+
+The badge text uses a compact relative-time formatter (today / yesterday /
+N days / N weeks / N months / N years). All timestamps are normalised to
+naive UTC before subtraction so timezone skew between session files and
+the build host cannot move pages across buckets by accident.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from llmwiki import REPO_ROOT
+
+DEFAULT_GREEN_DAYS = 14
+DEFAULT_YELLOW_DAYS = 60
+
+
+def load_freshness_config(repo_root: Path = REPO_ROOT) -> tuple[int, int]:
+    """Return ``(green_days, yellow_days)`` from ``config.json`` or defaults."""
+    candidate = repo_root / "config.json"
+    if not candidate.exists():
+        return DEFAULT_GREEN_DAYS, DEFAULT_YELLOW_DAYS
+    try:
+        data = json.loads(candidate.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return DEFAULT_GREEN_DAYS, DEFAULT_YELLOW_DAYS
+    fresh = data.get("freshness") or {}
+    try:
+        green = int(fresh.get("green_days", DEFAULT_GREEN_DAYS))
+        yellow = int(fresh.get("yellow_days", DEFAULT_YELLOW_DAYS))
+    except (TypeError, ValueError):
+        return DEFAULT_GREEN_DAYS, DEFAULT_YELLOW_DAYS
+    if green < 0 or yellow < green:
+        return DEFAULT_GREEN_DAYS, DEFAULT_YELLOW_DAYS
+    return green, yellow
+
+
+def parse_timestamp(value: Any) -> Optional[datetime]:
+    """Parse an ISO datetime or ``YYYY-MM-DD`` into a naive UTC datetime.
+
+    Returns ``None`` for empty, missing, or malformed values.
+    """
+    if value is None:
+        return None
+    s = str(value).strip()
+    if not s:
+        return None
+    # Try ISO datetime first (with or without timezone)
+    if "T" in s or "+" in s[10:] or "Z" in s:
+        clean = s.replace("Z", "+00:00")
+        try:
+            dt = datetime.fromisoformat(clean)
+        except ValueError:
+            return None
+        if dt.tzinfo is not None:
+            dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+        return dt
+    # Fall back to date-only
+    try:
+        return datetime.strptime(s[:10], "%Y-%m-%d")
+    except ValueError:
+        return None
+
+
+def resolve_last_updated(meta: dict[str, Any]) -> Optional[datetime]:
+    """Pick the newest timestamp available from a page's frontmatter.
+
+    Prefers ``last_updated`` (explicit), then ``ended``, ``started``, ``date``.
+    """
+    for key in ("last_updated", "ended", "started", "date"):
+        dt = parse_timestamp(meta.get(key))
+        if dt is not None:
+            return dt
+    return None
+
+
+def format_relative_time(age_days: int) -> str:
+    """Compact human label for an age in days (never more than 2 words)."""
+    if age_days < 0:
+        return "unknown"
+    if age_days == 0:
+        return "today"
+    if age_days == 1:
+        return "yesterday"
+    if age_days < 14:
+        return f"{age_days} days ago"
+    if age_days < 60:
+        weeks = age_days // 7
+        return f"{weeks} week{'s' if weeks != 1 else ''} ago"
+    if age_days < 365:
+        months = age_days // 30
+        return f"{months} month{'s' if months != 1 else ''} ago"
+    years = age_days // 365
+    return f"{years} year{'s' if years != 1 else ''} ago"
+
+
+def freshness_class(
+    age_days: Optional[int],
+    green_days: int = DEFAULT_GREEN_DAYS,
+    yellow_days: int = DEFAULT_YELLOW_DAYS,
+) -> str:
+    """Return the CSS class for a given age. ``None`` or negative → unknown."""
+    if age_days is None or age_days < 0:
+        return "fresh-unknown"
+    if age_days <= green_days:
+        return "fresh-green"
+    if age_days <= yellow_days:
+        return "fresh-yellow"
+    return "fresh-red"
+
+
+def freshness_badge(
+    meta: dict[str, Any],
+    now: Optional[datetime] = None,
+    green_days: int = DEFAULT_GREEN_DAYS,
+    yellow_days: int = DEFAULT_YELLOW_DAYS,
+) -> str:
+    """Render a freshness badge for a page given its frontmatter.
+
+    ``now`` lets tests inject a deterministic clock; otherwise ``utcnow()``.
+    """
+    dt = resolve_last_updated(meta)
+    if dt is None:
+        return (
+            '<span class="freshness fresh-unknown" '
+            'title="No last-updated timestamp">updated unknown</span>'
+        )
+    current = now if now is not None else datetime.utcnow()
+    age = (current - dt).days
+    cls = freshness_class(age, green_days, yellow_days)
+    label = format_relative_time(age)
+    iso = dt.strftime("%Y-%m-%d")
+    return (
+        f'<span class="freshness {cls}" '
+        f'title="Last updated {html.escape(iso)}">updated {html.escape(label)}</span>'
+    )

--- a/tests/test_freshness.py
+++ b/tests/test_freshness.py
@@ -1,0 +1,269 @@
+"""Tests for llmwiki.freshness — content-freshness badges (#57)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from llmwiki.freshness import (
+    DEFAULT_GREEN_DAYS,
+    DEFAULT_YELLOW_DAYS,
+    format_relative_time,
+    freshness_badge,
+    freshness_class,
+    load_freshness_config,
+    parse_timestamp,
+    resolve_last_updated,
+)
+
+
+# ─── parse_timestamp ─────────────────────────────────────────────────────
+
+
+def test_parse_timestamp_iso_with_utc():
+    dt = parse_timestamp("2026-04-07T21:45:13.703000+00:00")
+    assert dt == datetime(2026, 4, 7, 21, 45, 13, 703000)
+    assert dt.tzinfo is None  # normalised to naive UTC
+
+
+def test_parse_timestamp_iso_with_z():
+    dt = parse_timestamp("2026-04-07T12:00:00Z")
+    assert dt == datetime(2026, 4, 7, 12, 0, 0)
+
+
+def test_parse_timestamp_iso_with_offset_normalises_to_utc():
+    # 10:00 in UTC+5 = 05:00 UTC
+    dt = parse_timestamp("2026-04-07T10:00:00+05:00")
+    assert dt == datetime(2026, 4, 7, 5, 0, 0)
+
+
+def test_parse_timestamp_date_only():
+    dt = parse_timestamp("2026-04-07")
+    assert dt == datetime(2026, 4, 7)
+
+
+def test_parse_timestamp_empty_returns_none():
+    assert parse_timestamp("") is None
+    assert parse_timestamp(None) is None
+    assert parse_timestamp("   ") is None
+
+
+def test_parse_timestamp_malformed_returns_none():
+    assert parse_timestamp("not a date") is None
+    assert parse_timestamp("2026-13-45") is None
+
+
+# ─── resolve_last_updated ───────────────────────────────────────────────
+
+
+def test_resolve_prefers_last_updated():
+    meta = {
+        "last_updated": "2026-04-07",
+        "ended": "2026-04-01T00:00:00Z",
+        "started": "2026-03-25T00:00:00Z",
+        "date": "2026-03-20",
+    }
+    assert resolve_last_updated(meta) == datetime(2026, 4, 7)
+
+
+def test_resolve_falls_back_to_ended_then_started():
+    assert resolve_last_updated({"ended": "2026-04-07T10:00:00Z"}) == datetime(2026, 4, 7, 10, 0, 0)
+    assert resolve_last_updated({"started": "2026-04-06T10:00:00Z"}) == datetime(2026, 4, 6, 10, 0, 0)
+    assert resolve_last_updated({"date": "2026-04-05"}) == datetime(2026, 4, 5)
+
+
+def test_resolve_no_fields_returns_none():
+    assert resolve_last_updated({}) is None
+    assert resolve_last_updated({"title": "Foo"}) is None
+
+
+# ─── format_relative_time ────────────────────────────────────────────────
+
+
+def test_format_relative_time_today_and_yesterday():
+    assert format_relative_time(0) == "today"
+    assert format_relative_time(1) == "yesterday"
+
+
+def test_format_relative_time_days():
+    assert format_relative_time(2) == "2 days ago"
+    assert format_relative_time(13) == "13 days ago"
+
+
+def test_format_relative_time_weeks():
+    assert format_relative_time(14) == "2 weeks ago"
+    assert format_relative_time(21) == "3 weeks ago"
+    assert format_relative_time(59) == "8 weeks ago"
+
+
+def test_format_relative_time_months():
+    assert format_relative_time(60) == "2 months ago"
+    assert format_relative_time(180) == "6 months ago"
+    assert format_relative_time(364) == "12 months ago"
+
+
+def test_format_relative_time_years():
+    assert format_relative_time(365) == "1 year ago"
+    assert format_relative_time(365 * 3) == "3 years ago"
+
+
+def test_format_relative_time_negative_is_unknown():
+    assert format_relative_time(-5) == "unknown"
+
+
+# ─── freshness_class ────────────────────────────────────────────────────
+
+
+def test_freshness_class_boundary_green():
+    # Exact boundary (14) should still be green with defaults
+    assert freshness_class(0) == "fresh-green"
+    assert freshness_class(14) == "fresh-green"
+    assert freshness_class(14, green_days=14, yellow_days=60) == "fresh-green"
+
+
+def test_freshness_class_boundary_yellow():
+    assert freshness_class(15) == "fresh-yellow"
+    assert freshness_class(60) == "fresh-yellow"
+
+
+def test_freshness_class_boundary_red():
+    assert freshness_class(61) == "fresh-red"
+    assert freshness_class(1000) == "fresh-red"
+
+
+def test_freshness_class_none_or_negative_is_unknown():
+    assert freshness_class(None) == "fresh-unknown"
+    assert freshness_class(-1) == "fresh-unknown"
+    assert freshness_class(-9999) == "fresh-unknown"  # clock skew / future
+
+
+def test_freshness_class_custom_thresholds():
+    assert freshness_class(7, green_days=7, yellow_days=30) == "fresh-green"
+    assert freshness_class(8, green_days=7, yellow_days=30) == "fresh-yellow"
+    assert freshness_class(31, green_days=7, yellow_days=30) == "fresh-red"
+
+
+# ─── freshness_badge ────────────────────────────────────────────────────
+
+
+def test_badge_with_recent_ended_is_green():
+    now = datetime(2026, 4, 8, 12, 0, 0)
+    meta = {"ended": "2026-04-07T12:00:00Z"}
+    html_str = freshness_badge(meta, now=now)
+    assert "fresh-green" in html_str
+    assert "yesterday" in html_str
+    assert "Last updated 2026-04-07" in html_str
+
+
+def test_badge_with_30_day_old_ended_is_yellow():
+    now = datetime(2026, 4, 8, 12, 0, 0)
+    meta = {"ended": "2026-03-08T12:00:00Z"}  # ~31 days ago
+    html_str = freshness_badge(meta, now=now)
+    assert "fresh-yellow" in html_str
+
+
+def test_badge_with_365_day_old_ended_is_red():
+    now = datetime(2026, 4, 8, 12, 0, 0)
+    meta = {"ended": "2025-04-08T12:00:00Z"}
+    html_str = freshness_badge(meta, now=now)
+    assert "fresh-red" in html_str
+    assert "1 year ago" in html_str
+
+
+def test_badge_future_date_is_unknown_due_to_clock_skew():
+    now = datetime(2026, 4, 8, 12, 0, 0)
+    meta = {"ended": "2026-04-15T12:00:00Z"}  # 7 days in the future
+    html_str = freshness_badge(meta, now=now)
+    assert "fresh-unknown" in html_str
+
+
+def test_badge_no_timestamp_is_unknown():
+    html_str = freshness_badge({})
+    assert "fresh-unknown" in html_str
+    assert "updated unknown" in html_str
+    assert "No last-updated timestamp" in html_str
+
+
+def test_badge_exact_boundary_green_to_yellow():
+    # Exactly 14 days ago — still green
+    now = datetime(2026, 4, 8, 12, 0, 0)
+    meta = {"ended": (now - timedelta(days=14)).isoformat() + "Z"}
+    html_str = freshness_badge(meta, now=now)
+    assert "fresh-green" in html_str
+
+    # 15 days ago — yellow
+    meta = {"ended": (now - timedelta(days=15)).isoformat() + "Z"}
+    html_str = freshness_badge(meta, now=now)
+    assert "fresh-yellow" in html_str
+
+
+def test_badge_exact_boundary_yellow_to_red():
+    now = datetime(2026, 4, 8, 12, 0, 0)
+    # 60 days ago — still yellow
+    meta = {"ended": (now - timedelta(days=60)).isoformat() + "Z"}
+    html_str = freshness_badge(meta, now=now)
+    assert "fresh-yellow" in html_str
+
+    # 61 days ago — red
+    meta = {"ended": (now - timedelta(days=61)).isoformat() + "Z"}
+    html_str = freshness_badge(meta, now=now)
+    assert "fresh-red" in html_str
+
+
+def test_badge_custom_thresholds_override():
+    now = datetime(2026, 4, 8, 12, 0, 0)
+    meta = {"ended": (now - timedelta(days=10)).isoformat() + "Z"}
+    html_str = freshness_badge(meta, now=now, green_days=7, yellow_days=30)
+    assert "fresh-yellow" in html_str  # 10 > 7, ≤ 30
+
+
+def test_badge_html_is_wellformed():
+    now = datetime(2026, 4, 8, 12, 0, 0)
+    meta = {"ended": (now - timedelta(days=5)).isoformat() + "Z"}
+    html_str = freshness_badge(meta, now=now)
+    assert html_str.startswith('<span class="freshness')
+    assert html_str.endswith("</span>")
+    assert "title=" in html_str
+
+
+# ─── load_freshness_config ──────────────────────────────────────────────
+
+
+def test_load_freshness_config_defaults_when_missing(tmp_path):
+    green, yellow = load_freshness_config(tmp_path)
+    assert green == DEFAULT_GREEN_DAYS
+    assert yellow == DEFAULT_YELLOW_DAYS
+
+
+def test_load_freshness_config_reads_custom_thresholds(tmp_path):
+    (tmp_path / "config.json").write_text(
+        '{"freshness": {"green_days": 7, "yellow_days": 30}}', encoding="utf-8"
+    )
+    green, yellow = load_freshness_config(tmp_path)
+    assert green == 7
+    assert yellow == 30
+
+
+def test_load_freshness_config_rejects_inverted_thresholds(tmp_path):
+    # yellow < green is nonsense; should fall back to defaults
+    (tmp_path / "config.json").write_text(
+        '{"freshness": {"green_days": 60, "yellow_days": 14}}', encoding="utf-8"
+    )
+    green, yellow = load_freshness_config(tmp_path)
+    assert green == DEFAULT_GREEN_DAYS
+    assert yellow == DEFAULT_YELLOW_DAYS
+
+
+def test_load_freshness_config_handles_bad_json(tmp_path):
+    (tmp_path / "config.json").write_text("{ not json }", encoding="utf-8")
+    green, yellow = load_freshness_config(tmp_path)
+    assert green == DEFAULT_GREEN_DAYS
+    assert yellow == DEFAULT_YELLOW_DAYS
+
+
+def test_load_freshness_config_missing_section_keeps_defaults(tmp_path):
+    (tmp_path / "config.json").write_text('{"redaction": {}}', encoding="utf-8")
+    green, yellow = load_freshness_config(tmp_path)
+    assert green == DEFAULT_GREEN_DAYS
+    assert yellow == DEFAULT_YELLOW_DAYS


### PR DESCRIPTION
Closes #57.

## Summary

New module `llmwiki.freshness` computes page age from frontmatter and renders a color-coded pill on every built page.

- **Green** — updated ≤ 14 days ago
- **Yellow** — updated 15–60 days ago
- **Red** — updated > 60 days ago
- **Unknown** — no timestamp OR clock skew (future date)

Thresholds are configurable in `config.json`:

```json
{ "freshness": { "green_days": 7, "yellow_days": 30 } }
```

Bad config (missing file, malformed JSON, inverted thresholds) silently falls back to defaults.

## How it picks the timestamp

For each page, the resolver tries frontmatter keys in this order: `last_updated` → `ended` → `started` → `date`. All ISO datetimes (with or without timezone) are normalised to naive UTC before subtraction so time-zone skew cannot shift pages across buckets.

"Build now" is cached once per build so the whole site shows a single consistent clock.

## Where badges render

- **Session page hero strip** — after the "N min read" bit
- **Project cards** on `projects/index.html` — using the newest session's timestamp
- **Session cards** on each project page

## Relative-time formatter

Compact and never more than 2 words: `today` / `yesterday` / `N days ago` / `N weeks ago` / `N months ago` / `N years ago`.

## Test plan
- [x] **34 new tests** in `tests/test_freshness.py`
- [x] Exact boundary tests: 14 → green, 15 → yellow, 60 → yellow, 61 → red
- [x] Far past (1000 days = red)
- [x] Far future clock skew (-5 days = unknown)
- [x] ISO datetime parsing — UTC, `Z` suffix, offset (+05:00), date-only, empty, malformed
- [x] Last-updated resolution priority (`last_updated` > `ended` > `started` > `date`)
- [x] Config loading: missing file, custom thresholds, inverted rejected, bad JSON tolerated
- [x] Full suite: 129 tests pass (was 95, +34)
- [x] Smoke build of real data: 280 session pages all get badges, 12 project cards get badges, CSS (including dark-mode) present in compiled `style.css`