### PR TITLE
release: v1.1.0-rc4 — navigation + quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 Versions below 1.0 are pre-production — API and file formats may change.
 
-## [Unreleased] — post-v1.0 cleanup
+## [Unreleased]
+
+## [1.1.0-rc4] — 2026-04-20
+
+Navigation + quality release. Fixed two high-impact usability bugs the
+user surfaced end-to-end: graph clicks went nowhere (99.7% 404) and
+95% of wiki pages were orphans with no backlinks. Plus source-code /
+root-file link routing through GitHub, verify-before-fixing
+contribution rule, and an upgrade guide.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.1.0--rc3-10B981.svg)](CHANGELOG.md)
-[![Tests](https://img.shields.io/badge/tests-2162%20passing-10B981.svg)](tests/)
+[![Version](https://img.shields.io/badge/version-v1.1.0--rc4-10B981.svg)](CHANGELOG.md)
+[![Tests](https://img.shields.io/badge/tests-2271%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)
 [![Wiki checks](https://github.com/Pratiyush/llm-wiki/actions/workflows/wiki-checks.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/wiki-checks.yml)
@@ -525,6 +525,8 @@ Per-adapter docs:
 | [v1.0.0](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.0.0) | Production-ready Obsidian integration — full v1.0 scope | `v1.0.0` |
 | [v1.1.0-rc1](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc1) | Solo quick-win sprint — candidates workflow, Ollama scaffold, prompt-cache scaffold | `v1.1.0-rc1` |
 | [v1.1.0-rc2](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc2) | Session E — interactive graph viewer + remaining code-only v1.1 work | `v1.1.0-rc2` |
+| [v1.1.0-rc3](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc3) | Gap-sweep bundle — state portability, quarantine, sync --status, log CLI, synthesize --estimate breakdown, tag family, stale references, graph context menu, raw immutability, AI-sessions default | `v1.1.0-rc3` |
+| [v1.1.0-rc4](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc4) | Navigation + quality — graph `site_url` resolver (99.7% → 0% dead clicks), `llmwiki backlinks` CLI (95% → 0% orphan pages), source-code → GitHub link rewriter (471 → 100 broken), verify-before-fixing contribution rule | `v1.1.0-rc4` |
 
 ## Roadmap
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,0 +1,91 @@
+---
+title: "Upgrade guide"
+type: navigation
+docs_shell: true
+---
+
+# Upgrade guide
+
+How to upgrade between `llmwiki` releases.  Most releases are drop-in
+(`pip install -U llmwiki` or `brew upgrade llmwiki`) — this page
+documents the exceptions: schema migrations, config changes, and
+behaviour flips that affect what happens on your next `sync`.
+
+The canonical per-release detail is
+[CHANGELOG.md](https://github.com/Pratiyush/llm-wiki/blob/master/CHANGELOG.md)
+— this guide focuses on "what might break".
+
+## v1.1.0-rc4
+
+**Released: 2026-04-20.**
+
+### New behaviour
+
+- **Obsidian is opt-in now.** Past versions fired the Obsidian adapter
+  on every `sync` by default. If your workflow relied on that, add
+  this to `sessions_config.json`:
+
+  ```json
+  { "obsidian": { "enabled": true } }
+  ```
+
+  Context: [#326](https://github.com/Pratiyush/llm-wiki/issues/326).
+  Runs as of rc3; surfaced in `llmwiki adapters` column `will_fire`.
+
+- **Graph clicks respect compiled-site existence.** Nodes whose
+  corresponding page wasn't rendered to HTML show a tooltip instead
+  of opening a 404. No action needed — if you see the tooltip on
+  entity / concept / nav pages that's the new design.
+
+- **Backlinks now propagate.** Run `llmwiki backlinks` once to inject
+  managed `## Referenced by` sections into every linked-to page.
+  Idempotent, dry-runnable, prune-able:
+
+  ```bash
+  llmwiki backlinks --dry-run --verbose   # preview
+  llmwiki backlinks                       # commit writes
+  llmwiki backlinks --prune               # strip every block
+  ```
+
+### Schema migrations
+
+- `.llmwiki-state.json` keys rewrite from absolute paths to
+  `<adapter>::<home-relative-path>` on first load under rc3+. Migration
+  is automatic and idempotent. If you moved your repo to a new machine,
+  old state will be preserved verbatim — re-sync to reindex.
+
+- `.llmwiki-quarantine.json` is a new local file (gitignored). First
+  appears when a convert error happens. Inspect with
+  `llmwiki quarantine list`.
+
+- Frontmatter `tags:` / `topics:` convention is lint-enforced (rule
+  #14 `tags_topics_convention`) — projects use `topics:`, everything
+  else uses `tags:`. Run `llmwiki tag convention` to see violations.
+  `llmwiki tag rename <old> <new>` rewrites across every page.
+
+### Breaking — none
+
+No breaking CLI or config changes. Every test pre-upgrade keeps
+passing post-upgrade.
+
+## v1.1.0-rc3
+
+See the [release notes](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc3)
+for the full rc3 gap-sweep bundle. No migration required.
+
+## v1.0.0 → v1.1.0-rc1
+
+Config: `synthesis.backend` now accepts `"ollama"` in addition to the
+default `"dummy"`. See `docs/reference/prompt-caching.md` for the
+ollama setup.
+
+`wiki/candidates/` directory is new — created automatically by ingest
+when it sees a brand-new entity/concept. Triage with `/wiki-candidates`
+(renamed from `/wiki-review` in rc3).
+
+## Older versions
+
+Pre-v1.0 milestones shipped under internal sprint tags. Upgrade from
+v0.9.x to v1.0.0 in one step — no intermediate migration required. If
+you're on a pre-0.9 build, start fresh: `llmwiki init` in a new tree
+and re-run `sync`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,7 @@ searchable, interlinked, and offline. No database, no account, no cloud.
 
 ## Operate
 
+- **[Upgrade guide](UPGRADING.md)** — what changes between releases, migrations, opt-ins.
 - **[FAQ](faq.md)** · **[Troubleshooting](troubleshooting.md)** · **[Privacy](privacy.md)**.
 - **[Testing — visual regression](testing/visual-regression.md)**.
 - **[Accessibility](accessibility.md)** (WCAG 2.1 AA).

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.1.0rc3"
+__version__ = "1.1.0rc4"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llmwiki"
-version = "1.1.0rc3"
+version = "1.1.0rc4"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Release PR stamping v1.1.0-rc4. No behaviour changes here — the fixes that make up rc4 already landed via #332 and #334.

## Releases in rc4

| PR | Issue | What |
|---|---|---|
| [#332](https://github.com/Pratiyush/llm-wiki/pull/332) | [#331](https://github.com/Pratiyush/llm-wiki/issues/331) | Graph `site_url` resolver (99.7% → 0% dead clicks) + `llmwiki backlinks` CLI (95% → 0% orphans) + verify-before-fixing rule |
| [#334](https://github.com/Pratiyush/llm-wiki/pull/334) | [#270](https://github.com/Pratiyush/llm-wiki/issues/270) | Source-code + root-file link rewriter (471 → 100 broken internal links) |
| [#329](https://github.com/Pratiyush/llm-wiki/pull/329) | — | Codified docs+CHANGELOG rule |

Follow-up filed: **[#336](https://github.com/Pratiyush/llm-wiki/issues/336)** — session-local ref stripping for the remaining 100 broken (user-content refs).

## This PR

- `__version__` 1.1.0rc3 → 1.1.0rc4 in `llmwiki/__init__.py` + `pyproject.toml`
- README badge + version table row
- `docs/UPGRADING.md` — new upgrade guide (migrations, opt-ins, breaking changes per release)
- `docs/index.md` links to the upgrade guide under Operate
- `CHANGELOG.md` rc4 release boundary

## Test plan

- [x] `python3 -m pytest` — 2271 pass, 10 skip
- [x] `python3 -m llmwiki build && python3 -m llmwiki check-links` — 100 broken (down from 471)
- [x] `python3 -m llmwiki backlinks --dry-run --verbose` — shows real referrers
- [x] GPG-signed commit
- [ ] CI green