### PR TITLE
feat(v0.8): session-metrics frontmatter foundation (#63)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,8 +3,8 @@
   "configurations": [
     {
       "name": "llmwiki-serve",
-      "runtimeExecutable": "/usr/bin/python3",
-      "runtimeArgs": ["${workspaceFolder}/scripts/preview_serve.py"],
+      "runtimeExecutable": "/usr/local/bin/python3.12",
+      "runtimeArgs": ["-m", "http.server", "8765", "--bind", "127.0.0.1", "--directory", "${workspaceFolder}/site"],
       "port": 8765
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+### Added
+
+- **Session metrics frontmatter** (#63) — converter now emits five new keys per session as JSON inline: `tool_counts`, `token_totals` (input / cache_creation / cache_read / output), `turn_count`, `hour_buckets` (UTC-normalised ISO-hour → activity count), and `duration_seconds`. Foundation for the v0.8 visualization stack (#64 heatmap / #65 tool chart / #66 token card). Stdlib-only; byte-identical on re-run. 24 new tests.
+
 ## [0.4.0] — 2026-04-08
 
 **Theme:** AI + human dual-format. Every page ships both as HTML for humans AND as machine-readable `.txt` + `.json` siblings for AI agents, alongside site-level exports that follow open standards (`llms.txt`, JSON-LD, sitemap, RSS).

--- a/llmwiki/convert.py
+++ b/llmwiki/convert.py
@@ -342,6 +342,79 @@ def extract_tools_used(records: list[dict[str, Any]]) -> list[str]:
     return list(seen.keys())
 
 
+# ─── v0.8 session metrics (#63) ───────────────────────────────────────────
+# Structured per-session metrics emitted into frontmatter as JSON inline
+# values. The build step and the v0.8 visualization modules (#64/#65/#66)
+# consume these without having to re-parse the raw .jsonl. Keep all helpers
+# stdlib-only and tolerant of missing fields.
+
+
+def compute_tool_counts(records: list[dict[str, Any]]) -> dict[str, int]:
+    """Return a {tool_name: count} mapping across all assistant tool_use blocks."""
+    counts: dict[str, int] = {}
+    for r in records:
+        if r.get("type") != "assistant":
+            continue
+        for b in r.get("message", {}).get("content", []) or []:
+            if isinstance(b, dict) and b.get("type") == "tool_use":
+                name = b.get("name") or "Unknown"
+                counts[name] = counts.get(name, 0) + 1
+    # Return with stable ordering (by count desc then name) so the rendered
+    # frontmatter is byte-identical across runs.
+    return dict(sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])))
+
+
+def compute_token_totals(records: list[dict[str, Any]]) -> dict[str, int]:
+    """Sum input / cache_creation / cache_read / output tokens across assistant
+    messages. Missing fields contribute 0.
+    """
+    totals = {"input": 0, "cache_creation": 0, "cache_read": 0, "output": 0}
+    for r in records:
+        if r.get("type") != "assistant":
+            continue
+        usage = r.get("message", {}).get("usage") or {}
+        if not isinstance(usage, dict):
+            continue
+        totals["input"] += int(usage.get("input_tokens") or 0)
+        totals["cache_creation"] += int(usage.get("cache_creation_input_tokens") or 0)
+        totals["cache_read"] += int(usage.get("cache_read_input_tokens") or 0)
+        totals["output"] += int(usage.get("output_tokens") or 0)
+    return totals
+
+
+def compute_turn_count(records: list[dict[str, Any]]) -> int:
+    """Number of user→assistant turn pairs (equivalent to real user prompts)."""
+    return count_user_messages(records)
+
+
+def compute_hour_buckets(records: list[dict[str, Any]]) -> dict[str, int]:
+    """Return {"YYYY-MM-DDTHH": count} keyed by UTC hour-of-activity.
+
+    Sparse — only hours with at least one record. Used by the v0.8 activity
+    heatmap (#64) to size per-day dots without reading the raw jsonl.
+    """
+    buckets: dict[str, int] = {}
+    for r in records:
+        ts = parse_iso(r.get("timestamp"))
+        if ts is None:
+            continue
+        ts_utc = ts.astimezone(timezone.utc) if ts.tzinfo else ts
+        key = ts_utc.strftime("%Y-%m-%dT%H")
+        buckets[key] = buckets.get(key, 0) + 1
+    # Sorted chronologically for stable frontmatter output.
+    return dict(sorted(buckets.items()))
+
+
+def compute_duration_seconds(records: list[dict[str, Any]]) -> int:
+    """Total elapsed session time in whole seconds (last_ts - first_ts)."""
+    first = first_record_time(records)
+    last = latest_record_time(records)
+    if first is None or last is None:
+        return 0
+    delta = last - first
+    return max(0, int(delta.total_seconds()))
+
+
 # ─── tool-use rendering ────────────────────────────────────────────────────
 
 def summarize_tool_use(block: dict[str, Any], redact: Redactor, config: dict[str, Any]) -> str:
@@ -510,6 +583,13 @@ def render_session_markdown(
     u_count = count_user_messages(records)
     t_count = count_tool_calls(records)
 
+    # v0.8 (#63) structured metrics — JSON inline in frontmatter
+    tool_counts = compute_tool_counts(records)
+    token_totals = compute_token_totals(records)
+    turn_count = compute_turn_count(records)
+    hour_buckets = compute_hour_buckets(records)
+    duration_seconds = compute_duration_seconds(records)
+
     title = f"Session: {slug} — {date_str}"
     front = [
         "---",
@@ -530,6 +610,13 @@ def render_session_markdown(
         f"user_messages: {u_count}",
         f"tool_calls: {t_count}",
         f"tools_used: [{', '.join(tools_used)}]",
+        # v0.8 — structured metrics (JSON inline so the simple frontmatter
+        # parser stores them as strings; consumers json.loads() on demand).
+        f"tool_counts: {json.dumps(tool_counts, sort_keys=False)}",
+        f"token_totals: {json.dumps(token_totals, sort_keys=False)}",
+        f"turn_count: {turn_count}",
+        f"hour_buckets: {json.dumps(hour_buckets, sort_keys=False)}",
+        f"duration_seconds: {duration_seconds}",
         f"is_subagent: {str(is_subagent_file).lower()}",
         "---",
         "",

--- a/tests/test_converter_metrics.py
+++ b/tests/test_converter_metrics.py
@@ -1,0 +1,334 @@
+"""Tests for v0.8 session metrics (#63) — extends the converter with
+structured per-session metrics in frontmatter.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from llmwiki.convert import (
+    compute_duration_seconds,
+    compute_hour_buckets,
+    compute_token_totals,
+    compute_tool_counts,
+    compute_turn_count,
+)
+
+
+# ─── synthetic records fixture ───────────────────────────────────────────
+
+
+@pytest.fixture
+def synthetic_records():
+    """Five-record session spanning one hour with Bash + 2×Read tool calls."""
+    return [
+        {
+            "type": "user",
+            "message": {"content": "Hello"},
+            "timestamp": "2026-04-07T10:00:00Z",
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "model": "claude-haiku-4-5",
+                "content": [
+                    {"type": "text", "text": "Hi"},
+                    {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}},
+                ],
+                "usage": {
+                    "input_tokens": 100,
+                    "cache_creation_input_tokens": 50,
+                    "cache_read_input_tokens": 200,
+                    "output_tokens": 30,
+                },
+            },
+            "timestamp": "2026-04-07T10:00:05Z",
+        },
+        {
+            "type": "user",
+            "message": {"content": [{"type": "tool_result", "content": "ok"}]},
+            "timestamp": "2026-04-07T10:00:06Z",
+        },
+        {
+            "type": "user",
+            "message": {"content": "Another turn"},
+            "timestamp": "2026-04-07T11:05:00Z",
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "model": "claude-haiku-4-5",
+                "content": [
+                    {"type": "tool_use", "name": "Read", "input": {"file_path": "/a"}},
+                    {"type": "tool_use", "name": "Read", "input": {"file_path": "/b"}},
+                ],
+                "usage": {"input_tokens": 200, "output_tokens": 10},
+            },
+            "timestamp": "2026-04-07T11:05:02Z",
+        },
+    ]
+
+
+# ─── compute_tool_counts ─────────────────────────────────────────────────
+
+
+def test_tool_counts_basic(synthetic_records):
+    counts = compute_tool_counts(synthetic_records)
+    assert counts == {"Read": 2, "Bash": 1}
+
+
+def test_tool_counts_empty_session():
+    assert compute_tool_counts([]) == {}
+
+
+def test_tool_counts_ignores_non_assistant():
+    records = [
+        {"type": "user", "message": {"content": "hi"}},
+        {"type": "system", "message": {}},
+    ]
+    assert compute_tool_counts(records) == {}
+
+
+def test_tool_counts_handles_missing_name():
+    records = [
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "tool_use"}]},
+        }
+    ]
+    assert compute_tool_counts(records) == {"Unknown": 1}
+
+
+def test_tool_counts_sorted_descending():
+    records = [
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "tool_use", "name": "Edit"},
+                    {"type": "tool_use", "name": "Bash"},
+                    {"type": "tool_use", "name": "Bash"},
+                    {"type": "tool_use", "name": "Bash"},
+                    {"type": "tool_use", "name": "Edit"},
+                    {"type": "tool_use", "name": "Read"},
+                ]
+            },
+        }
+    ]
+    counts = compute_tool_counts(records)
+    # Bash (3) > Edit (2) > Read (1); insertion order preserved
+    assert list(counts.keys()) == ["Bash", "Edit", "Read"]
+    assert counts == {"Bash": 3, "Edit": 2, "Read": 1}
+
+
+# ─── compute_token_totals ────────────────────────────────────────────────
+
+
+def test_token_totals_basic(synthetic_records):
+    totals = compute_token_totals(synthetic_records)
+    assert totals == {
+        "input": 300,
+        "cache_creation": 50,
+        "cache_read": 200,
+        "output": 40,
+    }
+
+
+def test_token_totals_missing_usage_is_zero():
+    records = [{"type": "assistant", "message": {"content": []}}]
+    assert compute_token_totals(records) == {
+        "input": 0,
+        "cache_creation": 0,
+        "cache_read": 0,
+        "output": 0,
+    }
+
+
+def test_token_totals_empty_session():
+    assert compute_token_totals([]) == {
+        "input": 0,
+        "cache_creation": 0,
+        "cache_read": 0,
+        "output": 0,
+    }
+
+
+def test_token_totals_partial_usage_counts_zero_for_missing_fields():
+    records = [
+        {
+            "type": "assistant",
+            "message": {"content": [], "usage": {"input_tokens": 500}},
+        }
+    ]
+    totals = compute_token_totals(records)
+    assert totals["input"] == 500
+    assert totals["output"] == 0
+    assert totals["cache_creation"] == 0
+    assert totals["cache_read"] == 0
+
+
+# ─── compute_turn_count ──────────────────────────────────────────────────
+
+
+def test_turn_count_counts_real_user_prompts(synthetic_records):
+    assert compute_turn_count(synthetic_records) == 2
+
+
+def test_turn_count_empty_session():
+    assert compute_turn_count([]) == 0
+
+
+def test_turn_count_ignores_tool_result_deliveries():
+    # tool_result is a list-content user record; should NOT count as a turn
+    records = [
+        {"type": "user", "message": {"content": "real prompt"}},
+        {"type": "user", "message": {"content": [{"type": "tool_result", "content": "ok"}]}},
+    ]
+    assert compute_turn_count(records) == 1
+
+
+# ─── compute_hour_buckets ────────────────────────────────────────────────
+
+
+def test_hour_buckets_basic(synthetic_records):
+    buckets = compute_hour_buckets(synthetic_records)
+    assert buckets == {"2026-04-07T10": 3, "2026-04-07T11": 2}
+
+
+def test_hour_buckets_sorted_chronologically():
+    records = [
+        {"type": "user", "timestamp": "2026-04-07T15:00:00Z", "message": {}},
+        {"type": "user", "timestamp": "2026-04-07T09:00:00Z", "message": {}},
+        {"type": "user", "timestamp": "2026-04-07T12:00:00Z", "message": {}},
+    ]
+    buckets = compute_hour_buckets(records)
+    assert list(buckets.keys()) == ["2026-04-07T09", "2026-04-07T12", "2026-04-07T15"]
+
+
+def test_hour_buckets_normalises_timezone():
+    # 10:00 UTC+5 == 05:00 UTC
+    records = [
+        {"type": "user", "timestamp": "2026-04-07T10:00:00+05:00", "message": {}}
+    ]
+    buckets = compute_hour_buckets(records)
+    assert buckets == {"2026-04-07T05": 1}
+
+
+def test_hour_buckets_skips_missing_timestamps():
+    records = [
+        {"type": "user", "message": {}},
+        {"type": "user", "timestamp": "", "message": {}},
+        {"type": "user", "timestamp": "2026-04-07T10:00:00Z", "message": {}},
+    ]
+    assert compute_hour_buckets(records) == {"2026-04-07T10": 1}
+
+
+def test_hour_buckets_all_values_are_positive_integers(synthetic_records):
+    buckets = compute_hour_buckets(synthetic_records)
+    for key, val in buckets.items():
+        assert isinstance(val, int)
+        assert val >= 1
+        assert "T" in key
+
+
+# ─── compute_duration_seconds ────────────────────────────────────────────
+
+
+def test_duration_seconds_basic(synthetic_records):
+    # 11:05:02 - 10:00:00 = 3902s
+    assert compute_duration_seconds(synthetic_records) == 3902
+
+
+def test_duration_seconds_empty_session():
+    assert compute_duration_seconds([]) == 0
+
+
+def test_duration_seconds_single_record():
+    records = [
+        {"type": "user", "timestamp": "2026-04-07T10:00:00Z", "message": {}},
+    ]
+    assert compute_duration_seconds(records) == 0
+
+
+def test_duration_seconds_never_negative():
+    # Out-of-order records; duration is last - first which is still positive
+    records = [
+        {"type": "user", "timestamp": "2026-04-07T12:00:00Z", "message": {}},
+        {"type": "user", "timestamp": "2026-04-07T10:00:00Z", "message": {}},
+    ]
+    assert compute_duration_seconds(records) == 7200
+
+
+# ─── end-to-end render_session_markdown ──────────────────────────────────
+
+
+def test_render_session_markdown_emits_v08_metrics(synthetic_records, tmp_path):
+    from llmwiki.convert import Redactor, render_session_markdown
+
+    redactor = Redactor({})
+    jsonl = tmp_path / "abc123.jsonl"
+    jsonl.touch()
+    md, _slug, _started = render_session_markdown(
+        synthetic_records,
+        jsonl_path=jsonl,
+        project_slug="test-project",
+        redact=redactor,
+        config={},
+        is_subagent_file=False,
+    )
+    # All 5 new keys are in the frontmatter
+    assert "tool_counts:" in md
+    assert "token_totals:" in md
+    assert "turn_count:" in md
+    assert "hour_buckets:" in md
+    assert "duration_seconds:" in md
+    # Values are valid JSON that round-trips
+    for line in md.splitlines():
+        if line.startswith("tool_counts: "):
+            assert json.loads(line[len("tool_counts: ") :]) == {"Read": 2, "Bash": 1}
+        if line.startswith("token_totals: "):
+            assert json.loads(line[len("token_totals: ") :]) == {
+                "input": 300,
+                "cache_creation": 50,
+                "cache_read": 200,
+                "output": 40,
+            }
+        if line.startswith("turn_count: "):
+            assert line == "turn_count: 2"
+        if line.startswith("duration_seconds: "):
+            assert line == "duration_seconds: 3902"
+
+
+def test_render_session_markdown_is_idempotent(synthetic_records, tmp_path):
+    """Re-running the converter on an unchanged record set produces
+    byte-identical output."""
+    from llmwiki.convert import Redactor, render_session_markdown
+
+    redactor = Redactor({})
+    jsonl = tmp_path / "abc123.jsonl"
+    jsonl.touch()
+    md1, _, _ = render_session_markdown(
+        synthetic_records, jsonl, "p", redactor, {}, False
+    )
+    md2, _, _ = render_session_markdown(
+        synthetic_records, jsonl, "p", redactor, {}, False
+    )
+    assert md1 == md2
+
+
+def test_render_session_markdown_keeps_legacy_fields(synthetic_records, tmp_path):
+    """Adding new frontmatter keys must not remove the old ones."""
+    from llmwiki.convert import Redactor, render_session_markdown
+
+    redactor = Redactor({})
+    jsonl = tmp_path / "abc123.jsonl"
+    jsonl.touch()
+    md, _, _ = render_session_markdown(
+        synthetic_records, jsonl, "p", redactor, {}, False
+    )
+    for legacy in ("title:", "slug:", "project:", "started:", "ended:",
+                   "model:", "user_messages:", "tool_calls:", "tools_used:"):
+        assert legacy in md, f"lost legacy frontmatter key: {legacy}"


### PR DESCRIPTION
Closes #63. **Foundation for the v0.8 visualization stack.**

## Summary

Computes structured per-session metrics in the converter so the build step and the upcoming heatmap (#64), tool-chart (#65), and token-card (#66) features can consume them from frontmatter without re-parsing raw JSONL.

Five new keys per session, JSON inline:

```yaml
tool_counts: {"Read": 112, "Bash": 47, "Grep": 18, ...}
token_totals: {"input": 12345, "cache_creation": 180432, "cache_read": 2145678, "output": 34567}
turn_count: 38
hour_buckets: {"2026-04-07T21": 42, "2026-04-07T22": 19, ...}
duration_seconds: 7920
```

Legacy fields (`title`, `slug`, `project`, `started`, `ended`, `model`, `user_messages`, `tool_calls`, `tools_used`, `is_subagent`) are preserved.

## Design notes

- **Stdlib-only** — no `pandas`, no `dateutil`. `datetime.fromisoformat` for ISO parsing.
- **Stable ordering** — `tool_counts` sorted by count desc, `hour_buckets` chronologically. Re-running the converter on unchanged JSONL produces byte-identical output (verified).
- **Tolerant of missing fields** — missing `usage` → zeros, missing timestamps → skipped from hour buckets, missing `name` → `"Unknown"`.
- **UTC normalisation** — timestamps with non-UTC offsets are converted before bucketing, so `2026-04-07T10:00+05:00` lands in the `2026-04-07T05` bucket.

## Test plan
- [x] **24 new tests** in `tests/test_converter_metrics.py`
- [x] Unit: tool counts (basic, empty, missing name, sorted), token totals (basic, missing, partial, empty), turn count (real prompts only), hour buckets (sort, tz, missing ts, positive ints), duration (basic, empty, single, out-of-order)
- [x] End-to-end: `render_session_markdown` emits all 5 keys as valid JSON, is byte-identical on re-run, preserves all legacy fields
- [x] Full suite: **153 tests pass** (was 129, +24)

## Dev tooling tweak

`.claude/launch.json` switches from the bootstrap script to `/usr/local/bin/python3.12 -m http.server --directory ${workspaceFolder}/site` so `preview_start` works under MCP without tripping the macOS TCC barrier on Command Line Tools Python 3.9. One-line change.