### PR TITLE
feat: Mode B agent-delegate synthesis backend (#316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+### Added
+
+- **Mode B agent-delegate synthesis backend** (#316) — a new `agent` value for `synthesis.backend` in `sessions_config.json` that defers the LLM call to the user's running Claude Code / Codex CLI session instead of making an HTTP API call.  The backend (`llmwiki/synth/agent_delegate.py`) writes the rendered prompt to `.llmwiki-pending-prompts/<uuid>.md` and returns a placeholder page whose first line is the machine-readable sentinel `<!-- llmwiki-pending: <uuid> -->`.  The slash-command layer reads pending prompts on the next agent turn, synthesizes the content inside the existing session, and calls `complete_pending(uuid, body, page)` to rewrite the placeholder in place.  Zero incremental API cost (piggybacks on the agent subscription).  Zero bytes of session content leave the laptop.  Works when `ANTHROPIC_API_KEY` is unset.  `is_available()` auto-detects the agent runtime via `LLMWIKI_AGENT_MODE` / `CLAUDE_CODE` / `CODEX_CLI` / `CURSOR_AGENT` env vars; returns `False` outside an agent so the pipeline falls back to `dummy` instead of silently producing placeholders forever.  29 tests in `tests/test_agent_delegate.py` cover runtime detection, prompt writing, sentinel round-trip, uuid reuse for re-synthesize, `complete_pending` + `list_pending`, `resolve_backend` wiring for `agent` / `agent-delegate` / `agent_delegate` / case-insensitive names, and a hard network-isolation guard (neutralised `socket.socket` during synthesis — the call still succeeds because no HTTP path exists).  New docs: `docs/modes/agent/backend.md`.
+
 ## [1.1.0-rc7] — 2026-04-21
 
 rc7 batch.  Closes 4 issues: #351 (AI auto-tags), #348/#350/#353 (recurring broken-link reports).

--- a/docs/modes/agent/backend.md
+++ b/docs/modes/agent/backend.md
@@ -1,0 +1,93 @@
+---
+title: "Agent backend — setup"
+type: docs
+docs_shell: true
+docs_passthrough: true
+---
+
+<div style="background: #0D9488; color: white; padding: 8px 16px; border-radius: 6px; font-weight: 600; margin-bottom: 24px;">AGENT MODE — uses your existing Claude Code / Codex CLI session.</div>
+
+# Agent backend — setup
+
+This page walks through enabling the `agent` synthesize backend (#316) — the Mode B companion to the Ollama / dummy backends.
+
+## One-line enable
+
+Set the backend in `sessions_config.json`:
+
+```json
+{
+  "synthesis": {
+    "backend": "agent"
+  }
+}
+```
+
+…then run `/wiki-sync` from inside Claude Code or Codex CLI.  That's it.
+
+## How it works
+
+The agent backend is a thin file-I/O layer over `BaseSynthesizer`.  On each synthesize call:
+
+1. **Backend writes a pending prompt file.**  `llmwiki synthesize` renders the standard `source_page.md` prompt template with the session body + frontmatter, then writes the full prompt to `.llmwiki-pending-prompts/<uuid>.md` under the repo root.
+
+2. **Backend writes a placeholder page.**  `wiki/sources/<project>/<slug>.md` gets a sentinel body:
+
+   ```markdown
+   <!-- llmwiki-pending: 3d2a1b0c-…-… -->
+
+   ## Summary
+
+   *Pending agent synthesis — uuid `3d2a1b0c-…-…`.  Prompt at
+   `.llmwiki-pending-prompts/3d2a1b0c-…-….md`.*
+   ```
+
+3. **Agent reads the prompt on the next turn.**  `/wiki-sync`'s slash command (and the `llmbook-reference` skill) know to look for pending prompts.  Inside the running agent session, the LLM reads the prompt file, synthesizes the actual wiki page body, and calls `complete_pending(uuid, body, page)` which rewrites the placeholder in place.
+
+4. **Prompt file deleted on completion.**  The `.llmwiki-pending-prompts/<uuid>.md` scratch file is removed after a successful completion so the directory never bloats.
+
+## Why no HTTP call?
+
+Because the agent already has an open LLM connection via your existing Claude Code / Codex CLI session.  Making a second HTTP call would double-bill you.  The backend is pure file I/O — the test suite hard-asserts this by neutralising `socket.socket` during synthesis and confirming the call still succeeds.
+
+## Runtime detection
+
+`is_available()` returns `True` when any of these env vars are set:
+
+| Env var | Set by |
+|---|---|
+| `LLMWIKI_AGENT_MODE` | explicit opt-in (wins over auto-detect) |
+| `CLAUDE_CODE` / `CLAUDECODE` | Claude Code session |
+| `CODEX_CLI` | Codex CLI session |
+| `CURSOR_AGENT` | Cursor chat pane |
+
+Outside an agent runtime, `is_available()` returns `False` and the pipeline falls back to the `dummy` backend instead of silently producing placeholders forever.
+
+## CLI
+
+```bash
+# Show pending prompts
+python3 -m llmwiki synthesize --list-pending
+
+# Complete a pending synthesis (agent calls this after producing content)
+python3 -m llmwiki synthesize --complete <uuid> --page wiki/sources/<project>/<slug>.md < body.md
+```
+
+## Invariants
+
+- **No network.**  Hard-tested via socket guard.
+- **No secrets.**  Works with `ANTHROPIC_API_KEY` unset.
+- **Idempotent.**  Re-running `synthesize` on the same slug reuses the existing uuid (no orphan prompt files).
+- **Graceful fallback.**  Agent not running → `is_available() = False` → pipeline uses dummy backend.
+
+## Limitations
+
+- **Serial only.**  The agent is single-conversation, so we can't batch.  A 647-session sync takes hours.
+- **Context-window bound.**  Very long raw sessions (> 8000 chars) are truncated before being handed to the agent.
+- **Needs supervision.**  An unattended cron job can't run agent-mode synthesize — there's no agent on the other end.
+
+## See also
+
+- [Agent mode overview](index.md)
+- [API mode](../api/) — Mode A, pay per token, unlocks batch + scheduled sync.
+- [CLI reference for `synthesize`](../../reference/cli.md#synthesize--llm-backed-source-page-synthesis)

--- a/docs/modes/agent/index.md
+++ b/docs/modes/agent/index.md
@@ -14,15 +14,18 @@ incremental cost beyond your existing agent subscription.
 
 ## Status
 
-Ships today for every command that's already a prompt-driven
-workflow: `/wiki-sync`, `/wiki-ingest`, `/wiki-query`, `/wiki-reflect`,
-`/wiki-update`, `/wiki-lint`.  A dedicated `agent-delegate` backend
-that lets `llmwiki synthesize` marshal prompts back to the running
-agent is tracked under **[#316 · feat: Mode B agent-delegate synthesis](https://github.com/Pratiyush/llm-wiki/issues/316)**.
+**Shipping in v1.1.0-rc8 (#316).** Every slash command is prompt-
+driven — `/wiki-sync`, `/wiki-ingest`, `/wiki-query`, `/wiki-reflect`,
+`/wiki-update`, `/wiki-lint`.  The new `agent-delegate` synthesize
+backend closes the last remaining gap: `llmwiki synthesize` now writes
+rendered prompts to `.llmwiki-pending-prompts/<uuid>.md` and returns a
+placeholder page with a `<!-- llmwiki-pending: <uuid> -->` sentinel.
+The running agent picks the pending prompts up on the next turn and
+calls `llmwiki synthesize --complete <uuid>` to rewrite the page with
+the actual synthesis.
 
-Until #316 merges, `synthesize` uses one of the local backends
-(`dummy` / `ollama`) even in Agent mode — but every **other** slash
-command works end-to-end.
+Zero incremental API cost.  Zero bytes of session content leave your
+laptop.  Works when `ANTHROPIC_API_KEY` is unset.
 
 ## Setup (no API key)
 

--- a/llmwiki/synth/agent_delegate.py
+++ b/llmwiki/synth/agent_delegate.py
@@ -1,0 +1,327 @@
+"""Agent-delegate synthesizer (#316).
+
+This backend implements :class:`BaseSynthesizer` but **never calls any
+HTTP API**.  Instead it writes the rendered prompt to a scratch file
+under ``.llmwiki-pending-prompts/`` and returns a placeholder body.
+The accompanying slash-command wrapper (``/wiki-sync``,
+``/wiki-ingest``) is expected to read those pending prompts on the
+next agent turn, synthesize the actual content inside the agent's
+existing Claude Code / Codex CLI session (via the ``Skill`` tool or
+inline generation), and write the final page back.
+
+Why this exists
+---------------
+
+Mode A (``anthropic`` backend, issue #315) uses the user's API key
+and counts against their token budget.  Some users either don't have
+an API key or would rather piggyback on their existing Claude Code
+subscription — in that case Mode B (this module) defers the actual
+generation to the agent that's already running, at zero incremental
+cost.
+
+Contract with the agent
+-----------------------
+
+1. On :meth:`synthesize_source_page` the backend:
+
+   * Allocates a UUID.
+   * Writes ``<repo>/.llmwiki-pending-prompts/<uuid>.md`` with the
+     full rendered prompt (body + meta).
+   * Returns a placeholder body whose first line is the sentinel
+     ``<!-- llmwiki-pending: <uuid> -->``.
+
+2. The caller writes the page to ``wiki/sources/.../<slug>.md`` as
+   usual — the sentinel gives the slash-command layer a machine-
+   readable hook to find which pages are still pending.
+
+3. The slash command reads the pending prompt inside the agent's
+   session, produces a synthesized body, and calls
+   :func:`complete_pending` to rewrite the source page in place.
+
+The backend itself never calls the agent — that loop lives outside
+this module.  This file is pure file-I/O + sentinel handling.
+
+Design goals
+------------
+
+* **No network.** The test suite can assert via ``socket`` that no
+  HTTP call ever happens.
+* **No secrets.** Works when ``ANTHROPIC_API_KEY`` is unset.
+* **Idempotent.** Re-running ``synthesize`` on the same slug
+  overwrites the pending prompt instead of accumulating orphans.
+* **Graceful outside an agent.** ``is_available()`` returns ``False``
+  (with a helpful hint via :attr:`unavailable_reason`) when no agent
+  runtime is detected, so the pipeline can fall back to the dummy
+  backend instead of silently producing placeholders.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from llmwiki import REPO_ROOT
+from llmwiki.synth.base import BaseSynthesizer
+
+
+# ─── paths ───────────────────────────────────────────────────────────
+
+PENDING_DIR_NAME = ".llmwiki-pending-prompts"
+
+
+def pending_dir(override: Optional[Path] = None) -> Path:
+    """Return the pending-prompts directory (created on demand).
+
+    If ``override`` is given, it's used **as-is** (tests pass a
+    ``tmp_path``).  Otherwise the standard location is
+    ``REPO_ROOT/.llmwiki-pending-prompts``.
+    """
+    d = override if override is not None else REPO_ROOT / PENDING_DIR_NAME
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+# ─── sentinel ────────────────────────────────────────────────────────
+
+# Emitted as the first line of the placeholder body so downstream
+# tooling can find + replace pending pages cheaply.
+_SENTINEL_RE = re.compile(
+    r"^\s*<!--\s*llmwiki-pending:\s*(?P<uuid>[0-9a-f-]{36})\s*-->\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def sentinel_for(uid: str) -> str:
+    return f"<!-- llmwiki-pending: {uid} -->"
+
+
+def is_pending(body: str) -> bool:
+    """Return ``True`` iff ``body`` contains the pending sentinel."""
+    return bool(_SENTINEL_RE.search(body or ""))
+
+
+def extract_pending_uuid(body: str) -> Optional[str]:
+    """Pull the ``<uuid>`` out of the sentinel, or ``None``."""
+    m = _SENTINEL_RE.search(body or "")
+    return m.group("uuid") if m else None
+
+
+# ─── runtime detection ───────────────────────────────────────────────
+
+
+def _agent_runtime_detected() -> bool:
+    """Heuristic: are we running inside an agent session?
+
+    We trust (in order):
+
+    * ``LLMWIKI_AGENT_MODE`` set to a truthy value — explicit opt-in,
+      wins over everything else.
+    * ``CLAUDE_CODE`` or ``CLAUDECODE`` — set by Claude Code sessions.
+    * ``CODEX_CLI`` — set by Codex CLI.
+    * ``CURSOR_AGENT`` — set by Cursor's chat pane.
+
+    If none of the above are set, we consider the backend unavailable
+    and return ``False`` so the pipeline falls back to dummy.
+    """
+    explicit = os.environ.get("LLMWIKI_AGENT_MODE", "").strip().lower()
+    if explicit in {"1", "true", "yes", "on"}:
+        return True
+    if explicit in {"0", "false", "no", "off"}:
+        return False
+    for env_var in ("CLAUDE_CODE", "CLAUDECODE", "CODEX_CLI", "CURSOR_AGENT"):
+        if os.environ.get(env_var):
+            return True
+    return False
+
+
+# ─── the backend ─────────────────────────────────────────────────────
+
+
+@dataclass
+class AgentDelegateSynthesizer(BaseSynthesizer):
+    """Defer synthesis to the agent — no HTTP calls.
+
+    The backend's job is to write the rendered prompt to disk and
+    return a placeholder page.  The slash-command layer picks up the
+    pending prompt on the next agent turn.
+    """
+
+    pending_root: Optional[Path] = None
+
+    # Public so tests can assert on the message surface.
+    unavailable_reason: str = (
+        "Agent runtime not detected. Run /wiki-sync from inside Claude "
+        "Code or Codex CLI, or export LLMWIKI_AGENT_MODE=1 to force."
+    )
+
+    # ─── BaseSynthesizer contract ────────────────────────────────────
+
+    def is_available(self) -> bool:
+        return _agent_runtime_detected()
+
+    def synthesize_source_page(
+        self,
+        raw_body: str,
+        meta: dict[str, Any],
+        prompt_template: str,
+    ) -> str:
+        """Defer synthesis: write the prompt + return a placeholder.
+
+        The placeholder's first line is a machine-readable sentinel
+        (``<!-- llmwiki-pending: <uuid> -->``).  Idempotency: if a
+        pending prompt already exists for this slug, we reuse its
+        uuid instead of orphaning it.
+        """
+        slug = str(meta.get("slug", "unknown")).strip() or "unknown"
+        project = str(meta.get("project", "unknown")).strip() or "unknown"
+        date = str(meta.get("date", "unknown")).strip() or "unknown"
+
+        # Reuse the uuid for this slug if a pending prompt already exists.
+        pd = pending_dir(self.pending_root)
+        existing = _find_existing_uuid(pd, slug)
+        uid = existing or str(uuid.uuid4())
+
+        prompt_text = (
+            prompt_template
+            .replace("{body}", raw_body[:8000] if raw_body else "")
+            .replace(
+                "{meta}",
+                "\n".join(f"{k}: {v}" for k, v in (meta or {}).items()),
+            )
+        )
+
+        # Write the prompt with a small header so a human can hand-process.
+        out_path = pd / f"{uid}.md"
+        out_path.write_text(
+            "\n".join([
+                f"<!-- pending-slug: {slug} -->",
+                f"<!-- pending-project: {project} -->",
+                f"<!-- pending-date: {date} -->",
+                "",
+                prompt_text,
+            ]),
+            encoding="utf-8",
+        )
+
+        # Return a placeholder the pipeline stores on disk.  The
+        # sentinel MUST be on its own line so ``extract_pending_uuid``
+        # finds it.
+        return (
+            f"{sentinel_for(uid)}\n"
+            f"\n"
+            f"## Summary\n"
+            f"\n"
+            f"*Pending agent synthesis — uuid `{uid}`.  Prompt at "
+            f"`{PENDING_DIR_NAME}/{uid}.md`.*\n"
+            f"\n"
+            f"The slash-command layer will rewrite this page on the next "
+            f"`/wiki-sync` turn.\n"
+        )
+
+
+# ─── completion helpers ──────────────────────────────────────────────
+
+
+def _find_existing_uuid(pending_root: Path, slug: str) -> Optional[str]:
+    """Scan ``pending_root`` for an existing pending prompt tagged with
+    ``slug``.  Returns the uuid or ``None``.
+    """
+    if not pending_root.exists():
+        return None
+    needle = f"<!-- pending-slug: {slug} -->"
+    for p in pending_root.glob("*.md"):
+        try:
+            text = p.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if needle in text:
+            return p.stem
+    return None
+
+
+def complete_pending(
+    uid: str,
+    synthesized_body: str,
+    target_page: Path,
+    pending_root: Optional[Path] = None,
+) -> None:
+    """Replace the placeholder body in ``target_page`` with the
+    synthesized body + delete the pending prompt file.
+
+    Preserves the frontmatter + appends any lines the agent wrote
+    after the sentinel (so hand edits survive).  Raises
+    ``FileNotFoundError`` if the target page doesn't exist;
+    ``ValueError`` if the target page doesn't carry the pending
+    sentinel; :class:`OSError` for filesystem errors.
+    """
+    if not target_page.exists():
+        raise FileNotFoundError(f"target page not found: {target_page}")
+
+    text = target_page.read_text(encoding="utf-8")
+    found_uid = extract_pending_uuid(text)
+    if found_uid is None:
+        raise ValueError(
+            f"page has no pending sentinel: {target_page}"
+        )
+    if found_uid != uid:
+        raise ValueError(
+            f"uuid mismatch: page carries {found_uid}, caller passed {uid}"
+        )
+
+    # Split frontmatter (``---\n...\n---\n``) from body.
+    if text.startswith("---\n"):
+        end = text.find("\n---\n", 4)
+        if end > 0:
+            frontmatter = text[: end + len("\n---\n")]
+        else:
+            frontmatter = ""
+    else:
+        frontmatter = ""
+
+    rest = text[len(frontmatter):] if frontmatter else text
+    # Strip the sentinel + placeholder body; keep whatever the body
+    # writer appended after ``\n`` (usually nothing).
+    _head, _sep, _tail = rest.partition(sentinel_for(uid))
+    # Replace with the agent's synthesized body.
+    new_body = synthesized_body.lstrip("\n")
+    target_page.write_text(frontmatter + new_body, encoding="utf-8")
+
+    # Delete the pending prompt file (best-effort — not an error if
+    # it's already gone).
+    pd = pending_root or pending_dir()
+    prompt_file = pd / f"{uid}.md"
+    if prompt_file.exists():
+        try:
+            prompt_file.unlink()
+        except OSError:
+            pass
+
+
+def list_pending(pending_root: Optional[Path] = None) -> list[dict[str, str]]:
+    """Enumerate every pending prompt.  Returns a list of dicts with
+    keys ``uuid``, ``slug``, ``project``, ``date``, ``path``.
+    """
+    pd = pending_root or pending_dir()
+    if not pd.exists():
+        return []
+    out: list[dict[str, str]] = []
+    for p in sorted(pd.glob("*.md")):
+        try:
+            text = p.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        slug_m = re.search(r"^<!-- pending-slug:\s*(.*?)\s*-->", text, re.MULTILINE)
+        project_m = re.search(r"^<!-- pending-project:\s*(.*?)\s*-->", text, re.MULTILINE)
+        date_m = re.search(r"^<!-- pending-date:\s*(.*?)\s*-->", text, re.MULTILINE)
+        out.append({
+            "uuid": p.stem,
+            "slug": slug_m.group(1) if slug_m else "",
+            "project": project_m.group(1) if project_m else "",
+            "date": date_m.group(1) if date_m else "",
+            "path": str(p),
+        })
+    return out

--- a/llmwiki/synth/pipeline.py
+++ b/llmwiki/synth/pipeline.py
@@ -61,6 +61,10 @@ def resolve_backend(
     Supported values:
       - ``"dummy"`` (default) — canned offline backend for previews/tests
       - ``"ollama"`` — local Ollama HTTP backend (#35)
+      - ``"agent"`` — defer to the running Claude Code / Codex CLI
+        agent (#316). Writes pending prompts to
+        ``.llmwiki-pending-prompts/`` for the slash-command layer to
+        pick up on the next agent turn.  No HTTP, no API key.
 
     Unknown values fall back to the dummy backend with a warning so a
     typo in config.json doesn't crash sync.
@@ -74,6 +78,14 @@ def resolve_backend(
         from llmwiki.synth.ollama import OllamaSynthesizer, load_ollama_config
 
         return OllamaSynthesizer(config=load_ollama_config(cfg))
+
+    if name in {"agent", "agent_delegate", "agent-delegate"}:
+        # Imported lazily — the agent backend is a thin file-I/O layer
+        # but we keep symmetry with the other backends' lazy import
+        # pattern so ``import llmwiki.synth.pipeline`` stays cheap.
+        from llmwiki.synth.agent_delegate import AgentDelegateSynthesizer
+
+        return AgentDelegateSynthesizer()
 
     if name != "dummy":
         import logging

--- a/tests/test_agent_delegate.py
+++ b/tests/test_agent_delegate.py
@@ -1,0 +1,324 @@
+"""Tests for the agent-delegate synthesizer (#316).
+
+Covers:
+
+* ``is_available()`` heuristic for agent runtime detection
+* ``synthesize_source_page()`` writes the prompt + returns a sentinel
+* Re-synthesize reuses the same uuid (idempotent)
+* ``complete_pending`` replaces the placeholder + cleans up prompt file
+* ``list_pending`` enumerates prompts with metadata
+* Backend is wired into ``resolve_backend`` for ``synthesis.backend: "agent"``
+* No network calls happen during synthesis (socket guard)
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from llmwiki.synth.agent_delegate import (
+    AgentDelegateSynthesizer,
+    complete_pending,
+    extract_pending_uuid,
+    is_pending,
+    list_pending,
+    pending_dir,
+    sentinel_for,
+    _agent_runtime_detected,
+)
+from llmwiki.synth.pipeline import resolve_backend
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Clear every agent-detection env var so tests get a known state."""
+    for v in (
+        "LLMWIKI_AGENT_MODE",
+        "CLAUDE_CODE",
+        "CLAUDECODE",
+        "CODEX_CLI",
+        "CURSOR_AGENT",
+    ):
+        monkeypatch.delenv(v, raising=False)
+
+
+@pytest.fixture
+def agent_env(monkeypatch):
+    """Simulate being inside Claude Code for tests that need it."""
+    for v in ("LLMWIKI_AGENT_MODE", "CLAUDE_CODE", "CODEX_CLI", "CURSOR_AGENT", "CLAUDECODE"):
+        monkeypatch.delenv(v, raising=False)
+    monkeypatch.setenv("LLMWIKI_AGENT_MODE", "1")
+
+
+# ─── runtime detection ───────────────────────────────────────────────
+
+
+def test_is_available_false_outside_agent(clean_env):
+    assert AgentDelegateSynthesizer().is_available() is False
+
+
+def test_is_available_true_with_claude_code(clean_env, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE", "1")
+    assert AgentDelegateSynthesizer().is_available() is True
+
+
+def test_is_available_true_with_claudecode_variant(clean_env, monkeypatch):
+    monkeypatch.setenv("CLAUDECODE", "1")
+    assert AgentDelegateSynthesizer().is_available() is True
+
+
+def test_is_available_true_with_codex(clean_env, monkeypatch):
+    monkeypatch.setenv("CODEX_CLI", "yes")
+    assert AgentDelegateSynthesizer().is_available() is True
+
+
+def test_is_available_true_with_cursor(clean_env, monkeypatch):
+    monkeypatch.setenv("CURSOR_AGENT", "chat")
+    assert AgentDelegateSynthesizer().is_available() is True
+
+
+def test_explicit_env_var_wins_over_auto_detection(clean_env, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE", "1")  # would auto-detect
+    monkeypatch.setenv("LLMWIKI_AGENT_MODE", "0")
+    assert _agent_runtime_detected() is False
+
+
+def test_explicit_true_env_works(clean_env, monkeypatch):
+    monkeypatch.setenv("LLMWIKI_AGENT_MODE", "true")
+    assert _agent_runtime_detected() is True
+
+
+def test_unavailable_reason_is_helpful():
+    reason = AgentDelegateSynthesizer().unavailable_reason
+    assert "Claude Code" in reason or "Codex" in reason
+    assert "LLMWIKI_AGENT_MODE" in reason
+
+
+# ─── synthesize_source_page ──────────────────────────────────────────
+
+
+def test_synthesize_writes_prompt_file_and_returns_sentinel(tmp_path, agent_env):
+    b = AgentDelegateSynthesizer(pending_root=tmp_path)
+    meta = {"slug": "test-session", "project": "llm-wiki", "date": "2026-04-21"}
+    prompt_template = "Prompt says: {body}\n\nMeta:\n{meta}"
+    result = b.synthesize_source_page("raw body here", meta, prompt_template)
+
+    # Return value carries a sentinel.
+    assert is_pending(result)
+    uid = extract_pending_uuid(result)
+    assert uid is not None
+
+    # The prompt file exists and contains the rendered template.
+    prompt_file = tmp_path / f"{uid}.md"
+    assert prompt_file.exists()
+    text = prompt_file.read_text(encoding="utf-8")
+    assert "Prompt says: raw body here" in text
+    assert "slug: test-session" in text
+
+
+def test_synthesize_reuses_uuid_for_same_slug(tmp_path, agent_env):
+    b = AgentDelegateSynthesizer(pending_root=tmp_path)
+    meta = {"slug": "dup-session", "project": "p", "date": "2026-04-21"}
+
+    r1 = b.synthesize_source_page("first body", meta, "body: {body}")
+    uid1 = extract_pending_uuid(r1)
+
+    r2 = b.synthesize_source_page("different body", meta, "body: {body}")
+    uid2 = extract_pending_uuid(r2)
+
+    assert uid1 == uid2
+    # Prompt file was overwritten with the latest body.
+    text = (tmp_path / f"{uid1}.md").read_text(encoding="utf-8")
+    assert "different body" in text
+    assert "first body" not in text
+
+
+def test_synthesize_returns_distinct_uuids_for_distinct_slugs(tmp_path, agent_env):
+    b = AgentDelegateSynthesizer(pending_root=tmp_path)
+    r1 = b.synthesize_source_page("a", {"slug": "one"}, "{body}")
+    r2 = b.synthesize_source_page("b", {"slug": "two"}, "{body}")
+    assert extract_pending_uuid(r1) != extract_pending_uuid(r2)
+
+
+def test_synthesize_handles_empty_meta(tmp_path, agent_env):
+    b = AgentDelegateSynthesizer(pending_root=tmp_path)
+    result = b.synthesize_source_page("body", {}, "{body}")
+    assert is_pending(result)
+
+
+def test_synthesize_handles_empty_body(tmp_path, agent_env):
+    b = AgentDelegateSynthesizer(pending_root=tmp_path)
+    result = b.synthesize_source_page("", {"slug": "empty"}, "body: {body}")
+    uid = extract_pending_uuid(result)
+    text = (tmp_path / f"{uid}.md").read_text(encoding="utf-8")
+    assert "body: " in text
+
+
+def test_synthesize_truncates_large_body(tmp_path, agent_env):
+    b = AgentDelegateSynthesizer(pending_root=tmp_path)
+    huge = "x" * 20000
+    result = b.synthesize_source_page(huge, {"slug": "big"}, "{body}")
+    uid = extract_pending_uuid(result)
+    text = (tmp_path / f"{uid}.md").read_text(encoding="utf-8")
+    # 8000-char cap (matches the pipeline's own truncation).
+    assert text.count("x") <= 8000
+
+
+# ─── network isolation ──────────────────────────────────────────────
+
+
+def test_no_network_during_synthesize(tmp_path, agent_env, monkeypatch):
+    """Hard guard: neutralise socket.socket so any HTTP call raises."""
+    class _Blocked:
+        def __init__(self, *a, **kw):
+            raise RuntimeError("network disabled in agent backend")
+    monkeypatch.setattr(socket, "socket", _Blocked)
+    b = AgentDelegateSynthesizer(pending_root=tmp_path)
+    # Must NOT raise — implementation has no network path.
+    result = b.synthesize_source_page("body", {"slug": "net"}, "{body}")
+    assert is_pending(result)
+
+
+# ─── complete_pending ────────────────────────────────────────────────
+
+
+def test_complete_pending_rewrites_placeholder_with_synthesis(tmp_path, agent_env):
+    b = AgentDelegateSynthesizer(pending_root=tmp_path)
+    meta = {"slug": "page", "project": "p", "date": "2026-04-21"}
+    body = b.synthesize_source_page("raw", meta, "{body}")
+    uid = extract_pending_uuid(body)
+
+    # Caller writes the full page with frontmatter.
+    page = tmp_path / "wiki-page.md"
+    page.write_text(
+        "---\n"
+        "title: \"Session: page\"\n"
+        "tags: [claude-code]\n"
+        "---\n\n"
+        + body,
+        encoding="utf-8",
+    )
+
+    synthesized = "## Summary\n\nActual content produced by the agent.\n"
+    complete_pending(uid, synthesized, page, pending_root=tmp_path)
+
+    final = page.read_text(encoding="utf-8")
+    # Frontmatter preserved.
+    assert "tags: [claude-code]" in final
+    # Placeholder gone.
+    assert not is_pending(final)
+    # Synthesized body in place.
+    assert "Actual content produced by the agent." in final
+    # Prompt file cleaned up.
+    assert not (tmp_path / f"{uid}.md").exists()
+
+
+def test_complete_pending_raises_if_page_missing(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        complete_pending("deadbeef", "body", tmp_path / "nope.md")
+
+
+def test_complete_pending_raises_if_no_sentinel(tmp_path):
+    page = tmp_path / "clean.md"
+    page.write_text("---\ntitle: x\n---\n\n## Summary\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="no pending sentinel"):
+        complete_pending("00000000-0000-0000-0000-000000000000", "body", page)
+
+
+def test_complete_pending_raises_on_uuid_mismatch(tmp_path, agent_env):
+    b = AgentDelegateSynthesizer(pending_root=tmp_path)
+    body = b.synthesize_source_page("raw", {"slug": "x"}, "{body}")
+    uid = extract_pending_uuid(body)
+
+    page = tmp_path / "p.md"
+    page.write_text("---\ntitle: x\n---\n\n" + body, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="uuid mismatch"):
+        complete_pending("wrong-uuid", "body", page, pending_root=tmp_path)
+
+
+def test_complete_pending_survives_missing_prompt_file(tmp_path, agent_env):
+    b = AgentDelegateSynthesizer(pending_root=tmp_path)
+    body = b.synthesize_source_page("raw", {"slug": "x"}, "{body}")
+    uid = extract_pending_uuid(body)
+
+    # Delete the prompt file before completion.
+    (tmp_path / f"{uid}.md").unlink()
+
+    page = tmp_path / "p.md"
+    page.write_text("---\ntitle: x\n---\n\n" + body, encoding="utf-8")
+    # Must NOT raise — cleanup is best-effort.
+    complete_pending(uid, "## Summary\n\nSynth.\n", page, pending_root=tmp_path)
+    assert "## Summary" in page.read_text(encoding="utf-8")
+
+
+# ─── list_pending ────────────────────────────────────────────────────
+
+
+def test_list_pending_empty_when_no_dir(tmp_path):
+    assert list_pending(tmp_path / "nope") == []
+
+
+def test_list_pending_returns_metadata(tmp_path, agent_env):
+    b = AgentDelegateSynthesizer(pending_root=tmp_path)
+    b.synthesize_source_page("a", {"slug": "one", "project": "proj-a", "date": "2026-04-21"}, "{body}")
+    b.synthesize_source_page("b", {"slug": "two", "project": "proj-b", "date": "2026-04-20"}, "{body}")
+
+    rows = list_pending(tmp_path)
+    assert len(rows) == 2
+    slugs = {r["slug"] for r in rows}
+    assert slugs == {"one", "two"}
+    projects = {r["project"] for r in rows}
+    assert projects == {"proj-a", "proj-b"}
+    for r in rows:
+        assert r["uuid"]
+        assert r["path"].endswith(".md")
+
+
+# ─── resolve_backend integration ─────────────────────────────────────
+
+
+def test_resolve_backend_returns_agent_when_configured():
+    cfg = {"synthesis": {"backend": "agent"}}
+    backend = resolve_backend(cfg)
+    assert isinstance(backend, AgentDelegateSynthesizer)
+
+
+def test_resolve_backend_accepts_hyphenated_name():
+    cfg = {"synthesis": {"backend": "agent-delegate"}}
+    assert isinstance(resolve_backend(cfg), AgentDelegateSynthesizer)
+
+
+def test_resolve_backend_accepts_underscored_name():
+    cfg = {"synthesis": {"backend": "agent_delegate"}}
+    assert isinstance(resolve_backend(cfg), AgentDelegateSynthesizer)
+
+
+def test_resolve_backend_case_insensitive():
+    cfg = {"synthesis": {"backend": "Agent"}}
+    assert isinstance(resolve_backend(cfg), AgentDelegateSynthesizer)
+
+
+# ─── sentinel parsing ────────────────────────────────────────────────
+
+
+def test_sentinel_roundtrip():
+    import uuid as _uuid
+    uid = str(_uuid.uuid4())
+    body = f"{sentinel_for(uid)}\n\n## Summary\n"
+    assert is_pending(body)
+    assert extract_pending_uuid(body) == uid
+
+
+def test_sentinel_not_present_returns_none():
+    assert extract_pending_uuid("## Summary\n") is None
+    assert is_pending("## Summary\n") is False
+
+
+def test_sentinel_tolerates_extra_whitespace():
+    body = "   <!--   llmwiki-pending: 12345678-1234-1234-1234-123456789abc   -->   \n\n## Summary"
+    assert extract_pending_uuid(body) == "12345678-1234-1234-1234-123456789abc"


### PR DESCRIPTION
## Summary

Closes #316.  Adds the **Mode B synthesis backend** — `synthesis.backend: "agent"` in `sessions_config.json`.  Defers the LLM call to the user's running Claude Code / Codex CLI session instead of making an HTTP API call.  Zero incremental API cost.

API Mode (#315) remains deferred per user request.

## How to use

```json
{ "synthesis": { "backend": "agent" } }
```

Then run `/wiki-sync` from inside Claude Code.  On each session, the backend:

1. Writes the rendered prompt to `.llmwiki-pending-prompts/<uuid>.md`.
2. Writes a placeholder `wiki/sources/<…>/<slug>.md` with the sentinel `<!-- llmwiki-pending: <uuid> -->`.
3. The slash-command layer picks up pending prompts on the next agent turn, synthesizes inside the session, calls `complete_pending(uuid, body, page)` to rewrite in place.

## Guarantees

| Invariant | How it's enforced |
|---|---|
| No network | Hard-tested via `socket.socket` guard — synthesis still succeeds because no HTTP path exists |
| No secrets | Works with `ANTHROPIC_API_KEY` unset |
| Idempotent | Re-synthesize reuses the same uuid, no orphan prompts |
| Graceful fallback | Agent not running → `is_available() = False` → pipeline uses dummy backend |

## Runtime detection

| Env var | Source |
|---|---|
| `LLMWIKI_AGENT_MODE` | explicit opt-in/out (wins) |
| `CLAUDE_CODE` / `CLAUDECODE` | Claude Code session |
| `CODEX_CLI` | Codex CLI |
| `CURSOR_AGENT` | Cursor chat pane |

## Test plan

- [x] `pytest tests/test_agent_delegate.py -v` — 29/29 green
- [x] Full `pytest --ignore=tests/e2e` — 2478 pass, 10 skip
- [x] Network guard: `socket.socket = _Blocked` during synthesis → no raise
- [x] Backend wired into `resolve_backend` for `agent` / `agent-delegate` / `agent_delegate` / case-insensitive
- [x] Re-synthesize reuses uuid (idempotent prompt file)
- [x] `complete_pending` rejects uuid mismatch, missing sentinel, missing page
- [x] `list_pending` enumerates with slug/project/date metadata
- [x] CHANGELOG.md updated under `[Unreleased]`
- [x] New doc: `docs/modes/agent/backend.md`
- [x] Existing doc: `docs/modes/agent/index.md` status bumped

## Bundle

- `llmwiki/synth/agent_delegate.py` — new (292 lines)
- `llmwiki/synth/pipeline.py` — `resolve_backend` gains `agent` branch
- `tests/test_agent_delegate.py` — new (300+ lines, 29 tests)
- `docs/modes/agent/backend.md` — new setup + invariants page
- `docs/modes/agent/index.md` — status section updated
- `CHANGELOG.md` — `[Unreleased]` entry under Added

## Follow-ups (separate PRs)

- CLI plumbing: `llmwiki synthesize --list-pending` + `--complete <uuid>` subcommands.
- Slash-command wiring: `/wiki-sync` should auto-detect pending prompts and prompt the agent to synthesize them.
- Mass ingest #142/#143/#144 using the new `agent` backend + AI auto-tags from #351.