### PR TITLE
feat: OpenCode / OpenClaw adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ### Added
 
+- **OpenCode / OpenClaw adapter** (#43) — new `llmwiki/adapters/opencode.py`. Discovers `.jsonl` sessions under `~/.config/opencode/sessions/` (Linux), `~/Library/Application Support/opencode/sessions/` (macOS), and `%APPDATA%/opencode/sessions/` (Windows), plus the equivalent `openclaw/` paths. `normalize_records()` translates OpenCode's `{role, content}` records into the Claude-style `{type, message: {role, content}}` that the shared renderer expects; `tool` role maps to `user` type while preserving the original role. Project slug derivation handles both nested (`<project>/<session>.jsonl`) and flat (`<project>-<session>.jsonl`) layouts. 23 tests.
+
 - **ChatGPT conversation-export adapter** (#44) — new `llmwiki/adapters/chatgpt.py`. Reads `conversations.json` from a user's ChatGPT export (Settings → Data Controls → Export), linearizes the parent→children mapping to recover the active conversation chain, extracts messages with roles + text, renders as frontmatter-tagged markdown. Disabled by default (opt-in via `chatgpt.enabled: true` in config). 28 tests.
 
 - **Shell completion for bash / zsh / fish** (#216) — new `llmwiki/completion.py` + `llmwiki completion <shell>` CLI command. Walks the argparse tree at runtime to enumerate every subcommand + its top-level flags, emits a working completion script. Stdlib-only (no argcomplete dep). Install: `llmwiki completion bash > ~/.bash_completion.d/llmwiki` (or equivalent for zsh / fish). 17 tests.

--- a/llmwiki/adapters/__init__.py
+++ b/llmwiki/adapters/__init__.py
@@ -43,6 +43,7 @@ def discover_adapters() -> None:
     from llmwiki.adapters import meeting  # noqa: F401
     from llmwiki.adapters import jira_adapter  # noqa: F401
     from llmwiki.adapters import chatgpt  # noqa: F401
+    from llmwiki.adapters import opencode  # noqa: F401
 
 
 def get_available() -> dict[str, type[BaseAdapter]]:

--- a/llmwiki/adapters/opencode.py
+++ b/llmwiki/adapters/opencode.py
@@ -1,0 +1,154 @@
+"""OpenCode / OpenClaw adapter (v1.1 · #43).
+
+OpenCode (sst/opencode) and OpenClaw (the community fork) are open-source
+terminal AI coding agents. They write session transcripts to the
+platform-specific app config directory:
+
+- macOS:   ~/Library/Application Support/opencode/sessions/
+           ~/Library/Application Support/openclaw/sessions/
+- Linux:   ~/.config/opencode/sessions/
+           ~/.config/openclaw/sessions/
+- Windows: %APPDATA%/opencode/sessions/
+           %APPDATA%/openclaw/sessions/
+
+Session files are `*.jsonl` (one JSON object per line) with a schema
+similar enough to Claude Code that the shared renderer in
+``llmwiki.convert`` works after a light normalization pass.
+
+The adapter registers as available when either `opencode/` or
+`openclaw/` session-store directory exists. Per-record normalization
+happens in ``normalize_records()`` which maps OpenCode's top-level
+``role`` / ``content`` fields onto the Claude-style
+``{type: user|assistant, message: {role: ..., content: ...}}`` shape
+that the renderer expects.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from llmwiki.adapters import register
+from llmwiki.adapters.base import BaseAdapter
+
+
+@register("opencode")
+class OpenCodeAdapter(BaseAdapter):
+    """OpenCode / OpenClaw — shared adapter (both use identical schema)."""
+
+    SUPPORTED_SCHEMA_VERSIONS = ["v1"]
+
+    DEFAULT_ROOTS = [
+        # macOS
+        Path.home() / "Library" / "Application Support" / "opencode" / "sessions",
+        Path.home() / "Library" / "Application Support" / "openclaw" / "sessions",
+        # Linux (XDG default)
+        Path.home() / ".config" / "opencode" / "sessions",
+        Path.home() / ".config" / "openclaw" / "sessions",
+        # Windows
+        Path.home() / "AppData" / "Roaming" / "opencode" / "sessions",
+        Path.home() / "AppData" / "Roaming" / "openclaw" / "sessions",
+    ]
+
+    def __init__(self, config: dict[str, Any] | None = None):
+        super().__init__(config)
+        ad_cfg = (config or {}).get("adapters", {}).get("opencode", {})
+        paths = ad_cfg.get("roots") or []
+        self.roots: list[Path] = (
+            [Path(p).expanduser() for p in paths] if paths else self.DEFAULT_ROOTS
+        )
+
+    @property
+    def session_store_path(self):  # type: ignore[override]
+        return self.roots
+
+    @classmethod
+    def is_available(cls) -> bool:
+        return any(Path(p).expanduser().exists() for p in cls.DEFAULT_ROOTS)
+
+    def discover_sessions(self) -> list[Path]:
+        """Return every .jsonl session file under every configured root."""
+        out: list[Path] = []
+        for root in self.roots:
+            root = Path(root).expanduser()
+            if not root.exists():
+                continue
+            out.extend(sorted(root.rglob("*.jsonl")))
+        return out
+
+    def derive_project_slug(self, jsonl_path: Path) -> str:
+        """OpenCode files are typically ``<project>-<session-id>.jsonl`` or
+        nested under ``<project>/<session-id>.jsonl``. Use parent dir if
+        nested, else split on first dash of filename."""
+        for root in self.roots:
+            root = Path(root).expanduser()
+            try:
+                rel = jsonl_path.relative_to(root)
+                # If nested: <project>/<session>.jsonl → project
+                if len(rel.parts) > 1:
+                    return rel.parts[0]
+                # Flat: <project>-<session>.jsonl → left-of-first-dash
+                stem = rel.stem
+                if "-" in stem:
+                    return stem.split("-", 1)[0]
+                return stem[:16]
+            except ValueError:
+                continue
+        return jsonl_path.parent.name
+
+    def is_subagent(self, jsonl_path: Path) -> bool:
+        """OpenCode marks subagent sessions with 'subagent' in the filename."""
+        return "subagent" in jsonl_path.name
+
+    def normalize_records(
+        self, records: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Translate OpenCode/OpenClaw records into the shared Claude-style
+        shape that ``llmwiki.convert.render_session_markdown`` expects.
+
+        OpenCode shape (approximate, based on public docs)::
+
+            {"role": "user",      "content": "string", "timestamp": "..."}
+            {"role": "assistant", "content": "string or [{type, text|tool_use}]"}
+            {"role": "tool",      "content": "tool result", "tool_call_id": "..."}
+
+        Claude Code shape::
+
+            {"type": "user",      "message": {"role": "user",      "content": "..."}}
+            {"type": "assistant", "message": {"role": "assistant", "content": [...]}}
+
+        Records already in Claude shape (have top-level ``type``) are
+        passed through unchanged.
+        """
+        out: list[dict[str, Any]] = []
+        for rec in records:
+            if not isinstance(rec, dict):
+                continue
+
+            # Pass-through if already Claude-shaped
+            if "type" in rec and "message" in rec:
+                out.append(rec)
+                continue
+
+            role = rec.get("role")
+            content = rec.get("content")
+            if role is None or content is None:
+                # Skip non-message records (metadata, session-init, etc.)
+                out.append(rec)
+                continue
+
+            # Map tool role → user (tool results are user-side in Claude shape)
+            claude_type = "user" if role in ("user", "tool", "system") else "assistant"
+
+            normalized = {
+                "type": claude_type,
+                "message": {"role": role, "content": content},
+            }
+            # Preserve timestamp if present — converter uses it for sorting
+            if "timestamp" in rec:
+                normalized["timestamp"] = rec["timestamp"]
+            if "sessionId" in rec:
+                normalized["sessionId"] = rec["sessionId"]
+
+            out.append(normalized)
+        return out

--- a/tests/test_opencode_adapter.py
+++ b/tests/test_opencode_adapter.py
@@ -1,0 +1,232 @@
+"""Tests for the OpenCode / OpenClaw adapter (v1.1, #43)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from llmwiki.adapters.opencode import OpenCodeAdapter
+
+
+# ─── Adapter registration ─────────────────────────────────────────────
+
+
+def test_adapter_registered():
+    from llmwiki.adapters import REGISTRY, discover_adapters
+    discover_adapters()
+    assert "opencode" in REGISTRY
+
+
+def test_adapter_has_schema_versions():
+    assert "v1" in OpenCodeAdapter.SUPPORTED_SCHEMA_VERSIONS
+
+
+def test_adapter_has_default_roots_for_all_platforms():
+    roots = OpenCodeAdapter.DEFAULT_ROOTS
+    root_strs = [str(r) for r in roots]
+    # macOS
+    assert any("Library/Application Support/opencode" in r for r in root_strs)
+    # Linux XDG
+    assert any(".config/opencode" in r for r in root_strs)
+    # Windows
+    assert any("AppData/Roaming/opencode" in r for r in root_strs)
+
+
+def test_adapter_includes_openclaw_variant():
+    root_strs = [str(r) for r in OpenCodeAdapter.DEFAULT_ROOTS]
+    # OpenClaw community fork uses its own dir
+    assert any("openclaw" in r for r in root_strs)
+
+
+# ─── Config-driven roots ─────────────────────────────────────────────
+
+
+def test_adapter_uses_config_roots(tmp_path: Path):
+    custom = tmp_path / "my-opencode"
+    custom.mkdir()
+    a = OpenCodeAdapter(config={
+        "adapters": {"opencode": {"roots": [str(custom)]}}
+    })
+    assert a.roots == [custom]
+
+
+def test_adapter_falls_back_to_defaults_when_no_config():
+    a = OpenCodeAdapter()
+    assert a.roots == OpenCodeAdapter.DEFAULT_ROOTS
+
+
+# ─── Discovery ───────────────────────────────────────────────────────
+
+
+def test_discover_empty_when_no_roots_exist(tmp_path: Path):
+    a = OpenCodeAdapter(config={
+        "adapters": {"opencode": {"roots": [str(tmp_path / "nonexistent")]}}
+    })
+    assert a.discover_sessions() == []
+
+
+def test_discover_finds_jsonl_files(tmp_path: Path):
+    # Create a fake opencode session store
+    store = tmp_path / "opencode" / "sessions"
+    store.mkdir(parents=True)
+    (store / "my-project-01.jsonl").write_text(
+        '{"role": "user", "content": "hi"}\n', encoding="utf-8"
+    )
+    (store / "my-project-02.jsonl").write_text(
+        '{"role": "assistant", "content": "hello"}\n', encoding="utf-8"
+    )
+    # Non-jsonl file should NOT be discovered
+    (store / "readme.txt").write_text("ignore me", encoding="utf-8")
+
+    a = OpenCodeAdapter(config={
+        "adapters": {"opencode": {"roots": [str(store)]}}
+    })
+    sessions = a.discover_sessions()
+    assert len(sessions) == 2
+    names = [s.name for s in sessions]
+    assert all(n.endswith(".jsonl") for n in names)
+
+
+def test_discover_nested_subdirs(tmp_path: Path):
+    store = tmp_path / "opencode" / "sessions"
+    store.mkdir(parents=True)
+    nested = store / "project-a"
+    nested.mkdir()
+    (nested / "session1.jsonl").write_text('{}\n', encoding="utf-8")
+
+    a = OpenCodeAdapter(config={
+        "adapters": {"opencode": {"roots": [str(store)]}}
+    })
+    sessions = a.discover_sessions()
+    assert len(sessions) == 1
+
+
+# ─── Project slug derivation ─────────────────────────────────────────
+
+
+def test_project_slug_from_flat_filename(tmp_path: Path):
+    store = tmp_path / "opencode" / "sessions"
+    store.mkdir(parents=True)
+    path = store / "my-project-abc123.jsonl"
+    path.touch()
+    a = OpenCodeAdapter(config={
+        "adapters": {"opencode": {"roots": [str(store)]}}
+    })
+    assert a.derive_project_slug(path) == "my"  # split on first dash
+
+
+def test_project_slug_from_nested_subdir(tmp_path: Path):
+    store = tmp_path / "opencode" / "sessions"
+    proj = store / "fancy-project"
+    proj.mkdir(parents=True)
+    path = proj / "session-1.jsonl"
+    path.touch()
+    a = OpenCodeAdapter(config={
+        "adapters": {"opencode": {"roots": [str(store)]}}
+    })
+    assert a.derive_project_slug(path) == "fancy-project"
+
+
+def test_project_slug_without_dashes(tmp_path: Path):
+    store = tmp_path / "opencode" / "sessions"
+    store.mkdir(parents=True)
+    path = store / "noslugs.jsonl"
+    path.touch()
+    a = OpenCodeAdapter(config={
+        "adapters": {"opencode": {"roots": [str(store)]}}
+    })
+    # Short enough to stay whole
+    assert a.derive_project_slug(path) == "noslugs"
+
+
+# ─── Subagent detection ──────────────────────────────────────────────
+
+
+def test_is_subagent_true():
+    a = OpenCodeAdapter()
+    assert a.is_subagent(Path("session-subagent-abc.jsonl")) is True
+
+
+def test_is_subagent_false():
+    a = OpenCodeAdapter()
+    assert a.is_subagent(Path("session-main.jsonl")) is False
+
+
+# ─── Record normalization ────────────────────────────────────────────
+
+
+def test_normalize_user_record():
+    a = OpenCodeAdapter()
+    records = [{"role": "user", "content": "hi"}]
+    out = a.normalize_records(records)
+    assert len(out) == 1
+    assert out[0]["type"] == "user"
+    assert out[0]["message"]["role"] == "user"
+    assert out[0]["message"]["content"] == "hi"
+
+
+def test_normalize_assistant_record():
+    a = OpenCodeAdapter()
+    records = [{"role": "assistant", "content": "response"}]
+    out = a.normalize_records(records)
+    assert out[0]["type"] == "assistant"
+
+
+def test_normalize_tool_role_maps_to_user_type():
+    """Tool results are user-side messages in Claude Code shape."""
+    a = OpenCodeAdapter()
+    records = [{"role": "tool", "content": "tool result"}]
+    out = a.normalize_records(records)
+    assert out[0]["type"] == "user"
+    # Preserve the original role for accurate rendering
+    assert out[0]["message"]["role"] == "tool"
+
+
+def test_normalize_preserves_timestamp():
+    a = OpenCodeAdapter()
+    records = [{"role": "user", "content": "hi", "timestamp": "2026-04-16T10:00:00Z"}]
+    out = a.normalize_records(records)
+    assert out[0]["timestamp"] == "2026-04-16T10:00:00Z"
+
+
+def test_normalize_passes_through_claude_shape():
+    """Records already in Claude format must not be rewrapped."""
+    a = OpenCodeAdapter()
+    records = [{
+        "type": "user",
+        "message": {"role": "user", "content": "already normalized"},
+    }]
+    out = a.normalize_records(records)
+    assert out == records
+
+
+def test_normalize_skips_non_dict_records():
+    a = OpenCodeAdapter()
+    records = ["not a dict", 42, {"role": "user", "content": "ok"}]
+    out = a.normalize_records(records)
+    # Only the dict is kept
+    assert len(out) == 1
+
+
+def test_normalize_passes_through_metadata_records():
+    """Records without role/content (e.g. session-init metadata) pass through."""
+    a = OpenCodeAdapter()
+    records = [{"sessionId": "abc", "type": "session-init"}]
+    out = a.normalize_records(records)
+    assert out == records
+
+
+def test_normalize_empty_list():
+    a = OpenCodeAdapter()
+    assert a.normalize_records([]) == []
+
+
+# ─── Availability ────────────────────────────────────────────────────
+
+
+def test_is_available_false_when_no_paths():
+    """is_available checks DEFAULT_ROOTS — on a fresh test runner it's typically False."""
+    # We can't guarantee this without a user install; just assert the call succeeds
+    result = OpenCodeAdapter.is_available()
+    assert isinstance(result, bool)


### PR DESCRIPTION
Closes #43

## PR Checklist
- [ ] 23 tests pass
- [ ] Registered in adapter __init__.py
- [ ] Covers opencode + openclaw variant
- [ ] macOS + Linux + Windows paths
- [ ] normalize_records() maps OpenCode shape → Claude shape
- [ ] CHANGELOG updated
- [ ] GPG-signed