### PR TITLE
feat: pending ingest queue for SessionStart hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ dist-site/
 .ingestion-state.json
 .llmwiki-state.json
 .llmwiki-synth-state.json
+.llmwiki-queue.json
 
 # Local config (user-specific).
 config.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Versions below 1.0 are pre-production — API and file formats may change.
 - **Confidence scoring module** (#135) — new `llmwiki/confidence.py` implementing the 4-factor weighted-average formula from the LLM Book design spec: `source_count(0.3) + source_quality(0.3) + recency(0.2) + cross_refs(0.2)`. Includes Ebbinghaus-inspired content-type decay with configurable half-lives (architecture 6mo, tool versions 30d, people 3mo, bugs 14d, APIs 2mo). Each factor maps to [0.0, 1.0]; composite is rounded to 2 decimal places and stored in YAML frontmatter as `confidence: 0.85`.
 - **Lifecycle state machine** (#136) — new `llmwiki/lifecycle.py` with 5 states (draft → reviewed → verified → stale → archived), validated transitions, auto-stale detection after 90 days without update, and confidence-based stale detection (confidence < 0.5). Manual-only transitions for `verified` (human confirms) and `archived` (human decision). Includes `parse_lifecycle()` for YAML frontmatter parsing.
 
+- **Pending ingest queue** (#148) — new `llmwiki/queue.py` module with `enqueue()`, `dequeue()`, `peek()`, `clear()`, `queue_size()`. SessionStart hook adds converted files to `.llmwiki-queue.json`; `/wiki-sync` processes and clears the queue. Deduplicates automatically, graceful recovery from corrupt files.
+
 ### Changed
 
 - **Flat raw/ naming** (#141) — converted session files now use `YYYY-MM-DDTHH-MM-project-slug.md` in a single flat directory instead of nested `<project>/<date>-<slug>.md`. Files sort chronologically, project is embedded in filename for traceability. New `flat_output_name()` helper. CLAUDE.md and AGENTS.md updated.

--- a/llmwiki/queue.py
+++ b/llmwiki/queue.py
@@ -1,0 +1,101 @@
+"""Pending ingest queue (v1.0 · #148).
+
+Tracks files that have been converted to raw/ but not yet ingested
+into wiki/. The SessionStart hook adds files here after conversion;
+``/wiki-sync`` processes and clears the queue.
+
+State is stored in ``.llmwiki-queue.json`` — a simple JSON array of
+file paths relative to the repo root.
+
+Usage::
+
+    from llmwiki.queue import enqueue, dequeue, peek, clear, queue_path
+
+    # Hook adds after conversion
+    enqueue(["raw/sessions/2026-04-16T10-30-proj-slug.md"])
+
+    # /wiki-sync reads and processes
+    pending = dequeue()   # returns list and clears queue
+    for path in pending:
+        ingest(path)
+
+    # Or peek without consuming
+    pending = peek()
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from llmwiki import REPO_ROOT
+
+DEFAULT_QUEUE_FILE = REPO_ROOT / ".llmwiki-queue.json"
+
+
+def _load(queue_file: Optional[Path] = None) -> list[str]:
+    """Load the queue file. Returns list of relative paths."""
+    qf = queue_file or DEFAULT_QUEUE_FILE
+    if not qf.is_file():
+        return []
+    try:
+        data = json.loads(qf.read_text(encoding="utf-8"))
+        if isinstance(data, list):
+            return [str(p) for p in data if isinstance(p, str)]
+    except (json.JSONDecodeError, OSError):
+        pass
+    return []
+
+
+def _save(items: list[str], queue_file: Optional[Path] = None) -> None:
+    """Save the queue file."""
+    qf = queue_file or DEFAULT_QUEUE_FILE
+    qf.write_text(
+        json.dumps(sorted(set(items)), indent=2), encoding="utf-8"
+    )
+
+
+def enqueue(
+    paths: list[str],
+    *,
+    queue_file: Optional[Path] = None,
+) -> int:
+    """Add paths to the pending ingest queue.
+
+    Deduplicates automatically. Returns the new queue length.
+    """
+    current = _load(queue_file)
+    combined = list(set(current) | set(paths))
+    _save(combined, queue_file)
+    return len(combined)
+
+
+def dequeue(*, queue_file: Optional[Path] = None) -> list[str]:
+    """Return all pending paths and clear the queue.
+
+    This is the consume operation — after calling this, the queue
+    is empty. Process the returned paths, then they're done.
+    """
+    items = _load(queue_file)
+    qf = queue_file or DEFAULT_QUEUE_FILE
+    if qf.is_file():
+        qf.write_text("[]", encoding="utf-8")
+    return items
+
+
+def peek(*, queue_file: Optional[Path] = None) -> list[str]:
+    """Return pending paths without consuming them."""
+    return _load(queue_file)
+
+
+def clear(*, queue_file: Optional[Path] = None) -> None:
+    """Clear the queue without reading."""
+    qf = queue_file or DEFAULT_QUEUE_FILE
+    if qf.is_file():
+        qf.write_text("[]", encoding="utf-8")
+
+
+def queue_size(*, queue_file: Optional[Path] = None) -> int:
+    """Return the number of pending items."""
+    return len(_load(queue_file))

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,0 +1,109 @@
+"""Tests for the pending ingest queue (v1.0, #148)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from llmwiki.queue import enqueue, dequeue, peek, clear, queue_size
+
+
+# ─── Basic operations ──────────────────────────────────────────────────
+
+
+def test_enqueue_creates_file(tmp_path: Path):
+    qf = tmp_path / "queue.json"
+    count = enqueue(["raw/sessions/a.md"], queue_file=qf)
+    assert count == 1
+    assert qf.exists()
+
+
+def test_peek_returns_items(tmp_path: Path):
+    qf = tmp_path / "queue.json"
+    enqueue(["raw/a.md", "raw/b.md"], queue_file=qf)
+    items = peek(queue_file=qf)
+    assert set(items) == {"raw/a.md", "raw/b.md"}
+
+
+def test_dequeue_returns_and_clears(tmp_path: Path):
+    qf = tmp_path / "queue.json"
+    enqueue(["raw/a.md", "raw/b.md"], queue_file=qf)
+    items = dequeue(queue_file=qf)
+    assert len(items) == 2
+    assert queue_size(queue_file=qf) == 0
+
+
+def test_clear_empties_queue(tmp_path: Path):
+    qf = tmp_path / "queue.json"
+    enqueue(["raw/a.md"], queue_file=qf)
+    clear(queue_file=qf)
+    assert queue_size(queue_file=qf) == 0
+
+
+def test_queue_size(tmp_path: Path):
+    qf = tmp_path / "queue.json"
+    assert queue_size(queue_file=qf) == 0
+    enqueue(["raw/a.md", "raw/b.md", "raw/c.md"], queue_file=qf)
+    assert queue_size(queue_file=qf) == 3
+
+
+# ─── Deduplication ─────────────────────────────────────────────────────
+
+
+def test_enqueue_deduplicates(tmp_path: Path):
+    qf = tmp_path / "queue.json"
+    enqueue(["raw/a.md", "raw/a.md", "raw/a.md"], queue_file=qf)
+    assert queue_size(queue_file=qf) == 1
+
+
+def test_enqueue_deduplicates_across_calls(tmp_path: Path):
+    qf = tmp_path / "queue.json"
+    enqueue(["raw/a.md", "raw/b.md"], queue_file=qf)
+    enqueue(["raw/b.md", "raw/c.md"], queue_file=qf)
+    assert queue_size(queue_file=qf) == 3
+
+
+# ─── Edge cases ────────────────────────────────────────────────────────
+
+
+def test_peek_empty_queue(tmp_path: Path):
+    qf = tmp_path / "queue.json"
+    assert peek(queue_file=qf) == []
+
+
+def test_dequeue_empty_queue(tmp_path: Path):
+    qf = tmp_path / "queue.json"
+    assert dequeue(queue_file=qf) == []
+
+
+def test_enqueue_empty_list(tmp_path: Path):
+    qf = tmp_path / "queue.json"
+    count = enqueue([], queue_file=qf)
+    assert count == 0
+
+
+def test_corrupt_queue_file(tmp_path: Path):
+    qf = tmp_path / "queue.json"
+    qf.write_text("NOT JSON", encoding="utf-8")
+    assert peek(queue_file=qf) == []  # graceful recovery
+
+
+def test_queue_with_non_string_items(tmp_path: Path):
+    """Non-string items in the JSON array are skipped."""
+    qf = tmp_path / "queue.json"
+    qf.write_text('[123, null, "raw/a.md", true]', encoding="utf-8")
+    items = peek(queue_file=qf)
+    assert items == ["raw/a.md"]
+
+
+def test_sorted_output(tmp_path: Path):
+    qf = tmp_path / "queue.json"
+    enqueue(["raw/c.md", "raw/a.md", "raw/b.md"], queue_file=qf)
+    items = peek(queue_file=qf)
+    assert items == sorted(items)
+
+
+def test_clear_nonexistent_file(tmp_path: Path):
+    qf = tmp_path / "queue.json"
+    clear(queue_file=qf)  # should not raise


### PR DESCRIPTION
## Summary

New `llmwiki/queue.py` module that tracks files converted to raw/ but not yet ingested into wiki/.

## API

- `enqueue(paths)` — add to queue, deduplicates
- `dequeue()` — return all and clear (consume)
- `peek()` — read without consuming
- `clear()` — empty the queue
- `queue_size()` — count pending

## PR Checklist

- [ ] 14 tests pass (basic ops, dedup, edge cases)
- [ ] Full suite green
- [ ] `.llmwiki-queue.json` gitignored
- [ ] Graceful recovery from corrupt JSON
- [ ] CHANGELOG updated
- [ ] GPG-signed, no Co-authored-by

## Closes

Closes #148