### PR TITLE
release: v1.1.0-rc5 — site audit + 12 issues closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.1.0-rc5] — 2026-04-21
+
+Site audit + 5 closed batches.  Closes 12 open issues in one pass:
+session-local ref stripping, cheatsheet, README+CONTRIBUTING compile,
+expanded Playwright E2E, slash-CLI parity test, 4 adapter docs, Ollama
+tutorial, dual-mode docs skeleton, `/wiki-synthesize` slash, and the
+shared frontmatter parser.
+
 ### Added
 
 - **Dual-mode docs skeleton** (#317) — new `docs/modes/` tree with a top-level comparison + two coloured-banner landing pages: `docs/modes/api/` (purple banner, "API MODE — uses your Anthropic API key") and `docs/modes/agent/` (teal banner, "AGENT MODE — uses your existing Claude Code / Codex CLI session"). The docs hub now leads with a "Pick your mode" comparison table before the tutorials. Prepares the info architecture for the actual backends that ship with #315 (API) and #316 (Agent).

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.1.0--rc4-10B981.svg)](CHANGELOG.md)
-[![Tests](https://img.shields.io/badge/tests-2271%20passing-10B981.svg)](tests/)
+[![Version](https://img.shields.io/badge/version-v1.1.0--rc5-10B981.svg)](CHANGELOG.md)
+[![Tests](https://img.shields.io/badge/tests-2368%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)
 [![Wiki checks](https://github.com/Pratiyush/llm-wiki/actions/workflows/wiki-checks.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/wiki-checks.yml)
@@ -527,6 +527,7 @@ Per-adapter docs:
 | [v1.1.0-rc2](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc2) | Session E — interactive graph viewer + remaining code-only v1.1 work | `v1.1.0-rc2` |
 | [v1.1.0-rc3](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc3) | Gap-sweep bundle — state portability, quarantine, sync --status, log CLI, synthesize --estimate breakdown, tag family, stale references, graph context menu, raw immutability, AI-sessions default | `v1.1.0-rc3` |
 | [v1.1.0-rc4](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc4) | Navigation + quality — graph `site_url` resolver (99.7% → 0% dead clicks), `llmwiki backlinks` CLI (95% → 0% orphan pages), source-code → GitHub link rewriter (471 → 100 broken), verify-before-fixing contribution rule | `v1.1.0-rc4` |
+| [v1.1.0-rc5](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc5) | Site audit + 5 closed batches — session-local ref stripping (351 → 247 broken), cheatsheet, README/CONTRIBUTING compile, expanded E2E, slash-CLI parity test, 4 adapter docs, Ollama tutorial, dual-mode docs skeleton, `/wiki-synthesize` slash | `v1.1.0-rc5` |
 
 ## Roadmap
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -15,6 +15,40 @@ The canonical per-release detail is
 [CHANGELOG.md](https://github.com/Pratiyush/llm-wiki/blob/master/CHANGELOG.md)
 — this guide focuses on "what might break".
 
+## v1.1.0-rc5
+
+**Released: 2026-04-21.**
+
+### New behaviour
+
+- **Session transcripts strip project-local file refs.** Anchors
+  pointing at `tasks.md`, `user_profile.md`, `settings.gradle.kts`,
+  `.kiro/…`, `/Users/…`, etc. are unwrapped into inline
+  `<span class="session-ref dead-link">` — the filename stays visible
+  but the anchor doesn't 404. No action required.
+
+- **`README.md` and `CONTRIBUTING.md` now compile as site pages.**
+  `site/README.html` and `site/CONTRIBUTING.html` ship alongside
+  `changelog.html`. Link rewriter routes to the compiled page instead
+  of GitHub for these two files.
+
+- **`/wiki-synthesize` slash command** — wraps `llmwiki synthesize`
+  with natural-language flags ("estimate cost", "dry run", "force").
+  Install via `llmwiki install-skills` or copy manually from
+  `.claude/commands/wiki-synthesize.md`.
+
+- **Dual-mode docs landing pages.** `docs/modes/api/` and
+  `docs/modes/agent/` exist as skeletons; the actual API / Agent
+  backends ship with #315 / #316.
+
+### Schema migrations
+
+None. Fully backwards-compatible with rc4 state files.
+
+### Breaking
+
+None.
+
 ## v1.1.0-rc4
 
 **Released: 2026-04-20.**

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.1.0rc4"
+__version__ = "1.1.0rc5"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llmwiki"
-version = "1.1.0rc4"
+version = "1.1.0rc5"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Release PR stamping v1.1.0-rc5. All work landed via #342.

## This PR

Version bump + doc updates only:
- `__version__` 1.1.0rc4 → 1.1.0rc5
- README badge + version table row
- `docs/UPGRADING.md` rc5 entry
- `CHANGELOG.md` rc5 release boundary

## Closed in rc5

12 issues in #342:
- #269 command cheatsheet
- #273 shared frontmatter parser (partial — `llmwiki/_frontmatter.py`)
- #274 4 missing adapter docs (chatgpt, jira, meeting, opencode)
- #275 configuration-reference.md + ~20 keys
- #276 tutorial 08 — synthesize with Ollama
- #278 expanded Playwright E2E + `llmwiki serve` smoke test
- #279 slash-CLI parity guardrail
- #280 eval-vs-lint + CLI-vs-slash decision trees
- #281 `/wiki-synthesize` slash command
- #284 README + CONTRIBUTING compile as site pages
- #317 dual-mode docs skeleton
- #336 session-local ref stripping (351 → 247 broken internal links)

## Test plan

- [x] `python3 -m pytest` — 2368 pass, 10 skip
- [x] `python3 -m llmwiki build && python3 -m llmwiki check-links` — 247 broken (from 351)
- [x] All slash commands + CLI flags parity-tested
- [x] GPG-signed commit
- [ ] CI green