### PR TITLE
chore: _context.md stubs for all wiki subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ wiki/hot/*
 !wiki/entities/_context.md
 !wiki/concepts/_context.md
 !wiki/sources/_context.md
+!wiki/syntheses/_context.md
+!wiki/comparisons/_context.md
+!wiki/questions/_context.md
 # v0.7 (#55, #56): seeded reference model entity ships with the repo
 # so the structured schema + changelog timeline are visible on the
 # live demo build.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versions below 1.0 are pre-production — API and file formats may change.
 - **Confidence scoring module** (#135) — new `llmwiki/confidence.py` implementing the 4-factor weighted-average formula from the LLM Book design spec: `source_count(0.3) + source_quality(0.3) + recency(0.2) + cross_refs(0.2)`. Includes Ebbinghaus-inspired content-type decay with configurable half-lives (architecture 6mo, tool versions 30d, people 3mo, bugs 14d, APIs 2mo). Each factor maps to [0.0, 1.0]; composite is rounded to 2 decimal places and stored in YAML frontmatter as `confidence: 0.85`.
 - **Lifecycle state machine** (#136) — new `llmwiki/lifecycle.py` with 5 states (draft → reviewed → verified → stale → archived), validated transitions, auto-stale detection after 90 days without update, and confidence-based stale detection (confidence < 0.5). Manual-only transitions for `verified` (human confirms) and `archived` (human decision). Includes `parse_lifecycle()` for YAML frontmatter parsing.
 
+- **`_context.md` stubs for all wiki subdirectories** (#150) — added stubs for `syntheses/`, `comparisons/`, and `questions/` folders. All 6 content folders now have context descriptions that guide LLM navigation during deep queries.
 - **Pending ingest queue** (#148) — new `llmwiki/queue.py` module with `enqueue()`, `dequeue()`, `peek()`, `clear()`, `queue_size()`. SessionStart hook adds converted files to `.llmwiki-queue.json`; `/wiki-sync` processes and clears the queue. Deduplicates automatically, graceful recovery from corrupt files.
 
 ### Changed

--- a/wiki/comparisons/_context.md
+++ b/wiki/comparisons/_context.md
@@ -1,0 +1,16 @@
+---
+title: "Comparisons Folder Context"
+type: context
+---
+
+# wiki/comparisons/
+
+Side-by-side analyses of two or more entities or concepts. Auto-generated
+by the build pipeline for model entities, or manually created for any
+topic where relative comparison is more useful than individual pages.
+
+**When to descend here:** The user asks "how does X compare to Y", or
+wants a diff between tools, frameworks, or approaches.
+
+**When to skip:** Single-entity lookups, concept definitions, or
+chronological source browsing.

--- a/wiki/questions/_context.md
+++ b/wiki/questions/_context.md
@@ -1,0 +1,16 @@
+---
+title: "Questions Folder Context"
+type: context
+---
+
+# wiki/questions/
+
+First-class open questions with state tracking. Each page represents
+a question the wiki cannot yet fully answer — a known gap that may
+drive future research, ingestion, or synthesis.
+
+**When to descend here:** The user asks about known unknowns, research
+gaps, or wants to see what the wiki doesn't know yet.
+
+**When to skip:** Questions that the wiki CAN answer — route those
+through `sources/`, `entities/`, `concepts/`, or `syntheses/` instead.

--- a/wiki/syntheses/_context.md
+++ b/wiki/syntheses/_context.md
@@ -1,0 +1,16 @@
+---
+title: "Syntheses Folder Context"
+type: context
+---
+
+# wiki/syntheses/
+
+Filed answers to `/wiki-query` questions. Each page is a saved synthesis
+that answered a specific question by reading multiple wiki pages and
+combining their information.
+
+**When to descend here:** The user asks a question that was previously
+answered and saved, or wants to find prior research/analysis outputs.
+
+**When to skip:** Entity lookups, concept definitions, or raw source
+browsing — those live in `entities/`, `concepts/`, and `sources/`.


### PR DESCRIPTION
## Summary

Adds folder-context stubs for the 3 remaining wiki subdirectories. All 6 content folders now have `_context.md`.

## New Files

- `wiki/syntheses/_context.md` — filed query answers
- `wiki/comparisons/_context.md` — side-by-side analyses
- `wiki/questions/_context.md` — open questions

## PR Checklist

- [ ] All 6 folders have `_context.md` (entities, concepts, sources, syntheses, comparisons, questions)
- [ ] `.gitignore` exceptions added
- [ ] CHANGELOG updated
- [ ] GPG-signed, no Co-authored-by

## Closes

Closes #150