### PR TITLE
chore: upgrade PR template to 15-box pre-merge checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,25 +27,34 @@ Closes #<issue>
 ```bash
 python3 -m pytest tests/ -q
 python3 -m llmwiki build
+python3 -m llmwiki lint --fail-on-errors
 ```
 
-## Checklist
+## Pre-merge checklist
 
-- [ ] Linked to an issue (or explained why the change is trivial enough not to need one)
-- [ ] One concern per PR — no mixing a bug fix with a new feature
-- [ ] Conventional-commit title: `feat:` / `fix:` / `docs:` / `chore:` / `test:` (optionally with a version scope like `feat(v0.8):`)
-- [ ] Tests added or updated — happy path + at least one edge case
-- [ ] `python3 -m pytest tests/ -q` passes locally
-- [ ] `python3 -m llmwiki build` completes without new warnings
-- [ ] CHANGELOG.md has a new entry under `## [Unreleased]` (skip for doc-only PRs)
-- [ ] No new runtime dependencies (stdlib + `markdown` only)
-- [ ] No real session data under `raw/sessions/` or in test fixtures
-- [ ] No machine-specific paths in committed files
-- [ ] Docs updated for any user-visible change
+Every box below must be checked (or have a one-line waiver explaining why it does not apply to this PR).
+
+- [ ] **One intent** — this PR does one thing (no mixing a fix with a refactor or a new feature)
+- [ ] **All CI checks green** — no `--no-verify`, no skipped required jobs
+- [ ] **Linked issue** — title or body contains `Closes #N` (or one-line waiver explaining why the change is trivial)
+- [ ] **Conventional-commit title** — `<type>(<scope>): <imperative>` where type is `feat` / `fix` / `chore` / `docs` / `test` / `refactor` / `perf` / `security` / `release` (optionally with a version scope like `feat(v0.8):`)
+- [ ] **Tests added or updated** — happy path + at least one edge case; TDD where shape is clear
+- [ ] **CHANGELOG.md updated** — new entry under `## [Unreleased]` (skip for doc-only PRs that don't change behavior)
+- [ ] **Breaking changes flagged** — PR labeled `breaking` and announced in the body under a clear heading
+- [ ] **No new runtime dependencies** — stdlib + `markdown` only; new dev/test deps need justification + license check (no AGPL/GPL into MIT)
+- [ ] **No real session data** — no personal sessions under `raw/sessions/` or in test fixtures; `wiki/` user content stays gitignored
+- [ ] **No machine-specific paths** or secrets in committed files (check `.env`, `*.key`, home paths, usernames)
+- [ ] **Docs updated** — `README.md`, `docs/`, inline `--help` all reflect any user-visible change
+- [ ] **UI verified** (light AND dark mode) — for any change to `llmwiki/build.py` CSS or static site. Paste screenshots below.
+- [ ] **A11y verified** — keyboard nav works, focus rings visible, `axe` clean (for UI changes). WCAG 2.1 AA minimum (contrast ≥ 4.5:1).
+- [ ] **Commits GPG-signed** by the repo author; no AI co-author trailers; atomic commits (one logical change each)
+- [ ] **Reviewer has read every changed line** — no rubber-stamping
 
 ## Screenshots / output
 
-<!-- Paste screenshots, preview URLs, or CLI output if the change affects the rendered site or the CLI -->
+<!-- For UI changes: paste LIGHT + DARK screenshots side-by-side.
+     For CLI changes: paste the new --help output.
+     For build changes: paste the build summary line. -->
 
 ## Out of scope / follow-ups
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased] — post-v1.0 cleanup
 
+### Changed
+
+- **PR template upgraded to 15-box pre-merge checklist** — inspired by the Translately platform's contribution rules. New boxes: one intent, breaking-change flagging, UI verified in light AND dark mode (with screenshots), a11y verified (WCAG 2.1 AA minimum), commits GPG-signed with no AI co-author trailers, reviewer reads every changed line. `CONTRIBUTING.md` updated with matching conventional-commit type table (9 types now vs 5 before), 500-line PR size limit, signed-commit branch protection rule. 21 new tests lock the checklist shape.
+
 ### Added
 
 - `llmwiki/tag_utils.py` — shared tag-parsing module. Consolidates the byte-identical `_parse_tags_field()` + `NOISE_TAGS` that were duplicated in `categories.py` and `search_facets.py`. 19 tests covering parsing, noise filtering, deterministic scan order, and backwards-compat re-exports.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,36 +81,54 @@ Adapted from the parent [Open Source Project Framework](docs/framework.md):
 
 ### PR size
 
-- **One concern per PR.** Don't mix "add a new adapter" with "fix a CSS bug".
-- **One file per PR preferred** unless the change is strictly atomic (e.g. test fixture + snapshot that must move together).
-- **Small commits.** Each commit should tell a clear story.
+- **One intent per PR.** Don't mix "add a new adapter" with "fix a CSS bug". Split before opening.
+- **≤500 lines of diff.** If the PR gets larger than that, the reviewer will ask you to split.
+- **Atomic commits.** Each commit tells a clear story; renames isolated from behavior changes.
 
 ### PR title format
 
-Use conventional-commit-style prefixes (matches what's in `git log` on
-this repo):
+Conventional Commits. Types we accept:
 
-- `feat: <feature>` or `feat(v0.X): <feature>` — new functionality
-- `fix: <what>` or `fix(v0.X): <what>` — bug fix
-- `docs: <what>` — docs only
-- `chore: <what>` — refactor, dep bump, CI, version bumps
-- `test: <what>` or `test+docs: <what>` — tests only / tests + docs
+| Type | When | Version bump |
+|------|------|--------------|
+| `feat` | New user-visible capability | minor |
+| `fix` | Bug fix | patch |
+| `chore` | Maintenance, deps, CI, version bumps | patch |
+| `docs` | Docs only | patch |
+| `test` | Tests only | patch |
+| `refactor` | Internal restructuring, no behavior change | patch |
+| `perf` | Performance improvement | patch |
+| `security` | Security fix or hardening | patch |
+| `release` | Version bump + CHANGELOG promotion | — |
 
-Include the issue number in the PR title or body when the PR closes
-one: `feat(v0.8): tool-calling bar chart (#65)`.
+Optionally scope with a version: `feat(v0.8): tool chart`. Include the issue number: `Closes #65` in the body.
 
-### PR body checklist
+### PR body — 15-box pre-merge checklist
 
-- What problem does this solve?
-- How does this solution work?
-- Which files changed and why?
-- How did you test it?
-- Any follow-up work left for a later PR?
+Every box must be checked (or have a one-line waiver). See [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) for the current list. Covers at minimum:
+
+1. One intent (no mixing concerns)
+2. CI green
+3. Linked issue via `Closes #N`
+4. Conventional-commit title
+5. Tests added/updated (happy path + edge case)
+6. CHANGELOG under Unreleased
+7. Breaking changes flagged + labeled `breaking`
+8. No new runtime deps (stdlib + `markdown` only)
+9. No real session data in `raw/` or fixtures
+10. No machine-specific paths or secrets
+11. Docs updated for user-visible changes
+12. **UI verified in light AND dark mode** (for CSS/UI changes) — screenshots attached
+13. **A11y verified** — keyboard nav, focus rings, WCAG 2.1 AA (≥ 4.5:1 contrast)
+14. Commits GPG-signed, no AI co-author trailers, atomic
+15. Reviewer has read every changed line (no rubber-stamping)
 
 ### Branch protection
 
-- Default branch is `master`.
+- Default branch is `master`; never push directly — PR required.
 - CI must pass before merge.
+- Signed commits required.
+- Branch must be up-to-date with master before merge.
 
 ## Adding a new adapter
 

--- a/tests/test_pr_template.py
+++ b/tests/test_pr_template.py
@@ -1,0 +1,127 @@
+"""Tests for the PR template (post-v1.0 governance upgrade)."""
+
+from __future__ import annotations
+
+import pytest
+
+from llmwiki import REPO_ROOT
+
+
+TEMPLATE = REPO_ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md"
+CONTRIBUTING = REPO_ROOT / "CONTRIBUTING.md"
+
+
+# ─── PR template ──────────────────────────────────────────────────────
+
+
+def test_template_exists():
+    assert TEMPLATE.is_file()
+
+
+def test_template_has_summary_section():
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert "## Summary" in text
+
+
+def test_template_has_closes_hint():
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert "Closes #" in text
+
+
+def test_template_has_how_to_test():
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert "How to test" in text
+
+
+def test_template_has_pre_merge_checklist():
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert "Pre-merge checklist" in text
+
+
+def test_template_checklist_enforces_one_intent():
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert "One intent" in text
+
+
+def test_template_checklist_enforces_conventional_commit_title():
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert "Conventional-commit title" in text
+
+
+def test_template_checklist_enforces_changelog_update():
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert "CHANGELOG.md updated" in text
+
+
+def test_template_checklist_flags_breaking_changes():
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert "Breaking changes" in text
+
+
+def test_template_checklist_blocks_new_runtime_deps():
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert "No new runtime dependencies" in text
+
+
+def test_template_checklist_protects_privacy():
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert "No real session data" in text
+    assert "No machine-specific paths" in text
+
+
+def test_template_checklist_requires_ui_verification_light_and_dark():
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert "light AND dark" in text
+
+
+def test_template_checklist_requires_a11y():
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert "A11y verified" in text
+    assert "WCAG" in text
+
+
+def test_template_checklist_requires_gpg_signed():
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert "GPG-signed" in text
+    # Match exact template wording "no AI co-author trailers"
+    assert "no AI co-author trailers" in text
+
+
+def test_template_checklist_requires_reviewer_reads_lines():
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert "read every changed line" in text
+
+
+def test_template_has_screenshots_section():
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert "Screenshots / output" in text
+
+
+def test_template_has_out_of_scope_section():
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert "Out of scope" in text
+
+
+# ─── CONTRIBUTING.md matches template ────────────────────────────────
+
+
+def test_contributing_documents_15_box_checklist():
+    text = CONTRIBUTING.read_text(encoding="utf-8")
+    assert "15-box pre-merge checklist" in text
+
+
+def test_contributing_lists_all_conventional_commit_types():
+    text = CONTRIBUTING.read_text(encoding="utf-8")
+    for t in ["feat", "fix", "chore", "docs", "test", "refactor",
+              "perf", "security", "release"]:
+        assert f"`{t}`" in text, f"missing commit type: {t}"
+
+
+def test_contributing_enforces_500_line_limit():
+    text = CONTRIBUTING.read_text(encoding="utf-8")
+    assert "500 lines" in text
+
+
+def test_contributing_requires_signed_commits_branch_protection():
+    text = CONTRIBUTING.read_text(encoding="utf-8")
+    assert "Signed commits required" in text


### PR DESCRIPTION
## Summary
Inspired by Translately platform's contribution rules. Tightens the pre-merge bar.

## Checklist bump: 11 → 15 boxes
New boxes:
- One intent
- Breaking-change flagging
- UI verified in light AND dark mode (screenshots)
- A11y verified (WCAG 2.1 AA)
- GPG-signed, no AI co-author trailers
- Reviewer reads every changed line

## CONTRIBUTING.md
- 9 conventional-commit types (was 5): +refactor, perf, security, release
- PR size cap explicit: 500 lines
- Signed-commit branch protection documented

## PR Checklist
- [ ] 21 new template tests pass
- [ ] Full suite still 1257+ tests
- [ ] CHANGELOG updated
- [ ] GPG-signed, no AI co-author