### PR TITLE
fix: resolve 9 broken external links flagged by lychee (#239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ### Fixed
 
+- **9 broken external links flagged by lychee CI** (#239) — one weekly link-check scan surfaced a batch of dead/missing references:
+  - `docs/competitor-landscape.md`: `rewind.ai` domain errors; delinked and noted the Limitless.ai rebrand.
+  - `docs/framework.md`: `../.framework/Framework.md` pointed at a gitignored local file; delinked and annotated as a local-only reference.
+  - `README.md`: `docs/adapters/copilot-chat.md` and `docs/adapters/copilot-cli.md` collapsed into the existing `docs/adapters/copilot.md` (the combined adapter doc already covers both modes).
+  - `README.md`: 5× 404 release tag links (`v0.5.0` / `v0.6.0` / `v0.7.0` / `v0.8.0` / `v0.9.0`) — those standalone releases were never published; work shipped consolidated under `v0.9.x`. Collapsed into one row that explains the gap, and extended the table forward with the actually-shipped `v0.9.5` / `v1.0.0` / `v1.1.0-rc1` / `v1.1.0-rc2` rows so the version history is current.
 - **`StaleCandidates` lint rule crashed with `NameError: name 'Path' is not defined`** (#51 follow-up) — the rule used `isinstance(page_path, Path)` without importing `Path`, so the `Lint + build seeded wiki` GH Actions job crashed on every push after #51 landed. Added `from pathlib import Path` inside the method (matching the existing lazy-import pattern). Regression test now exercises the rule against a seeded tmp_path wiki.
 - **`tests/test_candidates.py` rejected by Python 3.9** (#51 follow-up) — line 55 nested an f-string with `\n` inside an outer f-string expression; Python 3.9 rejects backslashes inside f-string parts (only 3.12+ permits it), breaking `lint-and-test (3.9)` CI. Extracted the default body into a local variable before interpolation.
 

--- a/README.md
+++ b/README.md
@@ -484,8 +484,7 @@ Per-adapter docs:
 - [Gemini CLI adapter](docs/adapters/gemini-cli.md)
 - [Obsidian adapter](docs/adapters/obsidian.md)
 - [PDF adapter](docs/adapters/pdf.md)
-- [Copilot Chat adapter](docs/adapters/copilot-chat.md)
-- [Copilot CLI adapter](docs/adapters/copilot-cli.md)
+- [Copilot adapter (Chat + CLI)](docs/adapters/copilot.md)
 
 ## Releases
 
@@ -495,15 +494,15 @@ Per-adapter docs:
 | [v0.2.0](https://github.com/Pratiyush/llm-wiki/releases/tag/v0.2.0) | Extensions — 3 new slash commands, 3 new adapters, Obsidian bidirectional, full MCP server | `v0.2.0` |
 | [v0.3.0](https://github.com/Pratiyush/llm-wiki/releases/tag/v0.3.0) | PyPI packaging, eval framework, i18n scaffold | `v0.3.0` |
 | [v0.4.0](https://github.com/Pratiyush/llm-wiki/releases/tag/v0.4.0) | AI + human dual format — per-page .txt/.json siblings, llms.txt, JSON-LD graph, sitemap, RSS, schema.org microdata, reading time, related pages, activity heatmap, deep-link anchors, build manifest, link checker, `wiki_export` MCP tool | `v0.4.0` |
-| [v0.5.0](https://github.com/Pratiyush/llm-wiki/releases/tag/v0.5.0) | Folder-level `_context.md`, auto-ingest, 3 adapter graduations (Cursor, Gemini CLI, PDF), lazy search index, scheduled sync templates, WCAG accessibility, Playwright E2E tests | `v0.5.0` |
-| [v0.6.0](https://github.com/Pratiyush/llm-wiki/releases/tag/v0.6.0) | qmd export, GitLab Pages CI, PyPI release automation, maintainer governance scaffold | `v0.6.0` |
-| [v0.7.0](https://github.com/Pratiyush/llm-wiki/releases/tag/v0.7.0) | Structured model-profile schema, auto-generated vs-comparison pages, append-only changelog timeline | `v0.7.0` |
-| [v0.8.0](https://github.com/Pratiyush/llm-wiki/releases/tag/v0.8.0) | 365-day activity heatmap, tool-calling bar chart, token usage card, session metrics frontmatter | `v0.8.0` |
-| [v0.9.0](https://github.com/Pratiyush/llm-wiki/releases/tag/v0.9.0) | Project topics, agent labels (Claude/Codex/Copilot/Cursor/Gemini badges), Copilot adapters, image pipeline, highlight.js, public demo deployment | `v0.9.0` |
+| v0.5.0 – v0.9.0 | Internal sprint milestones — features (`_context.md`, auto-ingest, qmd export, model-profile schema, activity heatmap, Copilot adapters, etc.) shipped consolidated under the v0.9.x line. No standalone tags were published. | — |
 | [v0.9.1](https://github.com/Pratiyush/llm-wiki/releases/tag/v0.9.1) | Sprint 1 & 2 foundation — link-obsidian CLI, 4-factor confidence scoring, 5-state lifecycle machine, llmbook-reference skill, 7 entity types, flat raw/ naming, pending ingest queue, `_context.md` stubs, meeting + Jira adapters, configurable Web Clipper intake, rich log format | `v0.9.1` |
 | [v0.9.2](https://github.com/Pratiyush/llm-wiki/releases/tag/v0.9.2) | Sprint 3 quality — 11 lint rules (8 basic + 3 LLM-powered), Auto Dream MEMORY.md consolidation, Dataview dashboard template, category pages (Dataview + static), auto-build on sync + configurable lint schedule | `v0.9.2` |
 | [v0.9.3](https://github.com/Pratiyush/llm-wiki/releases/tag/v0.9.3) | Sprint 3 polish — Obsidian Templater templates, integration guide, two-way editing tests, MCP server 7→12 tools, adapter config validation, pipeline fix (sigstore, PyPI gate) | `v0.9.3` |
 | [v0.9.4](https://github.com/Pratiyush/llm-wiki/releases/tag/v0.9.4) | Session C1 (Sprint 4) — multi-agent skill installer, enhanced search with facets, configurable scheduled sync (launchd/systemd/Task Scheduler), CI wiki-checks workflow | `v0.9.4` |
+| [v0.9.5](https://github.com/Pratiyush/llm-wiki/releases/tag/v0.9.5) | Docs polish + consistency audit before v1.0.0 | `v0.9.5` |
+| [v1.0.0](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.0.0) | Production-ready Obsidian integration — full v1.0 scope | `v1.0.0` |
+| [v1.1.0-rc1](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc1) | Solo quick-win sprint — candidates workflow, Ollama scaffold, prompt-cache scaffold | `v1.1.0-rc1` |
+| [v1.1.0-rc2](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc2) | Session E — interactive graph viewer + remaining code-only v1.1 work | `v1.1.0-rc2` |
 
 ## Roadmap
 

--- a/docs/competitor-landscape.md
+++ b/docs/competitor-landscape.md
@@ -59,8 +59,9 @@ is a tool, not a library.
 
 ### llmwiki vs Rewind (now Limitless)
 
-[Rewind](https://www.rewind.ai/) records everything on your screen,
-indexes it with OCR, and lets you search your visual history.
+Rewind (later rebranded to [Limitless](https://www.limitless.ai/))
+records everything on your screen, indexes it with OCR, and lets
+you search your visual history.
 
 **When to use Rewind:** You want to search across all your screen
 activity, not just AI coding sessions. You're on macOS and comfortable

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -1,6 +1,6 @@
 # llmwiki Framework — Building an Agent-Native Dev Tool
 
-> **Adapted from** the [Open Source Project Framework v4.0](../.framework/Framework.md) *(local reference — not in the public repo)*.
+> **Adapted from** the maintainer's "Open Source Project Framework v4.0" (local reference — kept outside the public repo).
 >
 > **Extensions** specific to llmwiki and any tool in this class (dev tools that ingest from AI coding agents):
 >


### PR DESCRIPTION
## Summary

Closes #239. The weekly lychee scan flagged 9 broken URLs across `README.md`, `docs/framework.md`, and `docs/competitor-landscape.md`. All fixed:

| File | Link | Fix |
|---|---|---|
| `docs/competitor-landscape.md` | `https://www.rewind.ai/` | Delinked; noted Rewind rebrand to Limitless.ai |
| `docs/framework.md` | `../.framework/Framework.md` | Gitignored personal ref — delinked (plain text) |
| `README.md` | `docs/adapters/copilot-chat.md` | Collapsed into existing `docs/adapters/copilot.md` |
| `README.md` | `docs/adapters/copilot-cli.md` | Same — combined entry |
| `README.md` | 5× `releases/tag/v0.{5,6,7,8,9}.0` (404) | Never published; collapsed into one annotated row + added the v0.9.5 / v1.0.0 / v1.1.0-rc1 / v1.1.0-rc2 rows that actually ship |

## Test plan

- [x] `grep` confirms every broken pattern from #239 is gone from scanned files (`README.md`, `docs/`, `CHANGELOG.md`)
- [x] Full test suite still green: 1549 passed, 10 skipped
- [x] CHANGELOG entry added under `### Fixed`
- [x] Commit GPG-signed
- [x] Version history table extended to cover everything actually released (v0.9.5 → v1.1.0-rc2)

## Checklist

- [x] One intent per PR (docs-only link fixes)
- [x] Conventional-commit title (`fix:`)
- [x] GPG-signed commit, no AI co-author trailers
- [x] CHANGELOG entry
- [x] No code changes → no tests needed
- [x] Closes #239