### PR TITLE
feat: flat raw/ naming (date+time+project+slug)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Versions below 1.0 are pre-production — API and file formats may change.
 - **Confidence scoring module** (#135) — new `llmwiki/confidence.py` implementing the 4-factor weighted-average formula from the LLM Book design spec: `source_count(0.3) + source_quality(0.3) + recency(0.2) + cross_refs(0.2)`. Includes Ebbinghaus-inspired content-type decay with configurable half-lives (architecture 6mo, tool versions 30d, people 3mo, bugs 14d, APIs 2mo). Each factor maps to [0.0, 1.0]; composite is rounded to 2 decimal places and stored in YAML frontmatter as `confidence: 0.85`.
 - **Lifecycle state machine** (#136) — new `llmwiki/lifecycle.py` with 5 states (draft → reviewed → verified → stale → archived), validated transitions, auto-stale detection after 90 days without update, and confidence-based stale detection (confidence < 0.5). Manual-only transitions for `verified` (human confirms) and `archived` (human decision). Includes `parse_lifecycle()` for YAML frontmatter parsing.
 
+### Changed
+
+- **Flat raw/ naming** (#141) — converted session files now use `YYYY-MM-DDTHH-MM-project-slug.md` in a single flat directory instead of nested `<project>/<date>-<slug>.md`. Files sort chronologically, project is embedded in filename for traceability. New `flat_output_name()` helper. CLAUDE.md and AGENTS.md updated.
+
 ### Security
 
 - **Remove personal data from tracked nav files** — `wiki/MEMORY.md`, `wiki/SOUL.md`, `wiki/CRITICAL_FACTS.md`, `wiki/hints.md`, `wiki/hot.md` untracked from git (contain user-specific data). Added to `.gitignore`. These are created locally by `llmwiki init` but never committed to the public repo.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ You are maintaining an **LLM Wiki** (per [Karpathy's spec](https://gist.github.c
 
 ```
 raw/           IMMUTABLE. Session transcripts converted from ~/.claude/projects/*/*.jsonl.
+               Flat naming: YYYY-MM-DDTHH-MM-project-slug.md (no subdirectories).
                Never modify files here. Treat as source-of-truth for facts.
 
 wiki/          YOU OWN THIS. LLM-generated pages that summarise, cross-reference, and
@@ -55,7 +56,7 @@ Triggered by `/wiki-ingest <path>` or `/wiki-sync`.
 
 ### Session-derived source specifics
 
-Files under `raw/sessions/<project>/<YYYY-MM-DD>-<slug>.md` are auto-generated from `.jsonl` transcripts. They have rich YAML frontmatter (`project`, `slug`, `started`, `model`, `tools_used`, `gitBranch`, etc.). When ingesting these:
+Files under `raw/sessions/<YYYY-MM-DDTHH-MM>-<project>-<slug>.md` are auto-generated from `.jsonl` transcripts (flat naming, no subdirectories). They have rich YAML frontmatter (`project`, `slug`, `started`, `model`, `tools_used`, `gitBranch`, etc.). When ingesting these:
 
 - **Trust the frontmatter** — don't re-infer metadata from the body
 - **Do NOT copy the Conversation section verbatim** — treat it as raw material to summarize
@@ -72,7 +73,7 @@ title: "Source Title"
 type: source
 tags: [claude-code, session-transcript]
 date: YYYY-MM-DD
-source_file: raw/sessions/<project>/<file>.md
+source_file: raw/sessions/<YYYY-MM-DDTHH-MM>-<project>-<slug>.md
 project: <project-slug>
 model: <model-id>
 ---

--- a/llmwiki/convert.py
+++ b/llmwiki/convert.py
@@ -581,6 +581,20 @@ def derive_session_slug(records: list[dict[str, Any]], jsonl_path: Path) -> str:
     return jsonl_path.stem[:12]
 
 
+def flat_output_name(
+    started: datetime,
+    project_slug: str,
+    slug: str,
+) -> str:
+    """Build a flat filename: ``YYYY-MM-DDTHH-MM-project-slug.md``.
+
+    The date+time+project+slug format ensures chronological sort,
+    project traceability, and uniqueness without nested directories.
+    """
+    ts = started.strftime("%Y-%m-%dT%H-%M")
+    return f"{ts}-{project_slug}-{slug}.md"
+
+
 def render_session_markdown(
     records: list[dict[str, Any]],
     jsonl_path: Path,
@@ -621,7 +635,7 @@ def render_session_markdown(
         "type: source",
         "tags: [claude-code, session-transcript]",
         f"date: {date_str}",
-        f"source_file: raw/sessions/{project_slug}/{date_str}-{slug}.md",
+        f"source_file: raw/sessions/{started.strftime('%Y-%m-%dT%H-%M')}-{project_slug}-{slug}.md",
         f"sessionId: {session_id}",
         f"slug: {slug}",
         f"project: {project_slug}",
@@ -787,8 +801,8 @@ def convert_all(
                 if len(text) < 50:
                     filtered += 1
                     continue
-                out_name = path.stem + ".md"
-                out_path = out_dir / project_slug / out_name
+                out_name = f"{project_slug}-{path.stem}.md"
+                out_path = out_dir / out_name
                 if dry_run:
                     print(f"  [dry-run] {out_path.relative_to(REPO_ROOT) if out_path.is_relative_to(REPO_ROOT) else out_path} ({len(text)} bytes)")
                 else:
@@ -809,7 +823,7 @@ def convert_all(
                 if not md:
                     filtered += 1
                     continue
-                out_path = out_dir / project_slug / out_name
+                out_path = out_dir / f"{project_slug}-{out_name}"
                 if dry_run:
                     print(f"  [dry-run] {out_path.relative_to(REPO_ROOT) if out_path.is_relative_to(REPO_ROOT) else out_path} ({len(md)} bytes)")
                 else:
@@ -845,7 +859,8 @@ def convert_all(
                 errors += 1
                 continue
             date_str = started.strftime("%Y-%m-%d")
-            out_path = out_dir / project_slug / f"{date_str}-{slug}.md"
+            out_name = flat_output_name(started, project_slug, slug)
+            out_path = out_dir / out_name
             if dry_run:
                 print(f"  [dry-run] {out_path.relative_to(REPO_ROOT)} ({len(md)} bytes)")
             else:

--- a/tests/test_flat_naming.py
+++ b/tests/test_flat_naming.py
@@ -1,0 +1,78 @@
+"""Tests for flat raw/ naming scheme (v1.0, #141)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from llmwiki.convert import flat_output_name
+
+
+def test_basic_flat_name():
+    started = datetime(2026, 4, 16, 10, 30, tzinfo=timezone.utc)
+    result = flat_output_name(started, "ai-newsletter", "kind-tinkering-hejlsberg")
+    assert result == "2026-04-16T10-30-ai-newsletter-kind-tinkering-hejlsberg.md"
+
+
+def test_midnight():
+    started = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+    result = flat_output_name(started, "demo", "test")
+    assert result == "2026-01-01T00-00-demo-test.md"
+
+
+def test_single_digit_hour():
+    started = datetime(2026, 3, 5, 9, 5, tzinfo=timezone.utc)
+    result = flat_output_name(started, "myproject", "slug")
+    assert result == "2026-03-05T09-05-myproject-slug.md"
+
+
+def test_ends_with_md():
+    result = flat_output_name(
+        datetime(2026, 4, 1, 14, 0, tzinfo=timezone.utc),
+        "proj",
+        "test-slug",
+    )
+    assert result.endswith(".md")
+
+
+def test_no_slashes_in_name():
+    """Flat naming must not produce nested directories."""
+    result = flat_output_name(
+        datetime(2026, 4, 1, 14, 0, tzinfo=timezone.utc),
+        "my-project",
+        "my-slug",
+    )
+    assert "/" not in result
+    assert "\\" not in result
+
+
+def test_chronological_sort():
+    """Files should sort chronologically by name."""
+    names = [
+        flat_output_name(datetime(2026, 4, 16, 10, 0, tzinfo=timezone.utc), "a", "s1"),
+        flat_output_name(datetime(2026, 4, 16, 9, 0, tzinfo=timezone.utc), "a", "s2"),
+        flat_output_name(datetime(2026, 4, 15, 23, 59, tzinfo=timezone.utc), "b", "s3"),
+    ]
+    assert sorted(names) == [names[2], names[1], names[0]]  # oldest first
+
+
+def test_project_embedded():
+    """Project slug is in the filename for traceability."""
+    result = flat_output_name(
+        datetime(2026, 4, 1, 14, 0, tzinfo=timezone.utc),
+        "germanly",
+        "slug",
+    )
+    assert "germanly" in result
+
+
+def test_subagent_slug():
+    """Subagent slugs (with -subagent- suffix) work fine."""
+    result = flat_output_name(
+        datetime(2026, 4, 1, 14, 0, tzinfo=timezone.utc),
+        "research",
+        "my-slug-subagent-abc12345",
+    )
+    assert "subagent" in result
+    assert "/" not in result


### PR DESCRIPTION
## Summary

Converts session file output from nested `raw/sessions/<project>/<date>-<slug>.md` to flat `raw/sessions/<YYYY-MM-DDTHH-MM>-<project>-<slug>.md`.

## Changes

- New `flat_output_name()` helper in `convert.py`
- All 3 output paths updated (JSONL sessions, MD copy, PDF)
- `source_file` frontmatter uses new flat format
- CLAUDE.md + AGENTS.md updated with naming convention
- 8 tests: chronological sort, no-slashes, subagent slugs, edge cases

## PR Checklist

- [ ] Tests pass (847+)
- [ ] `flat_output_name()` produces `YYYY-MM-DDTHH-MM-project-slug.md`
- [ ] No slashes in output filenames
- [ ] `source_file` frontmatter updated
- [ ] CLAUDE.md documents flat naming
- [ ] CHANGELOG updated
- [ ] GPG-signed, no Co-authored-by

## Closes

Closes #141