### PR TITLE
chore: enrich ClaudeSonnet4 + GPT5 seed entities with v1.0 metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ### Changed
 
+- **Public seed entities enriched with v1.0 metadata** (#140) — `wiki/entities/ClaudeSonnet4.md` and `wiki/entities/GPT5.md` (the two public AI-model seed entities shipped with the repo) now carry `confidence`, `lifecycle`, `entity_type: tool` fields matching the v1.0 schema. Computed confidence: 0.56 for each (no source_count bump since they're structured schema entities with `sources: []`; quality gets "official" due to `entity_kind: ai-model`, recency is current, cross-refs are 0 since no other public wiki pages link to them).
+
 - **PR template upgraded to 15-box pre-merge checklist** — inspired by the Translately platform's contribution rules. New boxes: one intent, breaking-change flagging, UI verified in light AND dark mode (with screenshots), a11y verified (WCAG 2.1 AA minimum), commits GPG-signed with no AI co-author trailers, reviewer reads every changed line. `CONTRIBUTING.md` updated with matching conventional-commit type table (9 types now vs 5 before), 500-line PR size limit, signed-commit branch protection rule. 21 new tests lock the checklist shape.
 
 ### Added

--- a/wiki/entities/ClaudeSonnet4.md
+++ b/wiki/entities/ClaudeSonnet4.md
@@ -10,6 +10,9 @@ benchmarks: {"gpqa_diamond": 0.725, "swe_bench": 0.619, "mmlu": 0.887, "livecode
 changelog: [{"date": "2026-03-18", "event": "Launched — initial pricing", "field": "model.pricing.input_per_1m", "from": null, "to": 4.00}, {"date": "2026-04-02", "event": "Input pricing cut", "field": "model.pricing.input_per_1m", "from": 4.00, "to": 3.00}, {"date": "2026-04-05", "event": "Context window expanded", "field": "model.context_window", "from": 100000, "to": 200000}, {"date": "2026-04-08", "event": "SWE-bench score updated after v2 evaluation", "field": "benchmarks.swe_bench", "from": 0.582, "to": 0.619}]
 last_updated: 2026-04-09
 sources: []
+confidence: 0.56
+lifecycle: reviewed
+entity_type: tool
 ---
 
 # Claude Sonnet 4

--- a/wiki/entities/GPT5.md
+++ b/wiki/entities/GPT5.md
@@ -10,6 +10,9 @@ benchmarks: {"gpqa_diamond": 0.680, "swe_bench": 0.595, "mmlu": 0.875, "livecode
 changelog: [{"date": "2026-02-14", "event": "GA launch", "field": "model.released", "from": null, "to": "2026-02-14"}, {"date": "2026-03-01", "event": "Vision + audio modalities added", "field": "modalities", "from": "[text]", "to": "[text, vision, audio]"}]
 last_updated: 2026-04-09
 sources: []
+confidence: 0.56
+lifecycle: reviewed
+entity_type: tool
 ---
 
 # GPT-5


### PR DESCRIPTION
## Summary
Public portion of #140. Adds `confidence` / `lifecycle` / `entity_type` to the 2 seeded AI-model entities shipped with the repo. 11 personal entity/concept pages also enriched locally (gitignored, not in this PR).

## PR Checklist
- [ ] 1258 tests pass
- [ ] Only 3 new frontmatter fields per file (no content changes)
- [ ] Personal wiki pages NOT touched in this PR (gitignored, enriched locally)
- [ ] CHANGELOG updated
- [ ] GPG-signed

Ref #140