### PR TITLE
release: v1.1.0-rc6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ Thumbs.db
 .claude/settings.local.json
 .claude/projects/
 .claude/cache/
+.claude/scheduled_tasks.lock
 .codex/sessions/
 .codex/cache/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.1.0-rc6] — 2026-04-21
+
+rc6 batch.  Closes 4 open issues: #346 (adapter tag fix), #282 (tutorial UX), #277 (palette indexes), #283 (md cache).
+
 ### Fixed
 
 - **Frontmatter `tags:` was hardcoded to `claude-code` for every adapter** (#346, reported by @fengguanghuai) — `render_session_markdown` emitted `tags: [claude-code, session-transcript]` regardless of which adapter (`claude_code`, `codex_cli`, `cursor`, `copilot-chat`, `gemini_cli`, `opencode`, `chatgpt`) produced the session.  Result: every session grouped under the Claude chip on the compiled site even when the user was on Codex or Cursor.  Fix: new `_adapter_tag()` helper normalises the registry name (`claude_code` → `claude-code`, `codex_cli` → `codex-cli`, `copilot-chat` → `copilot-chat`), and `render_session_markdown` now takes an `adapter_name` kwarg propagated from `convert_all`.  Back-compat default of `claude-code` for callers that don't pass the kwarg so no silent regression on existing tests.  22 new parametrized tests in `tests/test_adapter_tag.py`.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.1.0--rc5-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.1.0--rc6-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2368%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)
@@ -528,6 +528,7 @@ Per-adapter docs:
 | [v1.1.0-rc3](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc3) | Gap-sweep bundle — state portability, quarantine, sync --status, log CLI, synthesize --estimate breakdown, tag family, stale references, graph context menu, raw immutability, AI-sessions default | `v1.1.0-rc3` |
 | [v1.1.0-rc4](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc4) | Navigation + quality — graph `site_url` resolver (99.7% → 0% dead clicks), `llmwiki backlinks` CLI (95% → 0% orphan pages), source-code → GitHub link rewriter (471 → 100 broken), verify-before-fixing contribution rule | `v1.1.0-rc4` |
 | [v1.1.0-rc5](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc5) | Site audit + 5 closed batches — session-local ref stripping (351 → 247 broken), cheatsheet, README/CONTRIBUTING compile, expanded E2E, slash-CLI parity test, 4 adapter docs, Ollama tutorial, dual-mode docs skeleton, `/wiki-synthesize` slash | `v1.1.0-rc5` |
+| [v1.1.0-rc6](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc6) | rc6 batch — fixed adapter tag hardcoded to `claude-code` for every adapter (#346), tutorial UX polish with in-page TOC + prev/next + edit-on-GitHub (#282), command palette now indexes 107 doc pages + 17 slash commands (#277), content-hash cache for `md_to_html` (#283) | `v1.1.0-rc6` |
 
 ## Roadmap
 

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.1.0rc5"
+__version__ = "1.1.0rc6"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llmwiki"
-version = "1.1.0rc5"
+version = "1.1.0rc6"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Bumps version 1.1.0rc5 → 1.1.0rc6 for the rc6 release.  PR #347 already shipped the code; this PR only updates the version markers + moves the CHANGELOG `[Unreleased]` block into `[1.1.0-rc6] — 2026-04-21`.

## Bundle

- `llmwiki/__init__.py` — `__version__ = "1.1.0rc6"`
- `pyproject.toml` — `version = "1.1.0rc6"`
- `README.md` — badge + version table row
- `CHANGELOG.md` — close the `[Unreleased]` section
- `.gitignore` — hide `.claude/scheduled_tasks.lock` (runtime artifact)

## Issues closed in rc6 (via #347)

- #346 · adapter tag hardcoded to `claude-code`
- #282 · tutorial UX polish (TOC + prev/next + edit-on-GitHub)
- #277 · command palette indexes 107 doc pages + 17 slash commands
- #283 · content-hash cache for `md_to_html`

## Test plan

- [x] `pytest --ignore=tests/e2e` — 2427 pass, 10 skip
- [x] All 4 rc6 test files green (77 tests)
- [x] Version strings in sync across `__init__.py`, `pyproject.toml`, README badge + table
- [x] CHANGELOG `[1.1.0-rc6]` dated 2026-04-21

## Next

After merge: sign `v1.1.0-rc6` tag, push, publish GitHub Release with the CHANGELOG section, close issues.