### PR TITLE
chore: adopt cache_tier + reader_shell on seeded wiki pages (#285)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+### Changed
+
+- **Live adoption of `cache_tier` + `reader_shell` on seeded wiki pages** (#285) — 6 committed wiki pages now carry explicit `cache_tier` (4× L2, 2× L1) and 2 have `reader_shell: true`. The `cache_tier_consistency` lint rule now runs against real data and correctly flags the 2 L1 pages as needing inbound wikilinks (which is useful, actionable info). `docs/reference/cache-tiers.md` + `docs/reference/reader-shell.md` gain "Live adopters" sections listing the opt-in pages + why each tier was picked. Closes the loop on two features that shipped scaffolds + tests + docs but had zero real adoption.
+
 ## [1.1.0-rc8] — 2026-04-21
 
 rc8 batch.  Completes Mode B end-to-end with CLI + slash-command plumbing on top of the agent-delegate backend from rc8.

--- a/docs/reference/cache-tiers.md
+++ b/docs/reference/cache-tiers.md
@@ -93,10 +93,27 @@ if is_preloaded(tier):
   `llmwiki lint` + explicit queries, but pay zero context cost for
   typical questions.
 
+## Live adopters (#285)
+
+Pages carrying an explicit `cache_tier` as of v1.1.0-rc8:
+
+| Page | Tier | Why |
+|---|---|---|
+| [`wiki/entities/ClaudeSonnet4.md`](../../wiki/entities/ClaudeSonnet4.md) | L1 | Flagship model entity — queries about current Claude behaviour always need this |
+| [`wiki/entities/GPT5.md`](../../wiki/entities/GPT5.md) | L2 | Reference comparison point, hot but not always loaded |
+| [`wiki/projects/llm-wiki.md`](../../wiki/projects/llm-wiki.md) | L1 | Meta project page — the framework's own canonical entry |
+| [`wiki/projects/demo-blog-engine.md`](../../wiki/projects/demo-blog-engine.md) | L2 | Demo project, loaded when queries touch SSG / Rust |
+| [`wiki/projects/demo-ml-pipeline.md`](../../wiki/projects/demo-ml-pipeline.md) | L2 | Demo project, loaded when queries touch ML / HuggingFace |
+| [`wiki/projects/demo-todo-api.md`](../../wiki/projects/demo-todo-api.md) | L2 | Demo project, loaded when queries touch FastAPI / OAuth2 |
+
+This exercises `CacheTierConsistency` in real conditions.  To opt a page in, add `cache_tier: L1` (or `L2`/`L3`/`L4`) to its frontmatter.
+
 ## Related
 
 - `#52` — the issue that shipped this
+- `#285` — live-adoption polish
 - `llmwiki/cache_tiers.py` — implementation
 - `llmwiki/lint/rules.py :: CacheTierConsistency` — lint rule
+- `docs/reference/reader-shell.md` — sibling opt-in feature, see "Live adopters" there
 - `docs/reference/prompt-caching.md` — sibling: Anthropic-level prompt
   cache control

--- a/docs/reference/reader-shell.md
+++ b/docs/reference/reader-shell.md
@@ -169,10 +169,23 @@ under `.reader-shell`:
   the first real adopter is a maintainer-chosen page. Bulk migration is
   a follow-up.
 
+## Live adopters (#285)
+
+Pages with `reader_shell: true` as of v1.1.0-rc8:
+
+| Page | Why |
+|---|---|
+| [`wiki/entities/ClaudeSonnet4.md`](../../wiki/entities/ClaudeSonnet4.md) | Flagship model entity — has infobox-worthy pricing, benchmarks, modalities that map cleanly to the Wikipedia-style shell |
+| [`wiki/projects/llm-wiki.md`](../../wiki/projects/llm-wiki.md) | Meta project page — showcases `reader_shell` on the framework's own canonical page |
+
+To opt a page in, add `reader_shell: true` to its frontmatter and rebuild with `llmwiki build`. The shell renders infobox + table of contents + references rail automatically from the page's existing frontmatter + wikilinks.
+
 ## Related
 
 - `llmwiki/reader_shell.py` — implementation
 - `llmwiki/render/css.py` — where `READER_SHELL_CSS` gets appended
 - `docs/design/brand-system.md` — the CSS tokens this shell inherits
+- `docs/reference/cache-tiers.md` — sibling opt-in feature, now also has live adopters (#285)
 - `#112` — this issue
 - `#114` — static prototype hub (the sibling layout surface)
+- `#285` — live-adoption polish for this + cache_tier

--- a/wiki/entities/ClaudeSonnet4.md
+++ b/wiki/entities/ClaudeSonnet4.md
@@ -14,6 +14,8 @@ sources: []
 confidence: 0.56
 lifecycle: reviewed
 entity_type: tool
+cache_tier: L1
+reader_shell: true
 ---
 
 # Claude Sonnet 4

--- a/wiki/entities/GPT5.md
+++ b/wiki/entities/GPT5.md
@@ -14,6 +14,7 @@ sources: []
 confidence: 0.56
 lifecycle: reviewed
 entity_type: tool
+cache_tier: L2
 ---
 
 # GPT-5

--- a/wiki/projects/demo-blog-engine.md
+++ b/wiki/projects/demo-blog-engine.md
@@ -6,6 +6,7 @@ project: demo-blog-engine
 topics: [rust, blog, ssg, pulldown-cmark, syntect, markdown]
 description: "Minimal Rust static site generator for a personal blog. Markdown → HTML pipeline, front-matter parsing, syntax highlighting via syntect, RSS feed, and a dark-mode toggle."
 homepage: "https://example.com/demo-blog-engine"
+cache_tier: L2
 ---
 
 # demo-blog-engine

--- a/wiki/projects/demo-ml-pipeline.md
+++ b/wiki/projects/demo-ml-pipeline.md
@@ -6,6 +6,7 @@ project: demo-ml-pipeline
 topics: [python, machine-learning, distilbert, transformers, huggingface, wandb, training, fine-tuning]
 description: "DistilBERT fine-tuning pipeline — data preparation, HuggingFace Trainer loop, W&B logging, and evaluation. Uses the classic transformers + datasets stack."
 homepage: "https://example.com/demo-ml-pipeline"
+cache_tier: L2
 ---
 
 # demo-ml-pipeline

--- a/wiki/projects/demo-todo-api.md
+++ b/wiki/projects/demo-todo-api.md
@@ -6,6 +6,7 @@ project: demo-todo-api
 topics: [python, fastapi, rest, oauth2, sqlite, api, crud, web]
 description: "FastAPI CRUD service for a to-do app — bootstrap, SQLite persistence layer, then OAuth2 authentication with the Authorization Code flow. Small and real."
 homepage: "https://example.com/demo-todo-api"
+cache_tier: L2
 ---
 
 # demo-todo-api

--- a/wiki/projects/llm-wiki.md
+++ b/wiki/projects/llm-wiki.md
@@ -6,6 +6,8 @@ project: llm-wiki
 topics: [python, wiki, karpathy, claude-code, static-site, markdown, open-source]
 description: "The llmwiki framework itself — a Karpathy-style LLM knowledge base compiled from Claude Code session transcripts. Stdlib Python, no server, no database."
 homepage: "https://github.com/Pratiyush/llm-wiki"
+cache_tier: L1
+reader_shell: true
 ---
 
 # llm-wiki


### PR DESCRIPTION
## Summary

Closes #285.  Both `cache_tier` (#52) and `reader_shell` (#112) shipped scaffolds + tests + docs but zero live adoption on committed pages.  This PR closes that gap.

## `cache_tier` adoption (6 pages, target ≥ 5)

| Page | Tier | Why |
|---|---|---|
| `wiki/entities/ClaudeSonnet4.md` | L1 | Flagship model — always needed for Claude queries |
| `wiki/entities/GPT5.md` | L2 | Reference comparison point |
| `wiki/projects/llm-wiki.md` | L1 | Meta project canonical page |
| `wiki/projects/demo-blog-engine.md` | L2 | Demo project, loaded on SSG / Rust queries |
| `wiki/projects/demo-ml-pipeline.md` | L2 | Demo project, loaded on ML queries |
| `wiki/projects/demo-todo-api.md` | L2 | Demo project, loaded on FastAPI / OAuth queries |

## `reader_shell` adoption (2 pages, target ≥ 1)

- `wiki/entities/ClaudeSonnet4.md` — infobox-friendly model metadata
- `wiki/projects/llm-wiki.md` — the framework's own canonical page

## Docs

- `docs/reference/cache-tiers.md` — new "Live adopters (#285)" section with the tier table
- `docs/reference/reader-shell.md` — new "Live adopters (#285)" section

## Lint

```
## cache_tier_consistency (2)
  [info] entities/ClaudeSonnet4.md: L1 page has no inbound [[wikilinks]]…
  [info] projects/llm-wiki.md: L1 page has no inbound [[wikilinks]]…
```

Both are `[info]` level (actionable guidance, not failure).  Overall `llmwiki lint` exits 0.  This is exactly what #285 wanted — the rule exercised on real data, surfacing a small real concern.

## Test plan

- [x] `pytest --ignore=tests/e2e` — 2487 pass, 10 skip
- [x] `llmwiki lint` exit 0
- [x] Both lint rules fire correctly against the new frontmatter
- [x] Acceptance bar met: ≥ 5 pages with cache_tier, ≥ 1 with reader_shell