### PR TITLE
fix: pipeline failures on tag pushes (Pages + PyPI)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,13 +1,14 @@
 name: Deploy demo site to GitHub Pages
 
 # Builds a public demo from dummy example sessions (no personal data) and
-# publishes it to GitHub Pages. Triggered on tag pushes, pushes to main, and
-# manual runs. Highlight.js loads client-side from CDN so no extra deps.
+# publishes it to GitHub Pages. Triggered on pushes to master/main and manual
+# runs. Not on tag pushes (GitHub Pages env only accepts deploys from master,
+# and the master push already covers the same content). Highlight.js loads
+# client-side from CDN so no extra deps.
 
 on:
   push:
     branches: ["master", "main"]
-    tags: ["v*"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,11 @@ jobs:
     environment: release
     permissions:
       id-token: write
+    # Skip PyPI publish if the PYPI_PUBLISHING variable is not set to "true".
+    # One-time setup required on PyPI (trusted publisher) — see #101.
+    # Until configured, release tags still build + sign + create GitHub Release;
+    # only PyPI upload is deferred. Enable via: gh variable set PYPI_PUBLISHING --body "true"
+    if: vars.PYPI_PUBLISHING == 'true'
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -96,7 +101,10 @@ jobs:
 
   github-release:
     name: Create GitHub Release
-    needs: [publish, sign]
+    needs: [build, sign]
+    # Run even if publish was skipped or failed — GitHub Release shouldn't
+    # depend on PyPI upload succeeding.
+    if: always() && needs.build.result == 'success' && needs.sign.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ### Fixed
 
+- **Pages deploy no longer fires on tag pushes** — only on push to master. Tag pushes would try to deploy the same content a second time and fail because the GitHub Pages env only accepts master-branch deploys.
+- **PyPI publish is gated on `PYPI_PUBLISHING` repo variable** — until PyPI Trusted Publisher is configured (#101), tag pushes won't fail. The build + sign + GitHub Release still run; only PyPI upload is deferred. Enable via `gh variable set PYPI_PUBLISHING --body "true"` after setup.
 - **Release-drafter runs only on push to master** — removed `pull_request` trigger that caused `target_commitish: refs/pull/N/merge` validation errors with release-drafter@v7. Draft releases only need to update when commits land on master.
 - **Synthesis pipeline writes to real log during tests** (#131) — `_append_log()` in `llmwiki/synth/pipeline.py` now accepts an optional `log_path` parameter (defaults to `WIKI_LOG`), and `synthesize_new_sessions()` forwards it. All tests in `test_synth_pipeline.py` pass isolated `tmp_path` log files. Cleaned 42 duplicate `synthesize | test-proj/test-synth` entries from `wiki/log.md` caused by unguarded test writes.
 


### PR DESCRIPTION
## Problem

Two pipelines failing on v0.9.1 and v0.9.2 tag pushes:

- **Pages deploy**: tries to deploy twice (master + tag), tag ref rejected by Pages env
- **PyPI publish**: Trusted Publisher not configured (needs #101 first)

## Fix

- Remove tag trigger from pages.yml — master push already deploys same content
- Gate PyPI publish on `PYPI_PUBLISHING` repo variable until #101 is done
- GitHub Release creation decoupled from PyPI publish outcome

## PR Checklist

- [ ] No workflow logic tests broken
- [ ] CHANGELOG updated
- [ ] GPG-signed
EOF