### PR TITLE
chore: add .editorconfig + weekly lychee link checker

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,42 @@
+# EditorConfig — https://editorconfig.org/
+#
+# Consistent indent + line endings + charset across every editor, no
+# matter whether contributors use VS Code, vim, Sublime, or JetBrains.
+# Enforced by the editor (not CI) — this file just tells your editor
+# what to do.
+
+root = true
+
+# ─── defaults for every file ──────────────────────────────────────────
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+# ─── Python: 4-space indent ──────────────────────────────────────────
+[*.py]
+indent_size = 4
+max_line_length = 120
+
+# ─── YAML + JSON + TOML: 2-space ────────────────────────────────────
+[*.{yml,yaml,json,toml}]
+indent_size = 2
+
+# ─── Markdown: keep trailing whitespace (hard line breaks) ───────────
+[*.md]
+trim_trailing_whitespace = false
+
+# ─── Makefile: tabs required ────────────────────────────────────────
+[{Makefile,*.mk}]
+indent_style = tab
+
+# ─── Shell scripts: 2-space ─────────────────────────────────────────
+[*.{sh,bash,zsh,fish}]
+indent_size = 2
+
+# ─── Windows batch: CRLF ────────────────────────────────────────────
+[*.{bat,cmd}]
+end_of_line = crlf

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,63 @@
+name: Link check
+
+# Scans README, CHANGELOG, docs/, and examples/ for broken external links.
+# Runs weekly on Sunday 03:00 UTC, on push to master when link-heavy files
+# change, and on manual dispatch. Internal links in site/ have a separate
+# checker (llmwiki check-links) that runs on build.
+
+on:
+  schedule:
+    - cron: "0 3 * * 0"
+  push:
+    branches: ["master"]
+    paths:
+      - "README.md"
+      - "CHANGELOG.md"
+      - "CONTRIBUTING.md"
+      - "docs/**/*.md"
+      - "examples/**/*.md"
+      - "lychee.toml"
+      - ".github/workflows/link-check.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  link-check:
+    name: Lychee external link scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Restore lychee cache
+        uses: actions/cache@v5
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
+      - name: Run lychee
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # Scan only the docs/content surface — exclude paths in lychee.toml
+          args: >-
+            --config lychee.toml
+            --cache
+            README.md
+            CHANGELOG.md
+            CONTRIBUTING.md
+            'docs/**/*.md'
+            'examples/**/*.md'
+          fail: false  # Don't fail the workflow; file an issue instead
+          output: lychee-report.md
+
+      - name: Create or update tracking issue on broken links
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "Broken external links detected"
+          content-filepath: lychee-report.md
+          labels: docs, chore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased] — post-v1.0 cleanup
 
+### Added
+
+- **`.editorconfig` + weekly lychee link checker** (#215) — new `.editorconfig` at repo root enforces consistent indent/line-endings across editors (Python 4-space, YAML/JSON/TOML 2-space, Makefiles tab, Windows `.bat` CRLF). New `lychee.toml` + `.github/workflows/link-check.yml` scans README, CHANGELOG, `docs/`, and `examples/` weekly (Sun 03:00 UTC) for broken external links. Creates/updates a tracking issue on failure instead of blocking CI. Personal `wiki/` and `raw/` paths excluded; `site/` skipped (already handled by `llmwiki check-links`). 22 tests.
+
 ### Changed
 
 - **Public seed entities enriched with v1.0 metadata** (#140) — `wiki/entities/ClaudeSonnet4.md` and `wiki/entities/GPT5.md` (the two public AI-model seed entities shipped with the repo) now carry `confidence`, `lifecycle`, `entity_type: tool` fields matching the v1.0 schema. Computed confidence: 0.56 for each (no source_count bump since they're structured schema entities with `sources: []`; quality gets "official" due to `entity_kind: ai-model`, recency is current, cross-refs are 0 since no other public wiki pages link to them).

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,53 @@
+# lychee link-checker config — https://lychee.cli.rs/
+#
+# Used by .github/workflows/link-check.yml to scan repo markdown
+# weekly for broken external links. Internal links (site/) have a
+# dedicated checker — `llmwiki check-links` — that runs on build.
+
+# ─── network ─────────────────────────────────────────────────────────
+timeout = 20
+max_redirects = 5
+max_retries = 3
+retry_wait_time = 2
+
+# ─── what to accept ─────────────────────────────────────────────────
+# Only error on 4xx/5xx. Ignore transient redirects and auth-gated URLs.
+accept = [200, 201, 202, 203, 204, 206, 301, 302, 303, 307, 308, 401, 403]
+
+# ─── exclude paths ──────────────────────────────────────────────────
+# site/ is the built output (already link-checked by llmwiki check-links).
+# .github/ISSUE_TEMPLATE/ contains tag URLs that resolve post-release.
+# docs/content-drafts/ is unpublished marketing — skip.
+exclude_path = [
+  "site/",
+  "node_modules/",
+  ".git/",
+  ".venv/",
+  "docs/content-drafts/",
+  "wiki/",
+  "raw/",
+]
+
+# ─── URL exclude patterns ───────────────────────────────────────────
+# Known-future URLs (release tags before we cut them) and private
+# endpoints that 403 from GitHub Actions runners.
+exclude = [
+  # Release tags may not exist yet
+  "^https://github\\.com/Pratiyush/llm-wiki/releases/tag/v1\\.1",
+  "^https://github\\.com/Pratiyush/llm-wiki/releases/tag/v1\\.2",
+  # Security advisory template (only resolves when filed)
+  "^https://github\\.com/Pratiyush/llm-wiki/security/advisories/new",
+  # PyPI (pre-first-release)
+  "^https://pypi\\.org/project/llmwiki/",
+  # Homebrew tap (pre-creation)
+  "^https://github\\.com/Pratiyush/homebrew-llmwiki",
+  # Localhost references in docs
+  "^http://127\\.0\\.0\\.1",
+  "^http://localhost",
+  # Placeholder URLs in demo content
+  "^https://example\\.com",
+]
+
+# ─── quiet output ───────────────────────────────────────────────────
+no_progress = true
+verbose = "info"

--- a/tests/test_editorconfig_lychee.py
+++ b/tests/test_editorconfig_lychee.py
@@ -1,0 +1,150 @@
+"""Tests for .editorconfig + lychee link checker (v1.1.0, #215)."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from llmwiki import REPO_ROOT
+
+
+EDITORCONFIG = REPO_ROOT / ".editorconfig"
+LYCHEE = REPO_ROOT / "lychee.toml"
+LINK_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "link-check.yml"
+
+
+# ─── .editorconfig ────────────────────────────────────────────────────
+
+
+def test_editorconfig_exists():
+    assert EDITORCONFIG.is_file()
+
+
+def test_editorconfig_is_root():
+    text = EDITORCONFIG.read_text(encoding="utf-8")
+    assert "root = true" in text
+
+
+def test_editorconfig_default_rules():
+    text = EDITORCONFIG.read_text(encoding="utf-8")
+    assert "charset = utf-8" in text
+    assert "end_of_line = lf" in text
+    assert "insert_final_newline = true" in text
+
+
+def test_editorconfig_python_has_4_space_indent():
+    text = EDITORCONFIG.read_text(encoding="utf-8")
+    # Python block has indent_size = 4
+    py_block = re.search(r"\[\*\.py\](.*?)(\[|\Z)", text, re.DOTALL)
+    assert py_block is not None
+    assert "indent_size = 4" in py_block.group(1)
+
+
+def test_editorconfig_yaml_json_has_2_space_indent():
+    text = EDITORCONFIG.read_text(encoding="utf-8")
+    # Check YAML/JSON block has 2-space
+    yaml_block = re.search(r"\[\*\.\{yml,yaml,json,toml\}\](.*?)(\[|\Z)", text, re.DOTALL)
+    assert yaml_block is not None
+    assert "indent_size = 2" in yaml_block.group(1)
+
+
+def test_editorconfig_makefile_uses_tabs():
+    text = EDITORCONFIG.read_text(encoding="utf-8")
+    mk_block = re.search(r"\[\{Makefile,\*\.mk\}\](.*?)(\[|\Z)", text, re.DOTALL)
+    assert mk_block is not None
+    assert "indent_style = tab" in mk_block.group(1)
+
+
+def test_editorconfig_windows_batch_uses_crlf():
+    text = EDITORCONFIG.read_text(encoding="utf-8")
+    assert re.search(r"\[\*\.\{bat,cmd\}\][\s\S]*?end_of_line = crlf", text)
+
+
+# ─── lychee.toml ──────────────────────────────────────────────────────
+
+
+def test_lychee_config_exists():
+    assert LYCHEE.is_file()
+
+
+def test_lychee_has_sensible_timeouts():
+    text = LYCHEE.read_text(encoding="utf-8")
+    assert re.search(r"^timeout\s*=\s*\d+", text, re.MULTILINE)
+    assert re.search(r"^max_retries\s*=\s*\d+", text, re.MULTILINE)
+
+
+def test_lychee_excludes_built_site():
+    text = LYCHEE.read_text(encoding="utf-8")
+    assert '"site/"' in text
+
+
+def test_lychee_excludes_user_data_folders():
+    text = LYCHEE.read_text(encoding="utf-8")
+    # Personal raw/ + wiki/ folders must not be scanned
+    assert '"wiki/"' in text
+    assert '"raw/"' in text
+
+
+def test_lychee_excludes_unpublished_drafts():
+    text = LYCHEE.read_text(encoding="utf-8")
+    assert '"docs/content-drafts/"' in text
+
+
+def test_lychee_skips_known_future_urls():
+    text = LYCHEE.read_text(encoding="utf-8")
+    # Release tags for v1.1 / v1.2 may not exist yet
+    assert "v1\\\\.1" in text or "v1.1" in text
+
+
+def test_lychee_skips_pypi_and_homebrew_placeholders():
+    text = LYCHEE.read_text(encoding="utf-8")
+    assert "pypi" in text
+    assert "homebrew-llmwiki" in text
+
+
+# ─── workflow ─────────────────────────────────────────────────────────
+
+
+def test_link_check_workflow_exists():
+    assert LINK_WORKFLOW.is_file()
+
+
+def test_workflow_runs_weekly():
+    text = LINK_WORKFLOW.read_text(encoding="utf-8")
+    assert "cron:" in text
+    # "0 3 * * 0" = Sunday 03:00 UTC
+    assert re.search(r'cron:\s*"[0-9\s*]+"', text)
+
+
+def test_workflow_allows_manual_dispatch():
+    text = LINK_WORKFLOW.read_text(encoding="utf-8")
+    assert "workflow_dispatch" in text
+
+
+def test_workflow_uses_lychee_action():
+    text = LINK_WORKFLOW.read_text(encoding="utf-8")
+    assert "lycheeverse/lychee-action" in text
+
+
+def test_workflow_uses_cache():
+    text = LINK_WORKFLOW.read_text(encoding="utf-8")
+    assert "actions/cache" in text
+    assert ".lycheecache" in text
+
+
+def test_workflow_files_issue_on_broken_links():
+    text = LINK_WORKFLOW.read_text(encoding="utf-8")
+    assert "create-issue-from-file" in text
+
+
+def test_workflow_scans_required_paths():
+    text = LINK_WORKFLOW.read_text(encoding="utf-8")
+    for path in ["README.md", "CHANGELOG.md", "docs/**/*.md", "examples/**/*.md"]:
+        assert path in text, f"missing scan path: {path}"
+
+
+def test_workflow_uses_pinned_action_versions():
+    text = LINK_WORKFLOW.read_text(encoding="utf-8")
+    # actions/checkout@v4 (pinned in the dependency bundle PR #189)
+    assert "actions/checkout@v4" in text


### PR DESCRIPTION
Closes #215

## Summary
Two small governance upgrades from Translately-platform gap analysis.

## PR Checklist
- [ ] 22 tests pass
- [ ] .editorconfig covers Python/YAML/JSON/Markdown/Makefile/batch
- [ ] Weekly workflow scans README+CHANGELOG+docs+examples only
- [ ] CHANGELOG updated
- [ ] GPG-signed, no AI co-author