### PR TITLE
release: v1.1.0-rc7 — AI auto-tags + link-check config fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.1.0-rc7] — 2026-04-21
+
+rc7 batch.  Closes 4 issues: #351 (AI auto-tags), #348/#350/#353 (recurring broken-link reports).
+
+### Fixed
+
+- **Recurring broken-link reports** (#348, #350, #353) — the `lychee` workflow kept opening the same "Broken external links detected" issue every Sunday because two URLs always failed on CI runners: (a) `https://github.com/Pratiyush/llm-wiki/settings/environments` is auth-gated (admin only), and (b) `docs/index.md` pointed at `../changelog.html` which only exists inside the compiled `site/`, not at repo root where lychee resolves relative links.  Fix: added `^https://github\.com/Pratiyush/llm-wiki/settings` to `lychee.toml`'s exclude list, and repointed the `docs/index.md` changelog link at the canonical `CHANGELOG.md` on master (stopped bitrotting the "latest release" text too — was frozen at rc2, now rc6).
+
 ### Added
 
 - **Automatic AI-suggested tags during synthesis** (#351) — before rc6 every wiki source page shipped with a deterministic-only tag list (`[<adapter>, session-transcript, <project>, <model-family>]`).  Readers got no *topical* signal — a session about prompt caching looked the same as a session about SQLite FTS.  Now the synthesizer's own call (Anthropic API in API mode, Ollama in Agent mode) emits a `<!-- suggested-tags: prompt-caching, anthropic-api, token-budget -->` block as the first line of its response, which `_extract_suggested_tags` parses and strips before the body hits disk.  `_merge_tags` then folds those topical tags into the deterministic baseline with (a) maintainer-curated tags preserved first (re-synthesize never overwrites hand edits), (b) stop-word filter so the LLM can't re-add `claude-code` / `session` / `summary`, (c) hard cap of 5 AI tags per page, (d) near-duplicate rejection at threshold 0.80 + prefix-containment check so `prompt-cache` gets blocked when `prompt-caching` already exists.  Zero extra API round-trips — rides the existing synthesis call.  22 new tests in `tests/test_ai_suggested_tags.py` cover parsing, merging, de-dup, stop-words, caps, re-synthesize preservation, and malformed-input graceful fallback.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.1.0--rc6-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.1.0--rc7-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2368%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)
@@ -529,6 +529,7 @@ Per-adapter docs:
 | [v1.1.0-rc4](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc4) | Navigation + quality — graph `site_url` resolver (99.7% → 0% dead clicks), `llmwiki backlinks` CLI (95% → 0% orphan pages), source-code → GitHub link rewriter (471 → 100 broken), verify-before-fixing contribution rule | `v1.1.0-rc4` |
 | [v1.1.0-rc5](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc5) | Site audit + 5 closed batches — session-local ref stripping (351 → 247 broken), cheatsheet, README/CONTRIBUTING compile, expanded E2E, slash-CLI parity test, 4 adapter docs, Ollama tutorial, dual-mode docs skeleton, `/wiki-synthesize` slash | `v1.1.0-rc5` |
 | [v1.1.0-rc6](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc6) | rc6 batch — fixed adapter tag hardcoded to `claude-code` for every adapter (#346), tutorial UX polish with in-page TOC + prev/next + edit-on-GitHub (#282), command palette now indexes 107 doc pages + 17 slash commands (#277), content-hash cache for `md_to_html` (#283) | `v1.1.0-rc6` |
+| [v1.1.0-rc7](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc7) | rc7 batch — automatic AI-suggested tags during synthesis (#351), link-checker config fix (#348, #350, #353) | `v1.1.0-rc7` |
 
 ## Roadmap
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,5 +113,5 @@ out of the way. The only third-party runtime dependency is `markdown`.
 
 ## What's new
 
-See the **[changelog](../changelog.html)**. Latest tagged release:
-[v1.1.0-rc2](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc2).
+See the **[CHANGELOG](https://github.com/Pratiyush/llm-wiki/blob/master/CHANGELOG.md)**. Latest tagged release:
+[v1.1.0-rc6](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc6).

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.1.0rc6"
+__version__ = "1.1.0rc7"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -41,6 +41,9 @@ exclude = [
   "^https://pypi\\.org/project/llmwiki/",
   # Homebrew tap (pre-creation)
   "^https://github\\.com/Pratiyush/homebrew-llmwiki",
+  # Repo settings URLs (auth-gated, only visible to admins — CI runner
+  # can't authenticate so every settings link 404s)
+  "^https://github\\.com/Pratiyush/llm-wiki/settings",
   # Localhost references in docs
   "^http://127\\.0\\.0\\.1",
   "^http://localhost",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llmwiki"
-version = "1.1.0rc6"
+version = "1.1.0rc7"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Bumps version 1.1.0rc6 → 1.1.0rc7 and closes 3 recurring broken-link issues.

## Issues closed

| # | Kind | Description |
|---|---|---|
| [#351](https://github.com/Pratiyush/llm-wiki/issues/351) | feat | Automatic AI-suggested tags during synthesis (already merged on master) |
| [#348](https://github.com/Pratiyush/llm-wiki/issues/348), [#350](https://github.com/Pratiyush/llm-wiki/issues/350), [#353](https://github.com/Pratiyush/llm-wiki/issues/353) | fix | Recurring lychee "broken external links" reports |

## What was broken

The lychee workflow opened the same tracking issue every Sunday because two URLs always failed on CI runners:

1. `https://github.com/Pratiyush/llm-wiki/settings/environments` — auth-gated (admin only). CI runner has no auth → 404.
2. `docs/index.md` linked to `../changelog.html` — that path only resolves inside the compiled `site/`, not at repo root where lychee walks. → file-not-found.

## The fix

- `lychee.toml` gained `^https://github\.com/Pratiyush/llm-wiki/settings` to the exclude list.
- `docs/index.md` now links to the canonical GitHub-rendered `CHANGELOG.md`, which always works and never 404s.
- While I was in there, bumped the stale "Latest tagged release: v1.1.0-rc2" text to v1.1.0-rc6.

## Bundle

- `llmwiki/__init__.py` — `__version__ = "1.1.0rc7"`
- `pyproject.toml` — `version = "1.1.0rc7"`
- `README.md` — badge + version table row
- `CHANGELOG.md` — `[1.1.0-rc7]` — 2026-04-21 with Fixed + Added sections
- `docs/index.md` — changelog link + latest-release ref
- `lychee.toml` — exclude settings URLs

## Test plan

- [x] `pytest --ignore=tests/e2e` — 2449 pass, 10 skip
- [x] Version strings in sync across `__init__.py`, `pyproject.toml`, README badge + table
- [x] CHANGELOG `[1.1.0-rc7]` dated 2026-04-21
- [x] `lychee.toml` regex is valid
- [x] No other `changelog.html` references remain in `docs/`

## Next

After merge: sign `v1.1.0-rc7` tag, push, publish GitHub Release, close the 4 referenced issues.