### PR TITLE
chore: codify 'every PR ships docs + CHANGELOG + release notes' rule

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -44,7 +44,8 @@ Every box below must be checked (or have a one-line waiver explaining why it doe
 - [ ] **No new runtime dependencies** — stdlib + `markdown` only; new dev/test deps need justification + license check (no AGPL/GPL into MIT)
 - [ ] **No real session data** — no personal sessions under `raw/sessions/` or in test fixtures; `wiki/` user content stays gitignored
 - [ ] **No machine-specific paths** or secrets in committed files (check `.env`, `*.key`, home paths, usernames)
-- [ ] **Docs updated** — `README.md`, `docs/`, inline `--help` all reflect any user-visible change
+- [ ] **Docs updated** — `README.md`, `docs/tutorials/*`, `docs/reference/*` (CLI / slash / UI tables), inline `--help`, design docs — every user-visible change reflected. PRs adding a new CLI subcommand / slash / config key / lint rule MUST grow the matching `docs/reference/*.md` row in the same PR.
+- [ ] **Release notes drafted** — one line suitable for the next `gh release create --notes` text, either in the Unreleased CHANGELOG section or in this PR body.
 - [ ] **UI verified** (light AND dark mode) — for any change to `llmwiki/build.py` CSS or static site. Paste screenshots below.
 - [ ] **A11y verified** — keyboard nav works, focus rings visible, `axe` clean (for UI changes). WCAG 2.1 AA minimum (contrast ≥ 4.5:1).
 - [ ] **Commits GPG-signed** by the repo author; no AI co-author trailers; atomic commits (one logical change each)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased] — post-v1.0 cleanup
 
+### Changed
+
+- **Contribution rule made explicit: every PR ships docs + CHANGELOG + release-note bullet** — previously the rule lived only in the plan file. Now codified in `CONTRIBUTING.md` rule #6 (the "seven rules" intro) and the PR template's pre-merge checklist. PRs adding a new CLI subcommand, slash command, config key, or lint rule MUST update the matching `docs/reference/*.md` table in the same PR. CI already blocks merges missing a CHANGELOG diff; this codifies the expectation so first-time contributors don't discover it at merge time.
+
 ### Fixed
 
 - **`raw/` immutability guardrail + AI-sessions-only default** (#326) — `CLAUDE.md` rule 1 was documentation-only. Now runtime-enforced: `_raw_write_guard()` refuses to overwrite any existing `raw/` file unless `llmwiki sync --force` is passed explicitly. Overwrite attempts are recorded in `.llmwiki-quarantine.json` (shipped in #300) with a clear reason, so the operator sees exactly what would have been clobbered. New `is_ai_session` class attribute on `BaseAdapter` classifies adapters; `obsidian`, `jira`, `meeting`, and `pdf` are marked `is_ai_session = False` and are now **opt-in only** — `llmwiki sync` with no flags no longer silently walks a user's personal Obsidian vault. `llmwiki adapters` column `will_fire` now reflects the classification (Obsidian: `auto no` unless explicitly enabled). 10 new tests in `tests/test_raw_immutability.py`: guard passes / raises / force-bypasses / error message formatting, every AI adapter marked, every non-AI adapter marked, default selection skips non-AI, explicit-enable includes non-AI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Thanks for wanting to contribute. This project follows strict rules about commit
 3. **Never commit real session data.** `raw/sessions/` is gitignored. Fixtures must be synthetic or heavily redacted.
 4. **No new runtime deps.** Stdlib + `markdown` only. Viewer loads highlight.js from a CDN — no server-side parser needed.
 5. **Tests must pass.** Run `python3 -m pytest tests/ -q` before pushing. CI runs on Python 3.9 + 3.12.
-6. **Add a CHANGELOG entry** under `## [Unreleased]` for every user-visible change.
+6. **Every PR ships docs + CHANGELOG + release-note bullet.** For every user-visible change update (a) `CHANGELOG.md` under `## [Unreleased]`, (b) any `docs/tutorials/*` / `docs/reference/*` / `README.md` / inline `--help` that describes the touched surface, and (c) a one-line release-note bullet either in the CHANGELOG entry or in the PR body so `gh release create` can pick it up. PRs adding a new CLI subcommand, slash command, config key, or lint rule MUST add the matching row to `docs/reference/*.md` in the same PR. CI enforces the CHANGELOG check; reviewers check the rest.
 7. **Open an issue first** for anything bigger than a one-file fix. Keeps scope aligned.
 
 That's it. If you follow those seven rules your PR is 90% of the way through review.


### PR DESCRIPTION
## Summary

Codify the standing rule: every PR must update docs + CHANGELOG + release-note bullet. Rule lived only in the private plan file — now surfaced where contributors + future-me will actually see it.

## Why

Per operator: *"Add to your rule in background that update docs and update release note and change log for every pr."*

CI already blocks merges without a CHANGELOG diff (the `CHANGELOG.md updated` workflow). But two gaps:

1. **First-time contributors** don't discover the rule until they hit the CI failure — they'd rather see it in `CONTRIBUTING.md`.
2. **Release notes** were implicit — no template slot specifically for them.
3. **Reference-doc updates** (CLI / slash / config / lint additions) were not explicitly required.

## Changes

- `CONTRIBUTING.md` rule #6 rewritten to name each artefact explicitly: `CHANGELOG.md` + `docs/tutorials/*` + `docs/reference/*` + `README.md` + `--help`.
- `.github/PULL_REQUEST_TEMPLATE.md` pre-merge checklist: new "Release notes drafted" box, expanded "Docs updated" text with the reference-table requirement.
- `CHANGELOG.md` Unreleased entry.

No code changes. No test changes required.

## Test plan

- [x] Read the new CONTRIBUTING.md text out loud — it's actionable, not vague
- [x] PR template renders correctly (markdown syntax intact)
- [x] GPG-signed commit
- [ ] CI green (CHANGELOG check + conventional-commit title should pass)