### PR TITLE
chore: add tests for confidence scoring and lifecycle modules

### DIFF
--- a/tests/test_confidence.py
+++ b/tests/test_confidence.py
@@ -1,0 +1,186 @@
+"""Tests for the confidence scoring module (v1.0, #135)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+from llmwiki.confidence import (
+    source_count_score,
+    source_quality_score,
+    avg_source_quality,
+    recency_score,
+    cross_reference_score,
+    compute_confidence,
+    decay_factor,
+    apply_decay,
+)
+
+
+# ─── Factor 1: Source Count ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("count,expected", [
+    (0, 0.0),
+    (1, 0.4),
+    (2, 0.6),
+    (3, 0.8),
+    (4, 1.0),
+    (10, 1.0),
+])
+def test_source_count_score(count, expected):
+    assert source_count_score(count) == expected
+
+
+# ─── Factor 2: Source Quality ──────────────────────────────────────────
+
+
+@pytest.mark.parametrize("quality,expected", [
+    ("official", 1.0),
+    ("documentation", 1.0),
+    ("peer_reviewed", 0.9),
+    ("blog", 0.7),
+    ("forum", 0.5),
+    ("llm_generated", 0.3),
+    ("session_transcript", 0.5),
+    ("unknown", 0.4),
+    ("OFFICIAL", 1.0),  # case-insensitive
+    ("nonexistent", 0.4),  # fallback
+])
+def test_source_quality_score(quality, expected):
+    assert source_quality_score(quality) == expected
+
+
+def test_avg_source_quality_empty():
+    assert avg_source_quality([]) == 0.4
+
+
+def test_avg_source_quality_mixed():
+    result = avg_source_quality(["official", "blog"])
+    assert result == pytest.approx((1.0 + 0.7) / 2)
+
+
+# ─── Factor 3: Recency ────────────────────────────────────────────────
+
+
+def test_recency_score_recent():
+    now = datetime(2026, 4, 16, tzinfo=timezone.utc)
+    assert recency_score("2026-04-10", now=now) == 1.0  # 6 days ago
+
+
+def test_recency_score_medium():
+    now = datetime(2026, 4, 16, tzinfo=timezone.utc)
+    assert recency_score("2026-02-16", now=now) == 0.8  # 59 days
+
+
+def test_recency_score_old():
+    now = datetime(2026, 4, 16, tzinfo=timezone.utc)
+    assert recency_score("2025-10-01", now=now) == 0.5  # ~198 days
+
+
+def test_recency_score_very_old():
+    now = datetime(2026, 4, 16, tzinfo=timezone.utc)
+    assert recency_score("2024-01-01", now=now) == 0.3  # >1 year
+
+
+def test_recency_score_none():
+    assert recency_score(None) == 0.3
+
+
+def test_recency_score_invalid():
+    assert recency_score("not-a-date") == 0.3
+
+
+def test_recency_score_future():
+    now = datetime(2026, 4, 16, tzinfo=timezone.utc)
+    assert recency_score("2027-01-01", now=now) == 1.0
+
+
+# ─── Factor 4: Cross-References ───────────────────────────────────────
+
+
+@pytest.mark.parametrize("links,expected", [
+    (0, 0.3),
+    (1, 0.6),
+    (2, 0.6),
+    (3, 0.8),
+    (5, 0.8),
+    (6, 1.0),
+    (100, 1.0),
+])
+def test_cross_reference_score(links, expected):
+    assert cross_reference_score(links) == expected
+
+
+# ─── Composite ─────────────────────────────────────────────────────────
+
+
+def test_compute_confidence_defaults():
+    score = compute_confidence()
+    assert 0.0 <= score <= 1.0
+
+
+def test_compute_confidence_perfect():
+    now = datetime(2026, 4, 16, tzinfo=timezone.utc)
+    score = compute_confidence(
+        source_count=5,
+        source_qualities=["official", "official"],
+        last_updated="2026-04-15",
+        inbound_links=10,
+        now=now,
+    )
+    assert score == 1.0
+
+
+def test_compute_confidence_minimal():
+    now = datetime(2026, 4, 16, tzinfo=timezone.utc)
+    score = compute_confidence(
+        source_count=0,
+        source_qualities=[],
+        last_updated=None,
+        inbound_links=0,
+        now=now,
+    )
+    assert score < 0.3
+
+
+def test_compute_confidence_rounded():
+    score = compute_confidence(source_count=2, inbound_links=3)
+    # Check it's rounded to 2 decimal places
+    assert score == round(score, 2)
+
+
+# ─── Decay ─────────────────────────────────────────────────────────────
+
+
+def test_decay_factor_zero_age():
+    assert decay_factor("architecture", 0) == 1.0
+
+
+def test_decay_factor_half_life():
+    factor = decay_factor("architecture", 180)  # half-life = 180 days
+    assert factor == pytest.approx(0.5, abs=0.01)
+
+
+def test_decay_factor_tool_version_fast():
+    factor = decay_factor("tool_version", 30)  # half-life = 30 days
+    assert factor == pytest.approx(0.5, abs=0.01)
+
+
+def test_decay_factor_bug_very_fast():
+    factor = decay_factor("bug", 14)  # half-life = 14 days
+    assert factor == pytest.approx(0.5, abs=0.01)
+
+
+def test_decay_factor_unknown_uses_default():
+    factor = decay_factor("unknown_type", 90)  # default half-life = 90 days
+    assert factor == pytest.approx(0.5, abs=0.01)
+
+
+def test_apply_decay():
+    result = apply_decay(0.8, "architecture", 0)
+    assert result == 0.8
+
+    result = apply_decay(0.8, "architecture", 180)
+    assert result == pytest.approx(0.4, abs=0.02)

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,153 @@
+"""Tests for the lifecycle state machine (v1.0, #136)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from llmwiki.lifecycle import (
+    LifecycleState,
+    can_transition,
+    transition,
+    InvalidTransition,
+    check_auto_stale,
+    check_confidence_stale,
+    initial_state,
+    parse_lifecycle,
+    AUTO_STALE_DAYS,
+)
+
+
+# ─── LifecycleState enum ──────────────────────────────────────────────
+
+
+def test_lifecycle_states_have_5_values():
+    assert len(LifecycleState) == 5
+
+
+def test_lifecycle_state_values():
+    assert LifecycleState.DRAFT.value == "draft"
+    assert LifecycleState.REVIEWED.value == "reviewed"
+    assert LifecycleState.VERIFIED.value == "verified"
+    assert LifecycleState.STALE.value == "stale"
+    assert LifecycleState.ARCHIVED.value == "archived"
+
+
+# ─── Valid transitions ─────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("current,target", [
+    (LifecycleState.DRAFT, LifecycleState.REVIEWED),
+    (LifecycleState.DRAFT, LifecycleState.STALE),
+    (LifecycleState.REVIEWED, LifecycleState.VERIFIED),
+    (LifecycleState.REVIEWED, LifecycleState.STALE),
+    (LifecycleState.VERIFIED, LifecycleState.STALE),
+    (LifecycleState.STALE, LifecycleState.REVIEWED),
+    (LifecycleState.STALE, LifecycleState.ARCHIVED),
+    (LifecycleState.ARCHIVED, LifecycleState.REVIEWED),
+])
+def test_valid_transitions(current, target):
+    assert can_transition(current, target) is True
+    result = transition(current, target)
+    assert result == target
+
+
+# ─── Invalid transitions ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("current,target", [
+    (LifecycleState.DRAFT, LifecycleState.VERIFIED),  # must go through reviewed
+    (LifecycleState.DRAFT, LifecycleState.ARCHIVED),
+    (LifecycleState.REVIEWED, LifecycleState.DRAFT),  # no going back
+    (LifecycleState.REVIEWED, LifecycleState.ARCHIVED),
+    (LifecycleState.VERIFIED, LifecycleState.DRAFT),
+    (LifecycleState.VERIFIED, LifecycleState.REVIEWED),
+    (LifecycleState.ARCHIVED, LifecycleState.DRAFT),
+    (LifecycleState.ARCHIVED, LifecycleState.VERIFIED),
+])
+def test_invalid_transitions(current, target):
+    assert can_transition(current, target) is False
+    with pytest.raises(InvalidTransition):
+        transition(current, target)
+
+
+# ─── Auto-stale detection ─────────────────────────────────────────────
+
+
+def test_auto_stale_triggers_after_90_days():
+    now = datetime(2026, 7, 16, tzinfo=timezone.utc)
+    result = check_auto_stale(
+        LifecycleState.DRAFT, "2026-04-16", now=now
+    )
+    assert result == LifecycleState.STALE  # 91 days
+
+
+def test_auto_stale_does_not_trigger_within_90_days():
+    now = datetime(2026, 7, 14, tzinfo=timezone.utc)
+    result = check_auto_stale(
+        LifecycleState.DRAFT, "2026-04-16", now=now
+    )
+    assert result is None  # 89 days
+
+
+def test_auto_stale_skips_already_stale():
+    now = datetime(2026, 12, 1, tzinfo=timezone.utc)
+    result = check_auto_stale(
+        LifecycleState.STALE, "2025-01-01", now=now
+    )
+    assert result is None
+
+
+def test_auto_stale_skips_archived():
+    now = datetime(2026, 12, 1, tzinfo=timezone.utc)
+    result = check_auto_stale(
+        LifecycleState.ARCHIVED, "2025-01-01", now=now
+    )
+    assert result is None
+
+
+def test_auto_stale_none_date_triggers():
+    result = check_auto_stale(LifecycleState.DRAFT, None)
+    assert result == LifecycleState.STALE
+
+
+def test_auto_stale_invalid_date_triggers():
+    result = check_auto_stale(LifecycleState.REVIEWED, "not-a-date")
+    assert result == LifecycleState.STALE
+
+
+# ─── Confidence-based stale ───────────────────────────────────────────
+
+
+def test_confidence_stale_triggers_below_threshold():
+    result = check_confidence_stale(LifecycleState.REVIEWED, 0.4)
+    assert result == LifecycleState.STALE
+
+
+def test_confidence_stale_ok_above_threshold():
+    result = check_confidence_stale(LifecycleState.REVIEWED, 0.5)
+    assert result is None
+
+
+def test_confidence_stale_skips_already_stale():
+    result = check_confidence_stale(LifecycleState.STALE, 0.1)
+    assert result is None
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────
+
+
+def test_initial_state_is_draft():
+    assert initial_state() == LifecycleState.DRAFT
+
+
+def test_parse_lifecycle_valid():
+    assert parse_lifecycle("draft") == LifecycleState.DRAFT
+    assert parse_lifecycle("REVIEWED") == LifecycleState.REVIEWED
+    assert parse_lifecycle("  verified  ") == LifecycleState.VERIFIED
+
+
+def test_parse_lifecycle_invalid():
+    with pytest.raises(ValueError, match="Invalid lifecycle"):
+        parse_lifecycle("unknown")


### PR DESCRIPTION
## Summary

Adds 72 tests for the two new Sprint 1 modules.

## Changes

- `tests/test_confidence.py` — 42 tests: 4 factors, composite formula, decay curves
- `tests/test_lifecycle.py` — 30 tests: 5 states, valid/invalid transitions, auto-stale, parse

## PR Checklist

- [ ] 72 new tests all pass
- [ ] Full suite still green (701+ existing + 72 new)
- [ ] GPG-signed, no Co-authored-by

## Ref

Ref #139