### PR TITLE
release: v1.1.0-rc8 — Mode B end-to-end (CLI + /wiki-sync)

### DIFF
--- a/.claude/commands/wiki-sync.md
+++ b/.claude/commands/wiki-sync.md
@@ -10,7 +10,7 @@ Steps (run in this order, report progress to the user):
    ```
    Capture the summary line (`N converted, M unchanged, K live, J filtered, X errors`).
 
-2. **If `N == 0`**: report "wiki is already up to date" and stop. Don't run ingest.
+2. **If `N == 0`**: report "wiki is already up to date" and continue to step 6 (pending-prompt scan). Don't run ingest.
 
 3. **If `N > 0`**: for each newly written markdown file under `raw/sessions/`, follow the **Ingest Workflow** from `CLAUDE.md`. Process one project at a time. If there are more than 20 new files total, ask the user whether to process them all or a subset first.
 
@@ -24,3 +24,29 @@ Steps (run in this order, report progress to the user):
    - Which projects got updated
    - Which wiki pages were created or updated
    - Any contradictions flagged under `## Contradictions` on wiki pages
+
+6. **Complete any pending agent-delegate syntheses (#316)** — the `agent` synthesis backend writes pending prompts to `.llmwiki-pending-prompts/<uuid>.md` that need you (the agent) to finalise. Run:
+
+   ```bash
+   python3 -m llmwiki synthesize --list-pending
+   ```
+
+   **If the output is "No pending prompts"**: skip to step 7.
+
+   **Otherwise** — for each pending prompt:
+
+   a. Read `.llmwiki-pending-prompts/<uuid>.md` — it contains the rendered prompt (body + frontmatter) that the pipeline already filled in.
+
+   b. Synthesize the wiki page body by following the prompt instructions. Emit the `<!-- suggested-tags: ... -->` comment as the first line per the prompt.
+
+   c. Write the synthesized body to a scratch file, then finalise:
+
+      ```bash
+      python3 -m llmwiki synthesize --complete <uuid> --page wiki/sources/<project>/<date>-<slug>.md --body /tmp/synth-<uuid>.md
+      ```
+
+   d. The CLI verifies the uuid matches the page's sentinel, rewrites the placeholder in place, and deletes `.llmwiki-pending-prompts/<uuid>.md`.
+
+   Process all pending prompts serially — the agent is single-conversation.
+
+7. **Done.** Run `/wiki-build` if the caller asked for fresh HTML.

--- a/.claude/commands/wiki-synthesize.md
+++ b/.claude/commands/wiki-synthesize.md
@@ -14,6 +14,8 @@ translates the phrasing into flags.
 | "check the backend is reachable" | `python3 -m llmwiki synthesize --check` |
 | "force re-synthesize everything" | `python3 -m llmwiki synthesize --force` |
 | "synthesize but don't touch my wiki yet" | `python3 -m llmwiki synthesize --dry-run` |
+| "list pending agent prompts" / "what's waiting on me?" | `python3 -m llmwiki synthesize --list-pending` |
+| "complete pending synthesis \<uuid\>" | `python3 -m llmwiki synthesize --complete <uuid> --page <path>` (body via `--body` or stdin) |
 
 ## Expected output
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,20 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.1.0-rc8] — 2026-04-21
+
+rc8 batch.  Completes Mode B end-to-end with CLI + slash-command plumbing on top of the agent-delegate backend from rc8.
+
 ### Added
+
+- **`llmwiki synthesize --list-pending`** (#316 follow-up) — prints every pending agent-synthesis prompt as a table (`UUID  SLUG · PROJECT · DATE`).  Returns exit 0 even when empty so the slash-command layer can use "no pending prompts" as a success signal.  Zero-cost read of `.llmwiki-pending-prompts/*.md`.
+- **`llmwiki synthesize --complete <uuid> --page <path>`** (#316 follow-up) — the agent-side counterpart of the backend's placeholder-writing step.  Reads the synthesized body from `--body <file>` or stdin, verifies the target page carries the matching `<!-- llmwiki-pending: <uuid> -->` sentinel, rewrites the placeholder in place (preserving frontmatter), and deletes the pending prompt file.  Non-zero exit on: missing `--page`, empty body, missing target file, missing sentinel, uuid mismatch.  9 tests in `tests/test_synthesize_cli_pending.py`.
+- **`/wiki-sync` step 6** — slash command now scans for pending agent-delegate prompts after ingest.  For each pending uuid: reads the prompt file, synthesizes inside the current agent turn (including the `<!-- suggested-tags: ... -->` block from #351), writes a scratch body, calls `llmwiki synthesize --complete` to rewrite the placeholder.  Serial loop — the agent is single-conversation.
+- **`/wiki-synthesize` two new natural-language variants** — "list pending agent prompts" → `--list-pending`; "complete pending synthesis <uuid>" → `--complete <uuid> --page <path>`.
+
+### Changed
+
+- **`docs/modes/agent/backend.md`** — expanded with the real CLI surface + exit-code table + `/wiki-sync` step-6 walkthrough.
 
 - **Mode B agent-delegate synthesis backend** (#316) — a new `agent` value for `synthesis.backend` in `sessions_config.json` that defers the LLM call to the user's running Claude Code / Codex CLI session instead of making an HTTP API call.  The backend (`llmwiki/synth/agent_delegate.py`) writes the rendered prompt to `.llmwiki-pending-prompts/<uuid>.md` and returns a placeholder page whose first line is the machine-readable sentinel `<!-- llmwiki-pending: <uuid> -->`.  The slash-command layer reads pending prompts on the next agent turn, synthesizes the content inside the existing session, and calls `complete_pending(uuid, body, page)` to rewrite the placeholder in place.  Zero incremental API cost (piggybacks on the agent subscription).  Zero bytes of session content leave the laptop.  Works when `ANTHROPIC_API_KEY` is unset.  `is_available()` auto-detects the agent runtime via `LLMWIKI_AGENT_MODE` / `CLAUDE_CODE` / `CODEX_CLI` / `CURSOR_AGENT` env vars; returns `False` outside an agent so the pipeline falls back to `dummy` instead of silently producing placeholders forever.  29 tests in `tests/test_agent_delegate.py` cover runtime detection, prompt writing, sentinel round-trip, uuid reuse for re-synthesize, `complete_pending` + `list_pending`, `resolve_backend` wiring for `agent` / `agent-delegate` / `agent_delegate` / case-insensitive names, and a hard network-isolation guard (neutralised `socket.socket` during synthesis — the call still succeeds because no HTTP path exists).  New docs: `docs/modes/agent/backend.md`.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.1.0--rc7-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.1.0--rc8-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2368%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)
@@ -530,6 +530,7 @@ Per-adapter docs:
 | [v1.1.0-rc5](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc5) | Site audit + 5 closed batches — session-local ref stripping (351 → 247 broken), cheatsheet, README/CONTRIBUTING compile, expanded E2E, slash-CLI parity test, 4 adapter docs, Ollama tutorial, dual-mode docs skeleton, `/wiki-synthesize` slash | `v1.1.0-rc5` |
 | [v1.1.0-rc6](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc6) | rc6 batch — fixed adapter tag hardcoded to `claude-code` for every adapter (#346), tutorial UX polish with in-page TOC + prev/next + edit-on-GitHub (#282), command palette now indexes 107 doc pages + 17 slash commands (#277), content-hash cache for `md_to_html` (#283) | `v1.1.0-rc6` |
 | [v1.1.0-rc7](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc7) | rc7 batch — automatic AI-suggested tags during synthesis (#351), link-checker config fix (#348, #350, #353) | `v1.1.0-rc7` |
+| [v1.1.0-rc8](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc8) | rc8 batch — complete Mode B agent-delegate backend (#316): new `llmwiki synthesize --list-pending` + `--complete <uuid>` CLI subcommands, `/wiki-sync` step 6 auto-detects pending prompts, Mode B ships end-to-end without an API key | `v1.1.0-rc8` |
 
 ## Roadmap
 

--- a/docs/modes/agent/backend.md
+++ b/docs/modes/agent/backend.md
@@ -66,12 +66,31 @@ Outside an agent runtime, `is_available()` returns `False` and the pipeline fall
 ## CLI
 
 ```bash
-# Show pending prompts
+# Show pending prompts (0 exit even when empty)
 python3 -m llmwiki synthesize --list-pending
 
-# Complete a pending synthesis (agent calls this after producing content)
-python3 -m llmwiki synthesize --complete <uuid> --page wiki/sources/<project>/<slug>.md < body.md
+# Complete a pending synthesis — body via stdin
+python3 -m llmwiki synthesize --complete <uuid> \
+  --page wiki/sources/<project>/<slug>.md < body.md
+
+# Complete a pending synthesis — body via file
+python3 -m llmwiki synthesize --complete <uuid> \
+  --page wiki/sources/<project>/<slug>.md \
+  --body /tmp/synth-<uuid>.md
 ```
+
+Exit codes: `0` success, `1` for any of: missing `--page`, empty body, missing target file, missing sentinel on target page, uuid mismatch between page and `--complete` argument.
+
+## How `/wiki-sync` uses these
+
+Step 6 of the `/wiki-sync` slash command (post-rc8) runs `--list-pending` after ingest. For every pending uuid:
+
+1. Slash command reads `.llmwiki-pending-prompts/<uuid>.md`.
+2. Slash command synthesizes the wiki body inside its own agent turn (including the `<!-- suggested-tags: ... -->` block).
+3. Slash command writes the body to a scratch file.
+4. Slash command runs `llmwiki synthesize --complete <uuid> --page <path> --body <scratch>` which rewrites the placeholder and deletes the prompt file.
+
+The loop is serial — the agent is single-conversation.
 
 ## Invariants
 

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.1.0rc7"
+__version__ = "1.1.0rc8"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/cli.py
+++ b/llmwiki/cli.py
@@ -938,6 +938,12 @@ def cmd_synthesize(args: argparse.Namespace) -> int:
     if args.estimate:
         return _synthesize_estimate()
 
+    # #316: agent-delegate operations that don't need a backend.
+    if args.list_pending:
+        return _synthesize_list_pending()
+    if args.complete:
+        return _synthesize_complete(args)
+
     backend = resolve_backend(config)
     print(f"Backend: {backend.name}")
 
@@ -967,6 +973,87 @@ def cmd_synthesize(args: argparse.Namespace) -> int:
         for err in summary["errors"]:
             print(f"  ! {err}", file=sys.stderr)
         return 1
+    return 0
+
+
+# ─── #316 agent-delegate CLI helpers ─────────────────────────────────
+
+
+def _synthesize_list_pending() -> int:
+    """Print the pending-prompts table for ``--list-pending``.
+
+    Two-column layout: uuid │ slug · project · date · prompt-path.
+    Exit 0 even when empty — the slash-command layer treats "nothing
+    pending" as a success signal.
+    """
+    from llmwiki.synth.agent_delegate import list_pending
+
+    rows = list_pending()
+    if not rows:
+        print("No pending prompts.")
+        return 0
+    # Max-width uuid column for alignment.
+    uuid_w = max(len(r["uuid"]) for r in rows)
+    print(f"{'UUID':<{uuid_w}}  SLUG · PROJECT · DATE")
+    print(f"{'-' * uuid_w}  " + "-" * 40)
+    for r in rows:
+        meta = " · ".join(
+            part for part in (r["slug"], r["project"], r["date"]) if part
+        )
+        print(f"{r['uuid']:<{uuid_w}}  {meta}")
+    print(f"\n{len(rows)} pending prompt(s).")
+    return 0
+
+
+def _synthesize_complete(args: argparse.Namespace) -> int:
+    """Rewrite a placeholder wiki page with the agent's synthesis.
+
+    Reads the synthesized body from ``args.body`` (file) or stdin, calls
+    :func:`llmwiki.synth.agent_delegate.complete_pending` to replace the
+    sentinel + prompt-file pair with the real content.  Exit codes:
+
+    * ``0`` — success
+    * ``1`` — missing --page, uuid mismatch, missing sentinel, or I/O
+      error
+    """
+    from llmwiki.synth.agent_delegate import complete_pending
+
+    if not args.page:
+        print("error: --complete requires --page <path>", file=sys.stderr)
+        return 1
+
+    page_path = Path(args.page)
+    if not page_path.is_absolute():
+        page_path = REPO_ROOT / page_path
+
+    if args.body:
+        body_path = Path(args.body)
+        if not body_path.is_absolute():
+            body_path = REPO_ROOT / body_path
+        try:
+            body = body_path.read_text(encoding="utf-8")
+        except OSError as e:
+            print(f"error: reading --body {body_path}: {e}", file=sys.stderr)
+            return 1
+    else:
+        body = sys.stdin.read()
+        if not body:
+            print(
+                "error: --complete expects a body on stdin or via --body",
+                file=sys.stderr,
+            )
+            return 1
+
+    try:
+        complete_pending(args.complete, body, page_path)
+    except FileNotFoundError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    print(f"completed: {page_path}")
     return 0
 
 
@@ -1648,6 +1735,23 @@ def build_parser() -> argparse.ArgumentParser:
     syn.add_argument(
         "--estimate", action="store_true",
         help="Print cached-vs-fresh token + dollar estimate without calling a backend (#50)",
+    )
+    # #316 — agent-delegate backend helpers.
+    syn.add_argument(
+        "--list-pending", action="store_true",
+        help="List pending prompts awaiting agent synthesis (agent-delegate backend, #316)",
+    )
+    syn.add_argument(
+        "--complete", metavar="UUID", default=None,
+        help="Complete a pending synthesis: read body from --body or stdin, rewrite --page in place (#316)",
+    )
+    syn.add_argument(
+        "--page", metavar="PATH", default=None,
+        help="Target wiki source page for --complete (path relative to repo root or absolute)",
+    )
+    syn.add_argument(
+        "--body", metavar="PATH", default=None,
+        help="Read synthesized body from this file for --complete (default: stdin)",
     )
     syn.set_defaults(func=cmd_synthesize)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llmwiki"
-version = "1.1.0rc7"
+version = "1.1.0rc8"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_synthesize_cli_pending.py
+++ b/tests/test_synthesize_cli_pending.py
@@ -1,0 +1,236 @@
+"""Tests for the ``llmwiki synthesize --list-pending`` + ``--complete``
+CLI subcommands (#316 follow-up).
+
+Covers:
+
+* ``--list-pending`` with no prompts → 0 exit + "No pending prompts."
+* ``--list-pending`` with prompts → table with uuid + slug + project
+* ``--complete`` without ``--page`` → 1 exit + helpful message
+* ``--complete`` with body from ``--body`` file → rewrites the page
+* ``--complete`` with body from stdin → rewrites the page
+* ``--complete`` with missing target page → 1 exit
+* ``--complete`` with no sentinel on the target page → 1 exit
+* ``--complete`` with uuid mismatch → 1 exit
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _run_cli(*args: str, cwd: Path, input_text: str = "") -> subprocess.CompletedProcess:
+    """Run the `llmwiki` CLI in a subprocess so argparse + stdin behave
+    like a real user invocation.  Always uses the current Python and
+    injects REPO_ROOT into PYTHONPATH so ``python -m llmwiki`` resolves
+    even when ``cwd`` is a scratch dir."""
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        str(REPO_ROOT) + (os.pathsep + existing if existing else "")
+    )
+    return subprocess.run(
+        [sys.executable, "-m", "llmwiki", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        input=input_text,
+        env=env,
+    )
+
+
+# ─── shared fixture: isolate from the real .llmwiki-pending-prompts/ ─
+
+
+@pytest.fixture
+def scratch_repo(tmp_path, monkeypatch):
+    """A sandbox that mirrors the layout enough for `llmwiki synthesize`
+    to work on its pending-prompts subfolder.  We monkeypatch REPO_ROOT
+    inside the subprocess by setting the CWD to ``tmp_path`` and
+    copying/linking the installed llmwiki package into ``sys.path``.
+
+    Simpler: since ``llmwiki.REPO_ROOT`` is resolved from ``llmwiki/__init__.py``'s
+    location (it is NOT driven by CWD), we can't point it at ``tmp_path`` via
+    subprocess alone.  Instead, write the pending-prompts dir at the real
+    REPO_ROOT and clean up afterwards.  This means we use the real module and
+    actually exercise the CLI, but we MUST clean up in a ``finally`` block.
+    """
+    pending = REPO_ROOT / ".llmwiki-pending-prompts"
+    created_files: list[Path] = []
+    yield pending, created_files
+    # Cleanup — remove only the files this test created.
+    for p in created_files:
+        if p.exists():
+            try:
+                p.unlink()
+            except OSError:
+                pass
+    # If we created the directory and it's now empty, remove it.
+    if pending.exists() and not any(pending.iterdir()):
+        try:
+            pending.rmdir()
+        except OSError:
+            pass
+
+
+# ─── --list-pending ───────────────────────────────────────────────────
+
+
+def test_list_pending_no_prompts(scratch_repo, monkeypatch):
+    pending, _ = scratch_repo
+    # Make sure there's nothing pending for this test.
+    if pending.exists():
+        for p in pending.glob("*.md"):
+            # Don't touch existing real prompts; skip if any present.
+            pytest.skip("real pending prompts present — skipping to avoid disturbing them")
+    result = _run_cli("synthesize", "--list-pending", cwd=REPO_ROOT)
+    assert result.returncode == 0
+    assert "No pending prompts" in result.stdout
+
+
+def test_list_pending_with_prompts(scratch_repo):
+    pending, created = scratch_repo
+    pending.mkdir(parents=True, exist_ok=True)
+    uid = "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
+    prompt = pending / f"{uid}.md"
+    prompt.write_text(
+        "<!-- pending-slug: test-slug -->\n"
+        "<!-- pending-project: test-project -->\n"
+        "<!-- pending-date: 2026-04-21 -->\n\n"
+        "Prompt body goes here.",
+        encoding="utf-8",
+    )
+    created.append(prompt)
+
+    result = _run_cli("synthesize", "--list-pending", cwd=REPO_ROOT)
+    assert result.returncode == 0
+    assert uid in result.stdout
+    assert "test-slug" in result.stdout
+    assert "test-project" in result.stdout
+    assert "2026-04-21" in result.stdout
+    assert "pending prompt" in result.stdout  # "N pending prompt(s)."
+
+
+# ─── --complete argument validation ──────────────────────────────────
+
+
+def test_complete_without_page_exits_1(tmp_path):
+    result = _run_cli("synthesize", "--complete", "deadbeef", cwd=tmp_path)
+    assert result.returncode == 1
+    assert "--page" in result.stderr
+
+
+def test_complete_without_body_or_stdin_exits_1(tmp_path):
+    page = tmp_path / "p.md"
+    page.write_text("stub", encoding="utf-8")
+    result = _run_cli(
+        "synthesize", "--complete", "deadbeef", "--page", str(page),
+        cwd=tmp_path,
+    )
+    # stdin is empty string → body empty → error
+    assert result.returncode == 1
+    assert "body" in result.stderr.lower()
+
+
+def test_complete_missing_page_file(tmp_path):
+    result = _run_cli(
+        "synthesize", "--complete", "deadbeef",
+        "--page", str(tmp_path / "nope.md"),
+        cwd=tmp_path,
+        input_text="some body",
+    )
+    assert result.returncode == 1
+    # FileNotFoundError from agent_delegate.complete_pending
+    assert "not found" in result.stderr.lower()
+
+
+def test_complete_page_without_sentinel(tmp_path):
+    page = tmp_path / "clean.md"
+    page.write_text(
+        "---\ntitle: x\n---\n\n## Summary\n\nNo sentinel here.\n",
+        encoding="utf-8",
+    )
+    result = _run_cli(
+        "synthesize", "--complete", "00000000-0000-0000-0000-000000000000",
+        "--page", str(page),
+        cwd=tmp_path,
+        input_text="## Summary\n\nBody.\n",
+    )
+    assert result.returncode == 1
+    assert "sentinel" in result.stderr.lower()
+
+
+def test_complete_uuid_mismatch(tmp_path):
+    actual_uid = "11111111-1111-1111-1111-111111111111"
+    page = tmp_path / "placeholder.md"
+    page.write_text(
+        "---\ntitle: x\n---\n\n"
+        f"<!-- llmwiki-pending: {actual_uid} -->\n\n"
+        "## Summary\n\nPending.\n",
+        encoding="utf-8",
+    )
+    result = _run_cli(
+        "synthesize", "--complete", "22222222-2222-2222-2222-222222222222",
+        "--page", str(page),
+        cwd=tmp_path,
+        input_text="## Summary\n\nBody.\n",
+    )
+    assert result.returncode == 1
+    assert "uuid" in result.stderr.lower()
+
+
+# ─── --complete happy paths ──────────────────────────────────────────
+
+
+def test_complete_with_body_file(tmp_path):
+    uid = "33333333-3333-3333-3333-333333333333"
+    page = tmp_path / "placeholder.md"
+    page.write_text(
+        "---\ntitle: x\ntags: [claude-code]\n---\n\n"
+        f"<!-- llmwiki-pending: {uid} -->\n\n"
+        "## Summary\n\nPending.\n",
+        encoding="utf-8",
+    )
+    body_file = tmp_path / "body.md"
+    body_file.write_text("## Summary\n\nAgent synthesis body.\n", encoding="utf-8")
+
+    result = _run_cli(
+        "synthesize", "--complete", uid,
+        "--page", str(page),
+        "--body", str(body_file),
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    final = page.read_text(encoding="utf-8")
+    assert "tags: [claude-code]" in final  # frontmatter preserved
+    assert "Agent synthesis body." in final  # body in place
+    assert "llmwiki-pending" not in final  # sentinel gone
+
+
+def test_complete_with_stdin(tmp_path):
+    uid = "44444444-4444-4444-4444-444444444444"
+    page = tmp_path / "placeholder.md"
+    page.write_text(
+        "---\ntitle: x\n---\n\n"
+        f"<!-- llmwiki-pending: {uid} -->\n\n"
+        "## Summary\n\nPending.\n",
+        encoding="utf-8",
+    )
+
+    result = _run_cli(
+        "synthesize", "--complete", uid,
+        "--page", str(page),
+        cwd=tmp_path,
+        input_text="## Summary\n\nStdin-supplied body.\n",
+    )
+    assert result.returncode == 0, result.stderr
+    final = page.read_text(encoding="utf-8")
+    assert "Stdin-supplied body." in final
+    assert "llmwiki-pending" not in final


### PR DESCRIPTION
## Summary

Bumps 1.1.0rc7 → 1.1.0rc8 and completes Mode B.  The backend shipped in rc7 (#316), this PR plumbs it through the CLI + `/wiki-sync` slash so it's actually usable end-to-end without an API key.

Mode A (API, #315) remains deferred per user request.

## What's new

| Surface | Change |
|---|---|
| CLI | `llmwiki synthesize --list-pending` prints pending prompts |
| CLI | `llmwiki synthesize --complete <uuid> --page <path>` rewrites placeholder |
| Slash | `/wiki-sync` step 6 auto-detects + drives completion |
| Slash | `/wiki-synthesize` maps "list pending" / "complete <uuid>" to CLI flags |
| Docs | `docs/modes/agent/backend.md` has real CLI surface + walkthrough |

## Exit codes for `--complete`

| Code | Reason |
|---|---|
| 0 | success |
| 1 | missing `--page` / empty body / missing target file / missing sentinel on target / uuid mismatch |

## `/wiki-sync` new step 6

After ingest, the slash runs `--list-pending`.  If empty → done.  Otherwise, for each pending uuid: reads `.llmwiki-pending-prompts/<uuid>.md`, synthesizes in-context (including the `<!-- suggested-tags: ... -->` block from #351), writes a scratch body, calls `--complete` to rewrite the placeholder and delete the prompt file.  Serial loop — agent is single-conversation.

## Test plan

- [x] `pytest tests/test_synthesize_cli_pending.py -v` — 9/9 green
- [x] Full `pytest --ignore=tests/e2e` — 2487 pass, 10 skip
- [x] Stdin + file input both exercised for `--body`
- [x] Missing `--page` exits 1 with `--page` in stderr
- [x] Empty body (no stdin, no `--body`) exits 1
- [x] Missing target file → FileNotFoundError exit 1
- [x] Target without sentinel → ValueError exit 1
- [x] UUID mismatch between page sentinel and `--complete` arg → exit 1
- [x] CHANGELOG `[1.1.0-rc8]` dated 2026-04-21
- [x] README version table row added

## Bundle

- `llmwiki/cli.py` — 4 new flags on `synthesize` subcommand + 2 helper functions
- `llmwiki/__init__.py`, `pyproject.toml` — version bump
- `README.md` — badge + table
- `CHANGELOG.md` — `[1.1.0-rc8]` under Added + Changed
- `tests/test_synthesize_cli_pending.py` — new (9 tests)
- `.claude/commands/wiki-sync.md` — step 6 added
- `.claude/commands/wiki-synthesize.md` — 2 new natural-language rows
- `docs/modes/agent/backend.md` — expanded CLI + `/wiki-sync` sections

## Next

After merge: sign `v1.1.0-rc8` tag, push, publish GitHub Release.