### PR TITLE
feat: wiki/candidates/ approval workflow

### DIFF
--- a/.claude/commands/wiki-review.md
+++ b/.claude/commands/wiki-review.md
@@ -1,0 +1,56 @@
+Review and triage candidate wiki pages — promote, merge, or discard.
+
+Candidate pages live under `wiki/candidates/<kind>/<slug>.md` and were
+created by `/wiki-ingest` for new entities/concepts the LLM detected. They
+are **not** part of the trusted wiki layer until a human approves them.
+
+Usage: `/wiki-review`
+
+## Workflow
+
+1. List all pending candidates:
+   ```
+   python3 -m llmwiki candidates list
+   ```
+   Or filter to stale (age > 30 days):
+   ```
+   python3 -m llmwiki candidates list --stale
+   ```
+
+2. For each candidate, decide:
+
+   - **promote** — candidate is legitimate and not a duplicate.
+     Moves it into the trusted tree (`wiki/entities/` or `wiki/concepts/`)
+     and rewrites `status: candidate` → `status: reviewed`.
+     ```
+     python3 -m llmwiki candidates promote --slug MyEntity
+     ```
+
+   - **merge** — candidate is essentially a duplicate of an existing page.
+     Appends the candidate's body under a `## Candidate merge — <date>`
+     heading in the target page, then archives the candidate.
+     ```
+     python3 -m llmwiki candidates merge --slug DuplicateFoo --into Foo
+     ```
+
+   - **discard** — candidate is a hallucination or noise.
+     Moves it to `wiki/archive/candidates/<timestamp>/` with a
+     `.reason.txt` audit-trail file.
+     ```
+     python3 -m llmwiki candidates discard --slug BogusEntity \
+       --reason "not a real company; LLM hallucinated"
+     ```
+
+3. After any promote/merge, run `/wiki-lint` to catch broken wikilinks
+   from pages that used to point at the candidate location.
+
+4. Append to `wiki/log.md`:
+   ```
+   ## [YYYY-MM-DD] review | <N> promoted, <M> merged, <K> discarded
+   ```
+
+## Related
+
+- #51 — the issue that added this workflow
+- `/wiki-lint` — finds stale candidates (age > 30 days) automatically
+- `/wiki-ingest` — routes new pages to `candidates/` instead of direct

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased] — post-v1.0 cleanup
 
+### Added
+
+- **`wiki/candidates/` approval workflow** (#51) — new `llmwiki/candidates.py` module with `list`, `promote`, `merge`, `discard`, and `stale_candidates` primitives. New pages from `/wiki-ingest` that represent brand-new entities/concepts can now land in `wiki/candidates/<kind>/<slug>.md` with `status: candidate` instead of going straight into the trusted wiki. `/wiki-review` slash command (`.claude/commands/wiki-review.md`) + `llmwiki candidates <action>` CLI walk through the queue. Merge folds the candidate's body under a `## Candidate merge — <date>` heading in the target and archives the source. Discard moves to `wiki/archive/candidates/<timestamp>/` with a timestamped `.reason.txt` audit file. New `stale_candidates` lint rule (12th overall) flags candidates sitting idle > 30 days. 34 tests cover: all 4 action paths, frontmatter status rewrite, staleness computation, kind inference, error handling.
+
 ### Refactored
 
 - **Split `llmwiki/build.py` (3,378 → 1,799 lines)** (#217) — new `llmwiki/render/` package with `css.py` (682 lines) and `js.py` (937 lines) housing the previously-inline CSS and JS constants. `build.py` re-exports both for backwards compatibility, so external imports `from llmwiki.build import CSS` still work. Build output verified byte-identical to pre-refactor (same HTML hash). 18 new tests verify byte equivalence, re-export, and content integrity (theme vars, dark mode, command palette, search-index loading). Zero behavior change.

--- a/llmwiki/candidates.py
+++ b/llmwiki/candidates.py
@@ -1,0 +1,309 @@
+"""Candidate approval workflow (v1.1.0 · #51).
+
+New entity/concept pages created by `/wiki-ingest` land in
+``wiki/candidates/`` first with ``status: candidate`` frontmatter.
+A human then runs `/wiki-review` to promote, merge, or discard each
+one. Promoted pages move into ``wiki/entities/`` or ``wiki/concepts/``.
+Discarded candidates are archived under ``wiki/archive/candidates/``
+for audit.
+
+Rationale: hallucinated entities ("CompanyX" that doesn't exist) should
+not land in the trusted wiki layer without human review.
+
+Public API:
+  - ``list_candidates(wiki_dir)`` → list of Candidate dicts
+  - ``promote(slug, wiki_dir, dest)`` → move candidate into trusted area
+  - ``merge(slug, wiki_dir, into_slug)`` → fold candidate into an existing page
+  - ``discard(slug, wiki_dir, reason)`` → move to archive/
+  - ``stale_candidates(wiki_dir, threshold_days=30)`` → list pages flagged stale
+  - ``is_candidate(page_path)`` → bool
+
+Design choices:
+  - Separate ``candidates/`` mirror tree (vs status field only) so the
+    build step can cleanly exclude them from the public site by default.
+  - ``## Connections`` links from candidates stay as-is when promoted;
+    callers run `llmwiki lint` afterward to catch any stale pointers.
+  - Discard is non-destructive: pages move to ``wiki/archive/candidates/``
+    with a timestamped reason file so you can recover them later.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional, TypedDict
+
+# ─── constants ─────────────────────────────────────────────────────────
+
+CANDIDATES_DIR_NAME = "candidates"
+ARCHIVE_DIR_NAME = "archive"
+ARCHIVED_CANDIDATES_SUBDIR = "candidates"
+
+# Subfolders mirrored under wiki/candidates/
+MIRRORED_SUBDIRS = ["entities", "concepts", "sources", "syntheses"]
+
+# Default staleness threshold (days)
+DEFAULT_STALE_DAYS = 30
+
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)$", re.DOTALL)
+
+
+# ─── types ─────────────────────────────────────────────────────────────
+
+class Candidate(TypedDict):
+    """Info about one candidate page waiting for review."""
+
+    slug: str              # bare filename stem (e.g. "NewEntity")
+    rel_path: str          # path relative to wiki/ (e.g. "candidates/entities/NewEntity.md")
+    abs_path: Path         # absolute path to the file
+    kind: str              # "entities" | "concepts" | "sources" | "syntheses"
+    title: str             # frontmatter title
+    created: Optional[str] # frontmatter created/last_updated date (YYYY-MM-DD)
+    age_days: int          # days since `created`
+    body_preview: str      # first 200 chars of body
+
+
+# ─── helpers ───────────────────────────────────────────────────────────
+
+def _parse_frontmatter(text: str) -> tuple[dict[str, str], str]:
+    """Return (meta_dict, body)."""
+    m = FRONTMATTER_RE.match(text)
+    if not m:
+        return {}, text
+    out: dict[str, str] = {}
+    for line in m.group(1).splitlines():
+        if ":" not in line:
+            continue
+        k, _, v = line.partition(":")
+        out[k.strip()] = v.strip().strip('"')
+    return out, m.group(2)
+
+
+def _age_days(date_str: Optional[str], *, now: Optional[datetime] = None) -> int:
+    """Compute days between ``date_str`` (YYYY-MM-DD) and now."""
+    if not date_str:
+        return 0
+    try:
+        dt = datetime.fromisoformat(date_str)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        return 0
+    ref = now or datetime.now(timezone.utc)
+    return max(0, (ref - dt).days)
+
+
+def is_candidate(page_path: Path) -> bool:
+    """True if the path is inside wiki/candidates/ subtree."""
+    parts = page_path.parts
+    return CANDIDATES_DIR_NAME in parts
+
+
+def candidates_dir(wiki_dir: Path) -> Path:
+    """Return wiki/candidates/ (creates parent if needed)."""
+    return wiki_dir / CANDIDATES_DIR_NAME
+
+
+def archive_dir(wiki_dir: Path) -> Path:
+    """Return wiki/archive/candidates/."""
+    return wiki_dir / ARCHIVE_DIR_NAME / ARCHIVED_CANDIDATES_SUBDIR
+
+
+# ─── public API ────────────────────────────────────────────────────────
+
+
+def list_candidates(
+    wiki_dir: Path,
+    *,
+    now: Optional[datetime] = None,
+) -> list[Candidate]:
+    """Walk wiki/candidates/ and return one entry per pending page."""
+    root = candidates_dir(wiki_dir)
+    if not root.is_dir():
+        return []
+
+    out: list[Candidate] = []
+    for sub in MIRRORED_SUBDIRS:
+        sub_dir = root / sub
+        if not sub_dir.is_dir():
+            continue
+        for path in sorted(sub_dir.glob("*.md")):
+            if path.name == "_context.md":
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            meta, body = _parse_frontmatter(text)
+            created = meta.get("last_updated") or meta.get("date")
+            out.append({
+                "slug": path.stem,
+                "rel_path": str(path.relative_to(wiki_dir)),
+                "abs_path": path,
+                "kind": sub,
+                "title": meta.get("title", path.stem),
+                "created": created,
+                "age_days": _age_days(created, now=now),
+                "body_preview": body.strip()[:200],
+            })
+    return out
+
+
+def promote(
+    slug: str,
+    wiki_dir: Path,
+    *,
+    kind: Optional[str] = None,
+) -> Path:
+    """Move ``wiki/candidates/<kind>/<slug>.md`` → ``wiki/<kind>/<slug>.md``.
+
+    If ``kind`` is omitted, infers from where the candidate lives. Rewrites
+    the frontmatter ``status:`` from ``candidate`` → ``reviewed`` so the
+    lifecycle rule picks it up.
+
+    Returns the new (promoted) path. Raises FileNotFoundError if the
+    candidate does not exist.
+    """
+    candidate = _find_candidate(slug, wiki_dir, kind)
+    inferred_kind = candidate.parent.name
+    target_dir = wiki_dir / inferred_kind
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / candidate.name
+
+    text = candidate.read_text(encoding="utf-8")
+    text = _rewrite_status(text, old="candidate", new="reviewed")
+    target.write_text(text, encoding="utf-8")
+    candidate.unlink()
+    return target
+
+
+def merge(
+    slug: str,
+    wiki_dir: Path,
+    *,
+    into_slug: str,
+    kind: Optional[str] = None,
+) -> Path:
+    """Append the candidate's body under a ``## Candidate merge — <date>``
+    heading into the existing wiki page ``<into_slug>.md``, then discard
+    the candidate.
+
+    Returns the path of the target page. Raises FileNotFoundError if either
+    page is missing.
+    """
+    candidate = _find_candidate(slug, wiki_dir, kind)
+    inferred_kind = candidate.parent.name
+    target = wiki_dir / inferred_kind / f"{into_slug}.md"
+    if not target.is_file():
+        raise FileNotFoundError(
+            f"merge target not found: {target} (candidate={candidate})"
+        )
+
+    candidate_text = candidate.read_text(encoding="utf-8")
+    _, candidate_body = _parse_frontmatter(candidate_text)
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    appended = (
+        target.read_text(encoding="utf-8").rstrip() +
+        f"\n\n## Candidate merge — {today}\n\n" +
+        f"Merged from `{candidate.relative_to(wiki_dir)}`:\n\n" +
+        candidate_body.strip() + "\n"
+    )
+    target.write_text(appended, encoding="utf-8")
+
+    # Discard candidate by moving it to archive with a merge-reason file
+    _archive_candidate(candidate, wiki_dir, reason=f"merged into {into_slug}")
+    return target
+
+
+def discard(
+    slug: str,
+    wiki_dir: Path,
+    *,
+    reason: str = "",
+    kind: Optional[str] = None,
+) -> Path:
+    """Move the candidate to ``wiki/archive/candidates/<timestamp>/<slug>.md``
+    with an adjacent ``<slug>.reason.txt`` capturing why.
+
+    Returns the archived path.
+    """
+    candidate = _find_candidate(slug, wiki_dir, kind)
+    return _archive_candidate(candidate, wiki_dir, reason=reason)
+
+
+def stale_candidates(
+    wiki_dir: Path,
+    *,
+    threshold_days: int = DEFAULT_STALE_DAYS,
+    now: Optional[datetime] = None,
+) -> list[Candidate]:
+    """Return candidates older than ``threshold_days``."""
+    return [
+        c for c in list_candidates(wiki_dir, now=now)
+        if c["age_days"] >= threshold_days
+    ]
+
+
+# ─── internals ─────────────────────────────────────────────────────────
+
+
+def _find_candidate(
+    slug: str,
+    wiki_dir: Path,
+    kind: Optional[str],
+) -> Path:
+    """Locate ``<slug>.md`` under wiki/candidates/, optionally filtered by kind."""
+    root = candidates_dir(wiki_dir)
+    subs = [kind] if kind else MIRRORED_SUBDIRS
+    for sub in subs:
+        path = root / sub / f"{slug}.md"
+        if path.is_file():
+            return path
+    raise FileNotFoundError(
+        f"candidate not found: {slug!r} under {root}"
+        + (f" (kind={kind})" if kind else "")
+    )
+
+
+def _rewrite_status(text: str, *, old: str, new: str) -> str:
+    """Replace ``status: <old>`` with ``status: <new>`` in frontmatter."""
+    pattern = re.compile(
+        rf"^(status:\s*){re.escape(old)}(\s*)$",
+        re.MULTILINE,
+    )
+    if pattern.search(text):
+        return pattern.sub(rf"\g<1>{new}\g<2>", text)
+    # Add status line to frontmatter if missing
+    m = FRONTMATTER_RE.match(text)
+    if m:
+        new_fm = m.group(1) + f"\nstatus: {new}"
+        return f"---\n{new_fm}\n---\n{m.group(2)}"
+    return text
+
+
+def _archive_candidate(
+    candidate: Path,
+    wiki_dir: Path,
+    *,
+    reason: str,
+) -> Path:
+    """Move candidate into archive with reason file."""
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")
+    dest_dir = archive_dir(wiki_dir) / stamp
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    dest = dest_dir / candidate.name
+    shutil.move(str(candidate), str(dest))
+
+    if reason:
+        reason_file = dest.with_suffix(".reason.txt")
+        reason_file.write_text(
+            f"Discarded at: {datetime.now(timezone.utc).isoformat()}\n"
+            f"Reason: {reason}\n"
+            f"Original path: candidates/{candidate.parent.name}/{candidate.name}\n",
+            encoding="utf-8",
+        )
+    return dest

--- a/llmwiki/cli.py
+++ b/llmwiki/cli.py
@@ -438,6 +438,69 @@ def cmd_lint(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_candidates(args: argparse.Namespace) -> int:
+    """List / promote / merge / discard candidate pages (v1.1.0 · #51)."""
+    import json as _json
+    from llmwiki.candidates import (
+        list_candidates,
+        promote,
+        merge as merge_candidate,
+        discard,
+        stale_candidates,
+    )
+
+    wiki_dir = args.wiki_dir or (REPO_ROOT / "wiki")
+    if not wiki_dir.is_dir():
+        print(f"error: wiki directory not found: {wiki_dir}", file=sys.stderr)
+        return 2
+
+    action = args.action
+
+    if action == "list":
+        items = (
+            stale_candidates(wiki_dir, threshold_days=args.stale_days)
+            if args.stale else list_candidates(wiki_dir)
+        )
+        if args.json:
+            # Path isn't JSON-serializable — drop it for the output
+            cleaned = [{k: v for k, v in c.items() if k != "abs_path"} for c in items]
+            print(_json.dumps(cleaned, indent=2))
+        else:
+            label = "stale" if args.stale else "pending"
+            print(f"  {len(items)} {label} candidate(s):")
+            for c in items:
+                age = f"{c['age_days']}d" if c["created"] else "unknown age"
+                print(f"    [{c['kind']:9}] {c['slug']}  ({age})  — {c['title']}")
+        return 0
+
+    if action == "promote":
+        if not args.slug:
+            print("error: --slug is required for promote", file=sys.stderr)
+            return 2
+        path = promote(args.slug, wiki_dir, kind=args.kind)
+        print(f"  promoted → {path.relative_to(wiki_dir)}")
+        return 0
+
+    if action == "merge":
+        if not args.slug or not args.into:
+            print("error: both --slug and --into are required for merge", file=sys.stderr)
+            return 2
+        path = merge_candidate(args.slug, wiki_dir, into_slug=args.into, kind=args.kind)
+        print(f"  merged into → {path.relative_to(wiki_dir)}")
+        return 0
+
+    if action == "discard":
+        if not args.slug:
+            print("error: --slug is required for discard", file=sys.stderr)
+            return 2
+        path = discard(args.slug, wiki_dir, reason=args.reason, kind=args.kind)
+        print(f"  discarded → {path.relative_to(wiki_dir)}")
+        return 0
+
+    print(f"error: unknown action {action!r}", file=sys.stderr)
+    return 2
+
+
 def cmd_completion(args: argparse.Namespace) -> int:
     """Emit shell completion script for the requested shell (v1.1.0 · #216)."""
     from llmwiki.completion import generate
@@ -714,6 +777,33 @@ def build_parser() -> argparse.ArgumentParser:
         help="Install llmwiki skills into .codex/skills/ and .agents/skills/ (multi-agent support)",
     )
     isk.set_defaults(func=cmd_install_skills)
+
+    # candidates (v1.1, #51) — approval workflow
+    cand = sub.add_parser(
+        "candidates",
+        help="List / promote / merge / discard candidate wiki pages (approval workflow)",
+    )
+    cand.add_argument(
+        "action", choices=["list", "promote", "merge", "discard"],
+        help="What to do with candidates",
+    )
+    cand.add_argument("--slug", type=str, default=None,
+                      help="Candidate slug (required for promote/merge/discard)")
+    cand.add_argument("--into", type=str, default=None,
+                      help="For merge: slug of the page to merge into")
+    cand.add_argument("--reason", type=str, default="",
+                      help="For discard: why the candidate is being rejected")
+    cand.add_argument("--kind", type=str, default=None,
+                      choices=["entities", "concepts", "sources", "syntheses"],
+                      help="Subtree (auto-detected if omitted)")
+    cand.add_argument("--wiki-dir", type=Path, default=None,
+                      help="Wiki directory (default: ./wiki)")
+    cand.add_argument("--stale", action="store_true",
+                      help="For list: only show stale candidates")
+    cand.add_argument("--stale-days", type=int, default=30,
+                      help="Staleness threshold in days (default 30)")
+    cand.add_argument("--json", action="store_true", help="JSON output for list")
+    cand.set_defaults(func=cmd_candidates)
 
     # completion (v1.1, #216) — emit shell completion script
     comp = sub.add_parser(

--- a/llmwiki/lint/rules.py
+++ b/llmwiki/lint/rules.py
@@ -428,6 +428,53 @@ class ClaimVerification(LintRule):
 
 
 @register
+class StaleCandidates(LintRule):
+    """Flag candidate pages older than N days (#51).
+
+    Candidates are new entity/concept pages waiting for human approval.
+    Anything sitting in wiki/candidates/ for > 30 days likely indicates
+    the reviewer forgot about it. Reports as info severity (not blocking).
+    """
+
+    name = "stale_candidates"
+    severity = "info"
+    STALE_DAYS = 30
+
+    def run(self, pages, *, llm_callback=None):
+        from llmwiki.candidates import stale_candidates, candidates_dir
+        # load_pages gives us the real wiki dir from page[path]
+        issues = []
+        if not pages:
+            return issues
+        # Infer wiki_dir from first page path
+        sample_page = next(iter(pages.values()))
+        page_path = sample_page.get("path")
+        if not isinstance(page_path, Path):
+            return issues
+        # Walk up to find wiki/ root
+        wiki_dir = page_path.parent
+        for _ in range(6):
+            if wiki_dir.name == "wiki":
+                break
+            if wiki_dir == wiki_dir.parent:
+                return issues
+            wiki_dir = wiki_dir.parent
+        if not candidates_dir(wiki_dir).is_dir():
+            return issues
+        for cand in stale_candidates(wiki_dir, threshold_days=self.STALE_DAYS):
+            issues.append({
+                "rule": self.name,
+                "severity": "info",
+                "page": cand["rel_path"],
+                "message": (
+                    f"candidate '{cand['slug']}' is {cand['age_days']} days old "
+                    f"(threshold {self.STALE_DAYS}) — review with `/wiki-review`"
+                ),
+            })
+        return issues
+
+
+@register
 class SummaryAccuracy(LintRule):
     """Check that summary: field matches content (LLM-powered)."""
 

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -1,0 +1,356 @@
+"""Tests for wiki/candidates/ approval workflow (v1.1.0, #51)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from llmwiki.candidates import (
+    CANDIDATES_DIR_NAME,
+    ARCHIVE_DIR_NAME,
+    MIRRORED_SUBDIRS,
+    DEFAULT_STALE_DAYS,
+    Candidate,
+    is_candidate,
+    candidates_dir,
+    archive_dir,
+    list_candidates,
+    promote,
+    merge,
+    discard,
+    stale_candidates,
+    _parse_frontmatter,
+    _age_days,
+    _rewrite_status,
+)
+
+
+# ─── Fixtures ──────────────────────────────────────────────────────────
+
+
+def _mk_wiki(tmp_path: Path) -> Path:
+    """Create a wiki/ tree with candidates/ + entities/ + concepts/."""
+    wiki = tmp_path / "wiki"
+    for sub in MIRRORED_SUBDIRS:
+        (wiki / sub).mkdir(parents=True, exist_ok=True)
+        (wiki / "candidates" / sub).mkdir(parents=True, exist_ok=True)
+    return wiki
+
+
+def _write_candidate(
+    wiki: Path,
+    kind: str,
+    slug: str,
+    *,
+    body: str = "",
+    date: str = "2026-04-17",
+    title: str | None = None,
+) -> Path:
+    path = wiki / "candidates" / kind / f"{slug}.md"
+    title = title or slug
+    path.write_text(
+        f'---\ntitle: "{title}"\ntype: {kind[:-1]}\nstatus: candidate\n'
+        f'last_updated: {date}\n---\n\n{body or f"# {title}\\n\\nCandidate body."}\n',
+        encoding="utf-8",
+    )
+    return path
+
+
+# ─── Constants ────────────────────────────────────────────────────────
+
+
+def test_constants_defined():
+    assert CANDIDATES_DIR_NAME == "candidates"
+    assert ARCHIVE_DIR_NAME == "archive"
+    assert DEFAULT_STALE_DAYS == 30
+    assert "entities" in MIRRORED_SUBDIRS
+    assert "concepts" in MIRRORED_SUBDIRS
+
+
+# ─── is_candidate / dir helpers ──────────────────────────────────────
+
+
+def test_is_candidate_true_for_candidates_path():
+    assert is_candidate(Path("/x/wiki/candidates/entities/Foo.md")) is True
+
+
+def test_is_candidate_false_for_normal_path():
+    assert is_candidate(Path("/x/wiki/entities/Foo.md")) is False
+
+
+def test_candidates_dir_returns_right_path(tmp_path: Path):
+    wiki = tmp_path / "wiki"
+    assert candidates_dir(wiki) == wiki / "candidates"
+
+
+def test_archive_dir_returns_right_path(tmp_path: Path):
+    wiki = tmp_path / "wiki"
+    assert archive_dir(wiki) == wiki / "archive" / "candidates"
+
+
+# ─── list_candidates ─────────────────────────────────────────────────
+
+
+def test_list_empty_wiki(tmp_path: Path):
+    wiki = _mk_wiki(tmp_path)
+    assert list_candidates(wiki) == []
+
+
+def test_list_missing_candidates_dir(tmp_path: Path):
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    # No candidates/ subdir
+    assert list_candidates(wiki) == []
+
+
+def test_list_returns_pending_entities(tmp_path: Path):
+    wiki = _mk_wiki(tmp_path)
+    _write_candidate(wiki, "entities", "NewEntity")
+    _write_candidate(wiki, "concepts", "NewConcept")
+    items = list_candidates(wiki)
+    assert len(items) == 2
+    kinds = {c["kind"] for c in items}
+    assert kinds == {"entities", "concepts"}
+
+
+def test_list_skips_context_md(tmp_path: Path):
+    wiki = _mk_wiki(tmp_path)
+    _write_candidate(wiki, "entities", "Real")
+    (wiki / "candidates" / "entities" / "_context.md").write_text(
+        "---\ntitle: Context\n---\n", encoding="utf-8"
+    )
+    items = list_candidates(wiki)
+    assert len(items) == 1
+    assert items[0]["slug"] == "Real"
+
+
+def test_list_includes_body_preview(tmp_path: Path):
+    wiki = _mk_wiki(tmp_path)
+    _write_candidate(wiki, "entities", "X", body="# X\n\nDetails about X entity.")
+    items = list_candidates(wiki)
+    assert "Details about X entity" in items[0]["body_preview"]
+
+
+def test_list_computes_age_days(tmp_path: Path):
+    wiki = _mk_wiki(tmp_path)
+    _write_candidate(wiki, "entities", "Old", date="2026-04-01")
+    now = datetime(2026, 4, 17, tzinfo=timezone.utc)
+    items = list_candidates(wiki, now=now)
+    assert items[0]["age_days"] == 16
+
+
+# ─── promote ────────────────────────────────────────────────────────
+
+
+def test_promote_moves_candidate_to_entities(tmp_path: Path):
+    wiki = _mk_wiki(tmp_path)
+    candidate = _write_candidate(wiki, "entities", "ApprovedFoo")
+
+    promoted = promote("ApprovedFoo", wiki)
+    assert promoted == wiki / "entities" / "ApprovedFoo.md"
+    assert promoted.is_file()
+    assert not candidate.exists()
+
+
+def test_promote_rewrites_status_to_reviewed(tmp_path: Path):
+    wiki = _mk_wiki(tmp_path)
+    _write_candidate(wiki, "entities", "Foo")
+    path = promote("Foo", wiki)
+    content = path.read_text(encoding="utf-8")
+    assert "status: reviewed" in content
+    assert "status: candidate" not in content
+
+
+def test_promote_infers_kind_from_candidate_location(tmp_path: Path):
+    wiki = _mk_wiki(tmp_path)
+    _write_candidate(wiki, "concepts", "Idea")
+    path = promote("Idea", wiki)
+    assert path.parent.name == "concepts"
+
+
+def test_promote_respects_explicit_kind(tmp_path: Path):
+    wiki = _mk_wiki(tmp_path)
+    _write_candidate(wiki, "entities", "Foo")
+    path = promote("Foo", wiki, kind="entities")
+    assert path.parent.name == "entities"
+
+
+def test_promote_raises_when_candidate_missing(tmp_path: Path):
+    wiki = _mk_wiki(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        promote("Ghost", wiki)
+
+
+# ─── merge ──────────────────────────────────────────────────────────
+
+
+def test_merge_appends_body_to_target(tmp_path: Path):
+    wiki = _mk_wiki(tmp_path)
+    target = wiki / "entities" / "Main.md"
+    target.write_text(
+        '---\ntitle: "Main"\ntype: entity\n---\n\n# Main\n\nOriginal content.\n',
+        encoding="utf-8",
+    )
+    _write_candidate(wiki, "entities", "Duplicate", body="# Duplicate\n\nExtra info.")
+
+    result = merge("Duplicate", wiki, into_slug="Main")
+    assert result == target
+    text = target.read_text(encoding="utf-8")
+    assert "Original content" in text
+    assert "## Candidate merge" in text
+    assert "Extra info" in text
+
+
+def test_merge_archives_candidate_after(tmp_path: Path):
+    wiki = _mk_wiki(tmp_path)
+    (wiki / "entities" / "Main.md").write_text(
+        '---\ntitle: Main\ntype: entity\n---\nbody\n', encoding="utf-8"
+    )
+    candidate = _write_candidate(wiki, "entities", "Dup")
+    merge("Dup", wiki, into_slug="Main")
+    assert not candidate.exists()
+
+
+def test_merge_raises_when_target_missing(tmp_path: Path):
+    wiki = _mk_wiki(tmp_path)
+    _write_candidate(wiki, "entities", "Dup")
+    with pytest.raises(FileNotFoundError):
+        merge("Dup", wiki, into_slug="Nonexistent")
+
+
+# ─── discard ────────────────────────────────────────────────────────
+
+
+def test_discard_moves_to_archive(tmp_path: Path):
+    wiki = _mk_wiki(tmp_path)
+    candidate = _write_candidate(wiki, "entities", "Bogus")
+    archived = discard("Bogus", wiki, reason="hallucinated")
+
+    assert not candidate.exists()
+    assert archived.is_file()
+    # Archive structure: wiki/archive/candidates/<timestamp>/Bogus.md
+    assert "archive" in archived.parts
+    assert "candidates" in archived.parts
+    assert archived.name == "Bogus.md"
+
+
+def test_discard_writes_reason_file(tmp_path: Path):
+    wiki = _mk_wiki(tmp_path)
+    _write_candidate(wiki, "entities", "Fake")
+    archived = discard("Fake", wiki, reason="not a real thing")
+
+    reason_file = archived.with_suffix(".reason.txt")
+    assert reason_file.is_file()
+    text = reason_file.read_text(encoding="utf-8")
+    assert "not a real thing" in text
+    assert "Discarded at:" in text
+
+
+def test_discard_raises_when_candidate_missing(tmp_path: Path):
+    wiki = _mk_wiki(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        discard("Ghost", wiki, reason="x")
+
+
+# ─── stale_candidates ────────────────────────────────────────────────
+
+
+def test_stale_returns_only_old_candidates(tmp_path: Path):
+    wiki = _mk_wiki(tmp_path)
+    _write_candidate(wiki, "entities", "Old", date="2026-01-01")
+    _write_candidate(wiki, "entities", "New", date="2026-04-15")
+    now = datetime(2026, 4, 17, tzinfo=timezone.utc)
+    stale = stale_candidates(wiki, threshold_days=30, now=now)
+    assert len(stale) == 1
+    assert stale[0]["slug"] == "Old"
+
+
+def test_stale_custom_threshold(tmp_path: Path):
+    wiki = _mk_wiki(tmp_path)
+    _write_candidate(wiki, "entities", "Medium", date="2026-04-05")
+    now = datetime(2026, 4, 17, tzinfo=timezone.utc)
+    # age = 12 days; threshold 10 → stale; threshold 30 → not stale
+    assert len(stale_candidates(wiki, threshold_days=10, now=now)) == 1
+    assert len(stale_candidates(wiki, threshold_days=30, now=now)) == 0
+
+
+# ─── Internals ───────────────────────────────────────────────────────
+
+
+def test_parse_frontmatter_valid():
+    meta, body = _parse_frontmatter('---\ntitle: "Foo"\ntype: entity\n---\n\nBody.\n')
+    assert meta == {"title": "Foo", "type": "entity"}
+    assert body.strip() == "Body."
+
+
+def test_parse_frontmatter_missing():
+    meta, body = _parse_frontmatter("no frontmatter")
+    assert meta == {}
+    assert body == "no frontmatter"
+
+
+def test_age_days_none_returns_zero():
+    assert _age_days(None) == 0
+
+
+def test_age_days_invalid_returns_zero():
+    assert _age_days("not-a-date") == 0
+
+
+def test_age_days_computes_correctly():
+    now = datetime(2026, 4, 17, tzinfo=timezone.utc)
+    assert _age_days("2026-04-01", now=now) == 16
+
+
+def test_rewrite_status_replaces_existing():
+    text = (
+        '---\ntitle: X\nstatus: candidate\n---\n\nbody\n'
+    )
+    result = _rewrite_status(text, old="candidate", new="reviewed")
+    assert "status: reviewed" in result
+    assert "status: candidate" not in result
+
+
+def test_rewrite_status_adds_when_missing():
+    text = '---\ntitle: X\n---\n\nbody\n'
+    result = _rewrite_status(text, old="candidate", new="reviewed")
+    assert "status: reviewed" in result
+
+
+# ─── Lint rule integration ───────────────────────────────────────────
+
+
+def test_stale_candidates_lint_rule_registered():
+    from llmwiki.lint import REGISTRY
+    from llmwiki.lint import rules  # noqa: F401
+    assert "stale_candidates" in REGISTRY
+
+
+# ─── Slash command ───────────────────────────────────────────────────
+
+
+def test_wiki_review_slash_command_exists():
+    from llmwiki import REPO_ROOT
+    cmd = REPO_ROOT / ".claude" / "commands" / "wiki-review.md"
+    assert cmd.is_file()
+    text = cmd.read_text(encoding="utf-8")
+    assert "promote" in text
+    assert "merge" in text
+    assert "discard" in text
+
+
+# ─── CLI integration ────────────────────────────────────────────────
+
+
+def test_cli_candidates_subcommand_registered():
+    from llmwiki.cli import build_parser
+    parser = build_parser()
+    sub_action = None
+    for a in parser._actions:
+        if hasattr(a, "choices") and a.choices:
+            sub_action = a
+            break
+    assert sub_action is not None
+    assert "candidates" in sub_action.choices

--- a/tests/test_lint_rules.py
+++ b/tests/test_lint_rules.py
@@ -34,10 +34,10 @@ def _mk_page(meta: dict, body: str) -> dict:
 # ─── Registry ──────────────────────────────────────────────────────────
 
 
-def test_all_11_rules_registered():
-    # Importing rules registers them
+def test_all_12_rules_registered():
+    # 11 original rules from v1.0 + stale_candidates (v1.1, #51)
     from llmwiki.lint import rules  # noqa: F401
-    assert len(REGISTRY) == 11
+    assert len(REGISTRY) == 12
 
 
 def test_registered_rule_names():
@@ -54,6 +54,7 @@ def test_registered_rule_names():
         "contradiction_detection",
         "claim_verification",
         "summary_accuracy",
+        "stale_candidates",  # v1.1 (#51)
     }
     assert set(REGISTRY.keys()) == expected
 


### PR DESCRIPTION
Closes #51

## Summary
Quality gate for LLM-generated wiki pages: new entities/concepts land in `wiki/candidates/` and require human review before promotion. Discard is non-destructive (archive with reason).

## PR Checklist
- [ ] 34 candidates tests pass
- [ ] 12th lint rule (stale_candidates) registered
- [ ] `/wiki-review` slash command shipped
- [ ] CLI `llmwiki candidates list|promote|merge|discard` works
- [ ] 1431 tests total
- [ ] CHANGELOG updated
- [ ] GPG-signed, no AI co-author