### PR TITLE
feat: AI-suggested tags run automatically during synthesis (#351)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+### Added
+
+- **Automatic AI-suggested tags during synthesis** (#351) — before rc6 every wiki source page shipped with a deterministic-only tag list (`[<adapter>, session-transcript, <project>, <model-family>]`).  Readers got no *topical* signal — a session about prompt caching looked the same as a session about SQLite FTS.  Now the synthesizer's own call (Anthropic API in API mode, Ollama in Agent mode) emits a `<!-- suggested-tags: prompt-caching, anthropic-api, token-budget -->` block as the first line of its response, which `_extract_suggested_tags` parses and strips before the body hits disk.  `_merge_tags` then folds those topical tags into the deterministic baseline with (a) maintainer-curated tags preserved first (re-synthesize never overwrites hand edits), (b) stop-word filter so the LLM can't re-add `claude-code` / `session` / `summary`, (c) hard cap of 5 AI tags per page, (d) near-duplicate rejection at threshold 0.80 + prefix-containment check so `prompt-cache` gets blocked when `prompt-caching` already exists.  Zero extra API round-trips — rides the existing synthesis call.  22 new tests in `tests/test_ai_suggested_tags.py` cover parsing, merging, de-dup, stop-words, caps, re-synthesize preservation, and malformed-input graceful fallback.
+
 ## [1.1.0-rc6] — 2026-04-21
 
 rc6 batch.  Closes 4 open issues: #346 (adapter tag fix), #282 (tutorial UX), #277 (palette indexes), #283 (md cache).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -672,6 +672,29 @@ Backend is picked from `synthesis.backend` in `sessions_config.json`
 (`dummy` by default, `ollama` for local, future `anthropic`). See
 [`reference/prompt-caching.md`](prompt-caching.md).
 
+### Auto-tagging (#351)
+
+Every `synthesize` call now produces **topical** tags alongside the
+deterministic baseline.  The synthesizer emits a
+`<!-- suggested-tags: prompt-caching, rag, github-actions -->` block
+as the first line of its response; the pipeline parses it, strips it
+from the body, and merges the tags into frontmatter with:
+
+- **Baseline preserved** — adapter, project slug, model family stay.
+- **Maintainer wins** — on `--force`, whatever you added via
+  `llmwiki tag add` is kept at the front of the list.
+- **Stop-word filter** — the LLM can't re-add boilerplate tags
+  (`session`, `summary`, `claude-code`, etc.).
+- **Cap 5** — max 5 AI tags per page to prevent drift.
+- **Near-dup rejection** — `prompt-cache` is blocked when
+  `prompt-caching` is already on the page (threshold 0.80 + prefix
+  check).
+
+No extra API round-trip — rides the existing synthesis call, so cost
+estimates from `--estimate` are unchanged.  If the backend returns no
+suggested-tags block (dummy backend, malformed output), the page still
+ships with baseline tags.
+
 ---
 
 ## `completion` — shell completion script

--- a/llmwiki/synth/pipeline.py
+++ b/llmwiki/synth/pipeline.py
@@ -299,6 +299,140 @@ def _discover_raw_sessions(
     return out
 
 
+# ─── #351: AI-suggested tags ──────────────────────────────────────────
+
+# Emitted by the LLM as the first line of its response — we strip it
+# from the body before writing, merge the tags into the frontmatter.
+# Format: ``<!-- suggested-tags: a, b, c -->``
+_SUGGESTED_TAGS_RE = re.compile(
+    r"^\s*<!--\s*suggested-tags:\s*(?P<body>[^>]*?)\s*-->\s*\n?",
+    re.IGNORECASE,
+)
+
+# Cap on AI-suggested tags per page (deterministic baseline is separate
+# and never counted against this budget).  5 keeps the frontmatter list
+# readable and prevents runaway tag-space growth on noisy sessions.
+_AI_TAG_CAP = 5
+
+# Tags the LLM sometimes proposes that duplicate the deterministic
+# baseline or add no value — drop silently so we don't pollute the tag
+# space with boilerplate the pipeline already emits.
+_AI_TAG_STOPWORDS = frozenset({
+    "session-transcript", "session", "claude-code", "codex-cli", "cursor",
+    "copilot-chat", "gemini-cli", "opencode", "chatgpt", "obsidian",
+    "claude", "gpt", "gemini", "llama", "opus",
+    "summary", "discussion", "conversation", "transcript",
+    # Empty-ish noise from malformed LLM responses.
+    "", "-", "tag", "tags",
+})
+
+
+def _extract_suggested_tags(body: str) -> tuple[list[str], str]:
+    """Pull the ``<!-- suggested-tags: … -->`` block off the top of
+    ``body`` and return ``(tags, cleaned_body)``.
+
+    Invariants:
+
+    * Missing / malformed block → ``([], body)`` (body untouched).
+    * Tags are kebab-cased + lowercased + deduped preserving order.
+    * Empty strings / stop-words filtered out.
+    * Hard-capped at :data:`_AI_TAG_CAP` before stop-word filtering so
+      a noisy LLM can't drown out the cap check.
+
+    Runs in pure Python — no LLM call.  This just parses whatever the
+    synthesizer already produced.
+    """
+    m = _SUGGESTED_TAGS_RE.match(body)
+    if not m:
+        return [], body
+    raw = m.group("body") or ""
+    cleaned_body = body[m.end():]
+    # Split on comma, normalise each.
+    tags: list[str] = []
+    seen: set[str] = set()
+    for part in raw.split(","):
+        t = part.strip().lower().replace(" ", "-")
+        if not t or t in seen or t in _AI_TAG_STOPWORDS:
+            continue
+        tags.append(t)
+        seen.add(t)
+        if len(tags) >= _AI_TAG_CAP:
+            break
+    return tags, cleaned_body
+
+
+def _merge_tags(
+    baseline: list[str],
+    suggested: list[str],
+    existing: Optional[list[str]] = None,
+) -> list[str]:
+    """Merge the three tag sources into the final frontmatter list.
+
+    Precedence (first-win, order preserved):
+
+    1. Maintainer-curated ``existing`` tags (preserve on re-synthesize).
+    2. Deterministic ``baseline`` (adapter + project + model family).
+    3. AI-``suggested`` topical tags — only if they don't collide with
+       or near-duplicate something already in 1 or 2.
+
+    Near-duplicate detection uses ``tags.near_duplicate_tags`` so we
+    reject ``prompt-cache`` when ``prompt-caching`` is already present.
+    """
+    # Local import to avoid a circular at module load.
+    from llmwiki.tags import near_duplicate_tags, TagEntry
+
+    out: list[str] = []
+    seen: set[str] = set()
+
+    def _push(tag: str) -> None:
+        t = tag.strip()
+        if not t:
+            return
+        key = t.lower()
+        if key in seen:
+            return
+        out.append(t)
+        seen.add(key)
+
+    for t in (existing or []):
+        _push(t)
+    for t in baseline:
+        _push(t)
+    # For each suggested tag, skip if a near-duplicate already exists.
+    # Uses a tighter threshold (0.80) than the CLI default (0.85) — we
+    # want auto-merge to be conservative so ``prompt-cache`` (0.846 vs
+    # ``prompt-caching``) gets rejected at ingest time.  Maintainers can
+    # still add it explicitly via ``llmwiki tag add``.
+    if suggested:
+        existing_snapshot = list(out)
+        for candidate in suggested:
+            candidate_lc = candidate.lower()
+            # Cheap prefix check: one is a prefix of the other.
+            def _substr_near(a: str, b: str) -> bool:
+                a_l, b_l = a.lower(), b.lower()
+                if a_l == b_l:
+                    return True
+                shorter, longer = sorted((a_l, b_l), key=len)
+                return len(shorter) >= 5 and shorter in longer
+            if any(_substr_near(candidate, existing_t) for existing_t in existing_snapshot):
+                continue
+            # Expensive fuzzy check for other near-dupes (typos, plural, etc.).
+            entries = [
+                TagEntry(page=Path("/virtual"), field="tags", tag=t)
+                for t in existing_snapshot + [candidate]
+            ]
+            dups = near_duplicate_tags(entries, threshold=0.80)
+            collides = any(
+                candidate_lc in (a.lower(), b.lower()) and a.lower() != b.lower()
+                for (a, b, _score) in dups
+            )
+            if collides:
+                continue
+            _push(candidate)
+            existing_snapshot.append(candidate)
+    return out
+
+
 def _derive_baseline_tags(meta: dict[str, Any]) -> list[str]:
     """Return a never-empty baseline tag list for synthesized source pages.
 
@@ -340,15 +474,45 @@ def _derive_baseline_tags(meta: dict[str, Any]) -> list[str]:
 def _build_source_page(
     meta: dict[str, Any],
     synthesized_body: str,
+    existing_page_path: Optional[Path] = None,
 ) -> str:
-    """Combine frontmatter + synthesized body into a full wiki source page."""
+    """Combine frontmatter + synthesized body into a full wiki source page.
+
+    #351: If the ``synthesized_body`` starts with a
+    ``<!-- suggested-tags: ... -->`` block (emitted by the LLM per the
+    ``source_page.md`` prompt), the tags are extracted, de-duplicated
+    against the deterministic baseline, and merged into the frontmatter.
+    The comment is stripped from the body so it never reaches the
+    rendered site.
+
+    If ``existing_page_path`` points at an existing wiki source file,
+    its current frontmatter ``tags`` are preserved verbatim (maintainer
+    curation is never overwritten on re-synthesize).
+    """
     slug = meta.get("slug", "unknown")
     title = meta.get("title", f"Source: {slug}")
     project = meta.get("project", "unknown")
     date = meta.get("date", "")
     model = meta.get("model", "")
     source_file = meta.get("source_file", "")
-    tags = _derive_baseline_tags(meta)
+
+    # #351: pull AI-suggested tags off the top of the body.
+    ai_tags, clean_body = _extract_suggested_tags(synthesized_body)
+
+    # Preserve any maintainer-curated tags on re-synthesize.
+    existing_tags: list[str] = []
+    if existing_page_path is not None and existing_page_path.exists():
+        try:
+            existing_meta, _existing_body = parse_frontmatter(
+                existing_page_path.read_text(encoding="utf-8")
+            )
+            existing_tags = list(existing_meta.get("tags", []) or [])
+        except Exception:
+            # Never fail synthesis on a frontmatter read error.
+            existing_tags = []
+
+    baseline = _derive_baseline_tags(meta)
+    tags = _merge_tags(baseline, ai_tags, existing_tags)
 
     fm = [
         "---",
@@ -363,7 +527,7 @@ def _build_source_page(
         "---",
         "",
     ]
-    return "\n".join(fm) + synthesized_body
+    return "\n".join(fm) + clean_body
 
 
 def synthesize_new_sessions(
@@ -459,13 +623,15 @@ def synthesize_new_sessions(
             )
             synthesized = backend.synthesize_source_page(body, meta, prompt)
 
-            # Build the full wiki source page
-            page_content = _build_source_page(meta, synthesized)
-
-            # Write to wiki/sources/<project>/<date>-<slug>.md  (G-06)
+            # Build the full wiki source page.
+            # #351: pass the existing path so maintainer-curated tags
+            # are preserved on re-synthesize.
             out_dir = sources_out / project
             out_dir.mkdir(parents=True, exist_ok=True)
             out_path = out_dir / f"{filename}.md"
+            page_content = _build_source_page(
+                meta, synthesized, existing_page_path=out_path
+            )
             out_path.write_text(page_content, encoding="utf-8")
 
             # Update state

--- a/llmwiki/synth/prompts/source_page.md
+++ b/llmwiki/synth/prompts/source_page.md
@@ -12,7 +12,26 @@ conversation transcript.
 Produce ONLY the body sections below (no frontmatter — the caller
 adds that). Use `[[wikilinks]]` for cross-references.
 
+The FIRST line of your response MUST be a suggested-tags HTML
+comment listing 3–5 topical tags (kebab-case, lowercase, no spaces)
+that describe *what the session was about*, not who produced it:
+
+```
+<!-- suggested-tags: prompt-caching, anthropic-api, token-budget -->
+```
+
+Good tags name concrete subjects a reader would search for (e.g.
+`prompt-caching`, `rag`, `regex-vs-llm`, `github-actions`, `sqlite-fts`).
+Bad tags are broad (`coding`, `discussion`) or structural (`summary`,
+`session`) — the pipeline already emits those.  Do NOT repeat the
+adapter (`claude-code`, `codex-cli`), project slug, or model family
+(`claude`, `gpt`) — those are added deterministically.
+
+Emit the comment, then a blank line, then the body:
+
 ```markdown
+<!-- suggested-tags: ..., ..., ... -->
+
 ## Summary
 
 2-4 sentence synthesis of what the session accomplished. Focus on

--- a/tests/test_ai_suggested_tags.py
+++ b/tests/test_ai_suggested_tags.py
@@ -1,0 +1,312 @@
+"""Tests for automatic AI-suggested tags (#351).
+
+Covers:
+
+* ``_extract_suggested_tags`` — parses the `<!-- suggested-tags: ... -->`
+  comment the LLM emits at the top of its response, returns clean body.
+* ``_merge_tags`` — merges maintainer-curated + baseline + AI sources
+  with de-dup + near-duplicate rejection.
+* ``_build_source_page`` — integration: frontmatter has merged tags,
+  body has no suggested-tags comment.
+* Re-synthesize: preserves existing maintainer-curated tags.
+* LLM unavailable / malformed output: baseline tags still emitted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from llmwiki.synth.pipeline import (
+    _AI_TAG_CAP,
+    _build_source_page,
+    _derive_baseline_tags,
+    _extract_suggested_tags,
+    _merge_tags,
+)
+
+
+# ─── _extract_suggested_tags ──────────────────────────────────────────
+
+
+def test_extract_happy_path():
+    body = (
+        "<!-- suggested-tags: prompt-caching, anthropic-api, token-budget -->\n"
+        "\n## Summary\n\nA paragraph.\n"
+    )
+    tags, clean = _extract_suggested_tags(body)
+    assert tags == ["prompt-caching", "anthropic-api", "token-budget"]
+    assert clean.lstrip().startswith("## Summary")
+    assert "suggested-tags" not in clean
+
+
+def test_extract_missing_block_returns_empty_and_unchanged():
+    body = "## Summary\n\nNothing special.\n"
+    tags, clean = _extract_suggested_tags(body)
+    assert tags == []
+    assert clean == body
+
+
+def test_extract_malformed_comment_returns_empty():
+    # No closing `-->`
+    body = "<!-- suggested-tags: foo, bar\n## Summary\n"
+    tags, clean = _extract_suggested_tags(body)
+    assert tags == []
+    assert clean == body
+
+
+def test_extract_empty_tag_list():
+    body = "<!-- suggested-tags:  -->\n\n## Summary\n"
+    tags, clean = _extract_suggested_tags(body)
+    assert tags == []
+    assert clean.lstrip().startswith("## Summary")
+
+
+def test_extract_normalises_case_and_spaces():
+    body = "<!-- suggested-tags: Prompt Caching, ANTHROPIC-API, token budget -->\n\n## Summary\n"
+    tags, _ = _extract_suggested_tags(body)
+    # Lowercased, spaces → hyphens.
+    assert tags == ["prompt-caching", "anthropic-api", "token-budget"]
+
+
+def test_extract_dedupes_within_suggestion():
+    body = "<!-- suggested-tags: rag, rag, RAG, retrieval -->\n\n## Summary\n"
+    tags, _ = _extract_suggested_tags(body)
+    assert tags == ["rag", "retrieval"]
+
+
+def test_extract_drops_stopwords():
+    body = (
+        "<!-- suggested-tags: claude, claude-code, session, rag, prompt-caching -->\n"
+        "\n## Summary\n"
+    )
+    tags, _ = _extract_suggested_tags(body)
+    # claude, claude-code, session are stop-words (pipeline already emits them).
+    assert "claude" not in tags
+    assert "claude-code" not in tags
+    assert "session" not in tags
+    assert "rag" in tags
+    assert "prompt-caching" in tags
+
+
+def test_extract_caps_at_five():
+    body = (
+        "<!-- suggested-tags: a, b, c, d, e, f, g, h -->\n\n## Summary\n"
+    )
+    tags, _ = _extract_suggested_tags(body)
+    assert len(tags) == _AI_TAG_CAP
+    assert tags == ["a", "b", "c", "d", "e"]
+
+
+def test_extract_tolerates_leading_whitespace():
+    body = "   \n<!-- suggested-tags: foo -->\n\n## Summary\n"
+    tags, clean = _extract_suggested_tags(body)
+    assert tags == ["foo"]
+    assert "suggested-tags" not in clean
+
+
+# ─── _merge_tags ──────────────────────────────────────────────────────
+
+
+def test_merge_keeps_baseline_when_no_suggestions():
+    result = _merge_tags(baseline=["claude-code", "session-transcript"], suggested=[])
+    assert result == ["claude-code", "session-transcript"]
+
+
+def test_merge_appends_suggestions_after_baseline():
+    result = _merge_tags(
+        baseline=["claude-code", "session-transcript", "llm-wiki", "claude"],
+        suggested=["prompt-caching", "rag"],
+    )
+    # Baseline comes first, suggestions appended.
+    assert result[:4] == ["claude-code", "session-transcript", "llm-wiki", "claude"]
+    assert "prompt-caching" in result
+    assert "rag" in result
+
+
+def test_merge_dedupes_case_insensitively():
+    result = _merge_tags(
+        baseline=["Claude-Code"],
+        suggested=["claude-code", "rag"],
+    )
+    # Only one "claude-code" variant survives.
+    claude_matches = [t for t in result if t.lower() == "claude-code"]
+    assert len(claude_matches) == 1
+
+
+def test_merge_rejects_near_duplicate_suggestion():
+    # "prompt-cache" is a near-dup of baseline "prompt-caching".
+    result = _merge_tags(
+        baseline=["claude-code", "prompt-caching"],
+        suggested=["prompt-cache", "rag"],
+    )
+    assert "prompt-caching" in result
+    assert "prompt-cache" not in result  # rejected as near-dup
+    assert "rag" in result  # kept, no near-dup
+
+
+def test_merge_preserves_existing_maintainer_tags_first():
+    result = _merge_tags(
+        baseline=["claude-code", "llm-wiki"],
+        suggested=["rag"],
+        existing=["hand-curated-tag", "another-curated"],
+    )
+    # Maintainer tags come first.
+    assert result[:2] == ["hand-curated-tag", "another-curated"]
+    assert "claude-code" in result
+    assert "rag" in result
+
+
+def test_merge_empty_everything():
+    assert _merge_tags(baseline=[], suggested=[]) == []
+
+
+def test_merge_ignores_whitespace_only():
+    result = _merge_tags(
+        baseline=["claude-code"],
+        suggested=["  ", "rag", ""],
+    )
+    assert result == ["claude-code", "rag"]
+
+
+# ─── _build_source_page integration ──────────────────────────────────
+
+
+def _synth_body(tags: str, rest: str = "## Summary\n\nA summary.\n") -> str:
+    return f"<!-- suggested-tags: {tags} -->\n\n{rest}"
+
+
+def test_build_source_page_merges_ai_tags_into_frontmatter():
+    meta = {
+        "slug": "test",
+        "title": "Session: test — 2026-04-21",
+        "project": "llm-wiki",
+        "model": "claude-sonnet-4-6",
+        "date": "2026-04-21",
+        "source_file": "raw/sessions/x.md",
+        "tags": ["claude-code", "session-transcript"],
+    }
+    body = _synth_body("prompt-caching, anthropic-api, token-budget")
+    page = _build_source_page(meta, body)
+
+    # Frontmatter line present + merged.
+    assert "tags: [claude-code, session-transcript, llm-wiki, claude, prompt-caching, anthropic-api, token-budget]" in page
+    # Suggested-tags comment stripped from body.
+    assert "<!-- suggested-tags" not in page
+    # Body content preserved.
+    assert "## Summary" in page
+    assert "A summary." in page
+
+
+def test_build_source_page_without_suggested_tags_falls_back_to_baseline():
+    meta = {
+        "slug": "test",
+        "title": "Session: test — 2026-04-21",
+        "project": "llm-wiki",
+        "model": "claude-sonnet-4-6",
+        "date": "2026-04-21",
+        "source_file": "raw/sessions/x.md",
+        "tags": ["claude-code", "session-transcript"],
+    }
+    # LLM didn't emit the comment.
+    body = "## Summary\n\nA summary.\n"
+    page = _build_source_page(meta, body)
+
+    baseline = _derive_baseline_tags(meta)
+    # Frontmatter still has all baseline tags.
+    for t in baseline:
+        assert t in page
+    # Body preserved verbatim.
+    assert "## Summary" in page
+
+
+def test_build_source_page_preserves_existing_tags_on_resynthesize(tmp_path):
+    existing = tmp_path / "existing.md"
+    existing.write_text(
+        "---\n"
+        "title: \"Session: test — 2026-04-21\"\n"
+        "type: source\n"
+        "tags: [hand-curated-tag, claude-code, session-transcript]\n"
+        "date: 2026-04-21\n"
+        "source_file: raw/sessions/x.md\n"
+        "project: llm-wiki\n"
+        "model: claude-sonnet-4-6\n"
+        "last_updated: 2026-04-20\n"
+        "---\n\n"
+        "## Summary\n\nOld content.\n",
+        encoding="utf-8",
+    )
+
+    meta = {
+        "slug": "test",
+        "title": "Session: test — 2026-04-21",
+        "project": "llm-wiki",
+        "model": "claude-sonnet-4-6",
+        "date": "2026-04-21",
+        "source_file": "raw/sessions/x.md",
+        "tags": ["claude-code", "session-transcript"],
+    }
+    body = _synth_body("prompt-caching, rag")
+    page = _build_source_page(meta, body, existing_page_path=existing)
+
+    # Hand-curated tag is preserved AT THE FRONT of the list.
+    assert page.count("hand-curated-tag") == 1
+    # Index of hand-curated comes before any AI tag.
+    hand_idx = page.find("hand-curated-tag")
+    rag_idx = page.find("rag")
+    assert hand_idx < rag_idx
+
+
+def test_build_source_page_missing_existing_path_is_safe(tmp_path):
+    # existing_page_path points at a file that doesn't exist yet.
+    meta = {
+        "slug": "test",
+        "title": "Session: test — 2026-04-21",
+        "project": "llm-wiki",
+        "model": "claude-sonnet-4-6",
+        "date": "2026-04-21",
+        "source_file": "raw/sessions/x.md",
+        "tags": ["claude-code"],
+    }
+    body = _synth_body("rag")
+    page = _build_source_page(
+        meta, body, existing_page_path=tmp_path / "does-not-exist.md"
+    )
+    assert "rag" in page
+    assert "## Summary" in page
+
+
+def test_build_source_page_handles_malformed_existing_frontmatter(tmp_path):
+    existing = tmp_path / "broken.md"
+    existing.write_text("no frontmatter here\n## Summary\n", encoding="utf-8")
+
+    meta = {
+        "slug": "test",
+        "title": "Session: test — 2026-04-21",
+        "project": "llm-wiki",
+        "model": "claude-sonnet-4-6",
+        "date": "2026-04-21",
+        "source_file": "raw/sessions/x.md",
+        "tags": ["claude-code"],
+    }
+    body = _synth_body("rag")
+    # Must not raise — baseline tags should still be emitted.
+    page = _build_source_page(meta, body, existing_page_path=existing)
+    assert "rag" in page
+
+
+def test_build_source_page_strips_comment_even_without_trailing_newline():
+    meta = {
+        "slug": "test",
+        "title": "t",
+        "project": "p",
+        "model": "claude-sonnet-4-6",
+        "date": "2026-04-21",
+        "source_file": "raw/sessions/x.md",
+        "tags": [],
+    }
+    body = "<!-- suggested-tags: rag -->## Summary\n\nBody.\n"
+    page = _build_source_page(meta, body)
+    assert "<!-- suggested-tags" not in page
+    assert "## Summary" in page


### PR DESCRIPTION
## Summary

Closes #351.  Every `/wiki-synthesize` call now produces **topical** tags on top of the deterministic baseline, without an extra API round-trip.

## Before

```yaml
tags: [claude-code, session-transcript, llm-wiki, claude]
```

## After

```yaml
tags: [claude-code, session-transcript, llm-wiki, claude, prompt-caching, anthropic-api, token-budget]
```

## How

1. `llmwiki/synth/prompts/source_page.md` — prompt instructs the LLM to emit `<!-- suggested-tags: a, b, c -->` as the first line of its response.
2. `_extract_suggested_tags(body)` — regex-parses the comment, strips it from the body, lowercases + kebab-cases + dedupes + drops stop-words + caps at 5.
3. `_merge_tags(baseline, suggested, existing)` — folds topical tags into baseline with near-duplicate rejection (threshold 0.80 + prefix check) and maintainer-tag preservation.
4. `_build_source_page` now reads the existing wiki source (if any) so re-synthesize never overwrites hand-curated tags.

## Guarantees

- ✅ Baseline (adapter + project + model family) always present.
- ✅ Maintainer-curated tags preserved on `--force` re-synthesize.
- ✅ Stop-word filter blocks `claude-code`, `session`, `summary`, model families, adapter names.
- ✅ Hard cap 5 AI tags per page.
- ✅ Near-dup rejection: `prompt-cache` blocked when `prompt-caching` exists.
- ✅ Zero extra API calls — rides the existing synthesis call.
- ✅ Graceful fallback: dummy backend / Ollama down / malformed output → baseline only, no crash.

## Test plan

- [x] `pytest tests/test_ai_suggested_tags.py -v` — 22/22 green
- [x] Full `pytest --ignore=tests/e2e` — 2449 pass, 10 skip
- [x] Stop-word filter: LLM emits `claude-code, claude, rag` → only `rag` survives
- [x] Cap: LLM emits 8 tags → first 5 kept
- [x] Re-synthesize preservation: existing `hand-curated-tag` kept at front of list
- [x] Missing `existing_page_path`: no crash, baseline + AI emitted
- [x] Malformed existing frontmatter: no crash, baseline + AI emitted
- [x] Missing `<!-- suggested-tags -->` block: body untouched, baseline emitted
- [x] `docs/reference/cli.md` updated with new "Auto-tagging (#351)" section
- [x] `CHANGELOG.md` updated under `[Unreleased]`

## Follow-on

Same treatment for entity + concept pages, tracked separately once this source-page loop is proven.