### PR TITLE
feat: shell completion for bash / zsh / fish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ### Added
 
+- **Shell completion for bash / zsh / fish** (#216) — new `llmwiki/completion.py` + `llmwiki completion <shell>` CLI command. Walks the argparse tree at runtime to enumerate every subcommand + its top-level flags, emits a working completion script. Stdlib-only (no argcomplete dep). Install: `llmwiki completion bash > ~/.bash_completion.d/llmwiki` (or equivalent for zsh / fish). 17 tests.
+
 - **`.editorconfig` + weekly lychee link checker** (#215) — new `.editorconfig` at repo root enforces consistent indent/line-endings across editors (Python 4-space, YAML/JSON/TOML 2-space, Makefiles tab, Windows `.bat` CRLF). New `lychee.toml` + `.github/workflows/link-check.yml` scans README, CHANGELOG, `docs/`, and `examples/` weekly (Sun 03:00 UTC) for broken external links. Creates/updates a tracking issue on failure instead of blocking CI. Personal `wiki/` and `raw/` paths excluded; `site/` skipped (already handled by `llmwiki check-links`). 22 tests.
 
 ### Changed

--- a/llmwiki/cli.py
+++ b/llmwiki/cli.py
@@ -438,6 +438,18 @@ def cmd_lint(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_completion(args: argparse.Namespace) -> int:
+    """Emit shell completion script for the requested shell (v1.1.0 · #216)."""
+    from llmwiki.completion import generate
+    try:
+        script = generate(args.shell)
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+    print(script)
+    return 0
+
+
 def cmd_schedule(args: argparse.Namespace) -> int:
     """Generate scheduled sync task files for the current platform (v1.0 · #162)."""
     import json as _json
@@ -702,6 +714,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="Install llmwiki skills into .codex/skills/ and .agents/skills/ (multi-agent support)",
     )
     isk.set_defaults(func=cmd_install_skills)
+
+    # completion (v1.1, #216) — emit shell completion script
+    comp = sub.add_parser(
+        "completion",
+        help="Emit shell completion script (bash/zsh/fish) — pipe to the shell's completion directory",
+    )
+    comp.add_argument(
+        "shell", choices=["bash", "zsh", "fish"],
+        help="Which shell to generate completion for",
+    )
+    comp.set_defaults(func=cmd_completion)
 
     # schedule (v1.0, #162) — generate scheduled sync task for the current OS
     sched = sub.add_parser(

--- a/llmwiki/completion.py
+++ b/llmwiki/completion.py
@@ -1,0 +1,191 @@
+"""Shell completion generators (v1.1.0 · #216).
+
+Emit hand-rolled completion scripts for bash, zsh, and fish. Stdlib
+only — no argcomplete dep. Each generator enumerates the argparse
+subparsers at runtime and builds a shell function that completes
+subcommand names + their top-level flags.
+
+Not perfect (doesn't complete values for --out paths, etc.) but
+covers the 80% case of "which subcommand?" and "what flags?".
+
+Usage::
+
+    llmwiki completion bash  > ~/.bash_completion.d/llmwiki
+    llmwiki completion zsh   > ~/.zsh/completions/_llmwiki
+    llmwiki completion fish  > ~/.config/fish/completions/llmwiki.fish
+"""
+
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from typing import Any
+
+
+def _collect(parser: ArgumentParser) -> tuple[list[str], dict[str, list[str]]]:
+    """Walk the argparse tree → (subcommand_list, {sub: [flags]})."""
+    subcommands: list[str] = []
+    flags_by_sub: dict[str, list[str]] = {}
+    top_flags: list[str] = []
+
+    # Top-level flags (like --version, --help)
+    for action in parser._actions:
+        for opt in action.option_strings:
+            if opt.startswith("--"):
+                top_flags.append(opt)
+    flags_by_sub[""] = sorted(set(top_flags))
+
+    # Subparsers
+    for action in parser._actions:
+        if hasattr(action, "choices") and action.choices:
+            for name, sub_parser in action.choices.items():
+                subcommands.append(name)
+                sub_flags: list[str] = []
+                for a in sub_parser._actions:
+                    for opt in a.option_strings:
+                        if opt.startswith("--"):
+                            sub_flags.append(opt)
+                flags_by_sub[name] = sorted(set(sub_flags))
+
+    return sorted(subcommands), flags_by_sub
+
+
+def _get_parser() -> ArgumentParser:
+    """Lazy import to avoid circular deps during completion generation."""
+    from llmwiki.cli import build_parser
+    return build_parser()
+
+
+# ─── bash ─────────────────────────────────────────────────────────────
+
+def bash_script() -> str:
+    """Generate a bash completion script."""
+    subs, flags = _collect(_get_parser())
+    subs_str = " ".join(subs)
+
+    # Per-subcommand flag cases
+    case_lines = []
+    for sub in subs:
+        sub_flags = " ".join(flags.get(sub, []))
+        if sub_flags:
+            case_lines.append(f"    {sub}) COMPREPLY=($(compgen -W \"{sub_flags}\" -- \"$cur\")) ;;")
+
+    case_block = "\n".join(case_lines) if case_lines else "    *) ;;"
+
+    return f"""# bash completion for llmwiki — source this file or drop it into
+# /usr/local/etc/bash_completion.d/llmwiki (Homebrew) or
+# /etc/bash_completion.d/llmwiki (Linux).
+
+_llmwiki() {{
+  local cur prev cword
+  _init_completion -s || return
+
+  if [ "$cword" -eq 1 ]; then
+    COMPREPLY=($(compgen -W "{subs_str}" -- "$cur"))
+    return 0
+  fi
+
+  case "${{COMP_WORDS[1]}}" in
+{case_block}
+  esac
+  return 0
+}}
+
+complete -F _llmwiki llmwiki
+"""
+
+
+# ─── zsh ─────────────────────────────────────────────────────────────
+
+def zsh_script() -> str:
+    """Generate a zsh completion function. File should be named _llmwiki."""
+    subs, flags = _collect(_get_parser())
+
+    # Per-sub case for flag completion
+    case_lines = []
+    for sub in subs:
+        sub_flags = flags.get(sub, [])
+        flag_list = " ".join(f"'{f}[--{f.lstrip('-')}]'" for f in sub_flags)
+        if flag_list:
+            case_lines.append(f"    {sub}) _arguments {flag_list} ;;")
+
+    case_block = "\n".join(case_lines) if case_lines else "    *) ;;"
+
+    sub_descriptions = "\n".join(f"    '{s}:{s}'" for s in subs)
+
+    return f"""#compdef llmwiki
+# zsh completion for llmwiki — drop into ~/.zsh/completions/_llmwiki
+# and ensure fpath contains ~/.zsh/completions.
+
+_llmwiki() {{
+  local state
+  local -a subcommands
+
+  _arguments -C \\
+    '1: :->subcmd' \\
+    '*::arg:->args'
+
+  case "$state" in
+    subcmd)
+      subcommands=(
+{sub_descriptions}
+      )
+      _describe 'subcommand' subcommands
+      ;;
+    args)
+      case "$words[1]" in
+{case_block}
+      esac
+      ;;
+  esac
+}}
+
+_llmwiki "$@"
+"""
+
+
+# ─── fish ────────────────────────────────────────────────────────────
+
+def fish_script() -> str:
+    """Generate a fish completion script."""
+    subs, flags = _collect(_get_parser())
+
+    lines = [
+        "# fish completion for llmwiki — drop into ~/.config/fish/completions/llmwiki.fish",
+        "",
+        "# subcommands",
+    ]
+    for sub in subs:
+        lines.append(
+            f"complete -c llmwiki -n '__fish_use_subcommand' "
+            f"-a '{sub}' -d '{sub}'"
+        )
+    lines.append("")
+    lines.append("# per-subcommand flags")
+    for sub in subs:
+        for flag in flags.get(sub, []):
+            # fish wants long-option without leading --
+            opt = flag.lstrip("-")
+            lines.append(
+                f"complete -c llmwiki -n '__fish_seen_subcommand_from {sub}' "
+                f"-l {opt} -d '{flag} option'"
+            )
+
+    return "\n".join(lines) + "\n"
+
+
+# ─── dispatch ────────────────────────────────────────────────────────
+
+GENERATORS = {
+    "bash": bash_script,
+    "zsh": zsh_script,
+    "fish": fish_script,
+}
+
+
+def generate(shell: str) -> str:
+    """Dispatch by shell name. Raises ValueError for unknown shells."""
+    if shell not in GENERATORS:
+        raise ValueError(
+            f"unknown shell {shell!r}; supported: {sorted(GENERATORS)}"
+        )
+    return GENERATORS[shell]()

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,0 +1,134 @@
+"""Tests for shell completion (v1.1.0, #216)."""
+
+from __future__ import annotations
+
+import pytest
+
+from llmwiki.completion import (
+    bash_script,
+    zsh_script,
+    fish_script,
+    generate,
+    GENERATORS,
+)
+
+
+# ─── registry ─────────────────────────────────────────────────────────
+
+
+def test_three_shells_supported():
+    assert set(GENERATORS.keys()) == {"bash", "zsh", "fish"}
+
+
+# ─── dispatcher ──────────────────────────────────────────────────────
+
+
+def test_generate_bash():
+    script = generate("bash")
+    assert isinstance(script, str)
+    assert "bash completion for llmwiki" in script
+
+
+def test_generate_zsh():
+    script = generate("zsh")
+    assert script.startswith("#compdef llmwiki")
+
+
+def test_generate_fish():
+    script = generate("fish")
+    assert "fish completion for llmwiki" in script
+
+
+def test_generate_invalid_shell():
+    with pytest.raises(ValueError, match="unknown shell"):
+        generate("powershell")
+
+
+# ─── bash ────────────────────────────────────────────────────────────
+
+
+def test_bash_registers_completion():
+    script = bash_script()
+    assert "complete -F _llmwiki llmwiki" in script
+
+
+def test_bash_defines_function():
+    script = bash_script()
+    assert "_llmwiki()" in script
+
+
+def test_bash_includes_every_subcommand():
+    script = bash_script()
+    # All key subcommands must appear in the WORD list
+    for sub in ["sync", "build", "serve", "init", "version",
+                "adapters", "graph", "watch", "link-obsidian",
+                "install-skills", "schedule", "lint", "check-links"]:
+        assert sub in script, f"missing subcommand: {sub}"
+
+
+def test_bash_handles_cword_1():
+    """cword == 1 means "which subcommand?" — complete against the sub list."""
+    script = bash_script()
+    assert 'cword" -eq 1' in script
+
+
+# ─── zsh ─────────────────────────────────────────────────────────────
+
+
+def test_zsh_compdef_directive():
+    script = zsh_script()
+    assert script.startswith("#compdef llmwiki")
+
+
+def test_zsh_describes_subcommands():
+    script = zsh_script()
+    assert "_describe 'subcommand'" in script
+
+
+def test_zsh_includes_subcommands():
+    script = zsh_script()
+    for sub in ["sync", "build", "serve", "lint"]:
+        assert sub in script
+
+
+# ─── fish ────────────────────────────────────────────────────────────
+
+
+def test_fish_has_subcommand_completions():
+    script = fish_script()
+    assert "__fish_use_subcommand" in script
+
+
+def test_fish_has_flag_completions():
+    script = fish_script()
+    assert "__fish_seen_subcommand_from" in script
+
+
+def test_fish_includes_every_subcommand():
+    script = fish_script()
+    for sub in ["sync", "build", "serve", "init", "lint",
+                "link-obsidian", "install-skills", "completion"]:
+        assert f"-a '{sub}'" in script
+
+
+def test_fish_completes_flags_for_sync():
+    script = fish_script()
+    # sync has --auto-build, --auto-lint, --dry-run, --force, --download-images, etc.
+    assert "-n '__fish_seen_subcommand_from sync'" in script
+
+
+# ─── CLI integration ────────────────────────────────────────────────
+
+
+def test_cli_completion_subcommand_exists():
+    """`llmwiki completion` subcommand is registered."""
+    from llmwiki.cli import build_parser
+    parser = build_parser()
+    # Walk subparsers to confirm "completion" exists
+    sub_action = None
+    for a in parser._actions:
+        if hasattr(a, "choices") and a.choices:
+            sub_action = a
+            break
+    assert sub_action is not None
+    assert "completion" in sub_action.choices


### PR DESCRIPTION
Closes #216

## Summary
`llmwiki completion <shell>` emits working completion scripts for bash / zsh / fish.

## PR Checklist
- [ ] 17 tests pass
- [ ] Stdlib-only (no argcomplete)
- [ ] All 3 shells verified with head output
- [ ] CHANGELOG updated
- [ ] GPG-signed, no AI co-author