### PR TITLE
feat: rich structured log format with auto-archival

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versions below 1.0 are pre-production — API and file formats may change.
 - **Confidence scoring module** (#135) — new `llmwiki/confidence.py` implementing the 4-factor weighted-average formula from the LLM Book design spec: `source_count(0.3) + source_quality(0.3) + recency(0.2) + cross_refs(0.2)`. Includes Ebbinghaus-inspired content-type decay with configurable half-lives (architecture 6mo, tool versions 30d, people 3mo, bugs 14d, APIs 2mo). Each factor maps to [0.0, 1.0]; composite is rounded to 2 decimal places and stored in YAML frontmatter as `confidence: 0.85`.
 - **Lifecycle state machine** (#136) — new `llmwiki/lifecycle.py` with 5 states (draft → reviewed → verified → stale → archived), validated transitions, auto-stale detection after 90 days without update, and confidence-based stale detection (confidence < 0.5). Manual-only transitions for `verified` (human confirms) and `archived` (human decision). Includes `parse_lifecycle()` for YAML frontmatter parsing.
 
+### Changed
+
+- **Rich structured log format with auto-archival** (#133) — `_append_log()` now accepts `operation` and `details` parameters to produce log entries with processed count, created/updated pages, and entities extracted. Auto-archives `wiki/log.md` to `wiki/log-archive-YYYY.md` when the log exceeds 50 KB.
+
 ### Fixed
 
 - **Synthesis pipeline writes to real log during tests** (#131) — `_append_log()` in `llmwiki/synth/pipeline.py` now accepts an optional `log_path` parameter (defaults to `WIKI_LOG`), and `synthesize_new_sessions()` forwards it. All tests in `test_synth_pipeline.py` pass isolated `tmp_path` log files. Cleaned 42 duplicate `synthesize | test-proj/test-synth` entries from `wiki/log.md` caused by unguarded test writes.

--- a/llmwiki/synth/pipeline.py
+++ b/llmwiki/synth/pipeline.py
@@ -63,8 +63,14 @@ def _save_state(state: dict[str, float]) -> None:
     )
 
 
-def _append_log(title: str, *, log_path: Optional[Path] = None) -> None:
-    """Append a synthesis entry to wiki/log.md.
+def _append_log(
+    title: str,
+    *,
+    log_path: Optional[Path] = None,
+    operation: str = "synthesize",
+    details: Optional[dict[str, Any]] = None,
+) -> None:
+    """Append a rich structured entry to wiki/log.md.
 
     Parameters
     ----------
@@ -73,14 +79,62 @@ def _append_log(title: str, *, log_path: Optional[Path] = None) -> None:
     log_path : Path, optional
         Override for the log file path — used by tests to avoid writing
         to the real wiki/log.md.  Defaults to ``WIKI_LOG``.
+    operation : str
+        Operation type: synthesize, ingest, query, lint, build, sync.
+    details : dict, optional
+        Rich details — created pages, updated pages, entities extracted, etc.
     """
     target = log_path or WIKI_LOG
     if not target.parent.exists():
         return
+
+    # Auto-archive when log exceeds 50 KB
+    _auto_archive_log(target)
+
     date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    entry = f"\n## [{date_str}] synthesize | {title}\n"
+    lines = [f"\n## [{date_str}] {operation} | {title}\n"]
+    if details:
+        if details.get("processed"):
+            lines.append(f"- Processed: {details['processed']}\n")
+        if details.get("created"):
+            lines.append(f"- Created: {', '.join(details['created'])}\n")
+        if details.get("updated"):
+            lines.append(f"- Updated: {', '.join(details['updated'])}\n")
+        if details.get("entities"):
+            lines.append(f"- Entities extracted: {', '.join(details['entities'])}\n")
+        if details.get("errors"):
+            lines.append(f"- Errors: {len(details['errors'])}\n")
     with open(target, "a", encoding="utf-8") as f:
-        f.write(entry)
+        f.writelines(lines)
+
+
+LOG_ARCHIVE_THRESHOLD = 50 * 1024  # 50 KB
+
+
+def _auto_archive_log(log_path: Path) -> Optional[Path]:
+    """Archive log.md when it exceeds 50 KB. Returns archive path or None."""
+    if not log_path.is_file():
+        return None
+    if log_path.stat().st_size < LOG_ARCHIVE_THRESHOLD:
+        return None
+
+    year = datetime.now(timezone.utc).strftime("%Y")
+    archive = log_path.parent / f"log-archive-{year}.md"
+
+    content = log_path.read_text(encoding="utf-8")
+    # Keep the header (first 5 lines), archive the rest
+    lines = content.split("\n")
+    header = "\n".join(lines[:5])
+    body = "\n".join(lines[5:])
+
+    # Append to archive
+    with open(archive, "a", encoding="utf-8") as f:
+        f.write(f"\n# Archived from log.md — {year}\n\n")
+        f.write(body)
+
+    # Reset log to header only
+    log_path.write_text(header + "\n\n---\n", encoding="utf-8")
+    return archive
 
 
 def _discover_raw_sessions(


### PR DESCRIPTION
## Summary

Upgrades `_append_log()` to produce rich structured log entries and auto-archive when log exceeds 50 KB.

## Changes

- `_append_log()` accepts `operation` and `details` kwargs for structured entries (processed count, created/updated pages, entities extracted)
- `_auto_archive_log()` moves log body to `wiki/log-archive-YYYY.md` when exceeding 50 KB, keeping the header
- Backward-compatible — existing callers without new params still work
- CHANGELOG updated

## PR Checklist

- [ ] Tests pass (`pytest tests/ -q`)
- [ ] `_append_log()` accepts `operation` and `details` kwargs
- [ ] `_auto_archive_log()` triggers at 50 KB, preserves header
- [ ] Backward-compatible with existing callers
- [ ] CHANGELOG.md updated
- [ ] All commits GPG-signed
- [ ] No `Co-authored-by` headers

## Closes

Closes #133