### PR TITLE
Resolve #376 + #377 — Audit fixes + wiki-all command

### DIFF
--- a/.claude/commands/wiki-all.md
+++ b/.claude/commands/wiki-all.md
@@ -1,0 +1,37 @@
+Run the full llmwiki pipeline end-to-end: build → graph → export all → lint.
+
+Usage: /wiki-all [flags]
+
+`$ARGUMENTS` is forwarded verbatim to `python3 -m llmwiki all`. Common flags:
+
+- `--graph-engine builtin` — skip optional Graphify (use when `pip install llmwiki[graph]` has not been run)
+- `--skip-graph` — skip the graph step entirely
+- `--strict` — exit non-zero if lint reports any errors/warnings (good for CI)
+- `--fail-fast` — stop at the first non-zero step instead of continuing to the next
+- `--out <dir>` — output directory (default: `site/`)
+
+Run:
+
+```bash
+python3 -m llmwiki all $ARGUMENTS
+```
+
+The command runs these steps in order and surfaces their combined output:
+
+1. **build** — compile the static HTML site from `raw/` + `wiki/`
+2. **graph** — build the knowledge graph (`graph/graph.json` + interactive `graph.html`)
+3. **export all** — write every AI-consumable format (`llms.txt`, `llms-full.txt`, `graph.jsonld`, `sitemap.xml`, `rss.xml`, `robots.txt`, `ai-readme.md`)
+4. **lint** — run every registered lint rule against the wiki
+
+Report to the user:
+
+- Output directory and total file / size count from the build step
+- Graph stats (pages · edges · broken · orphans)
+- Which export files were written
+- Lint summary (errors / warnings / info)
+- Overall exit code — `0` means every step succeeded
+
+If any step fails, surface the failing step's output and the pipeline exit code.
+
+Use this instead of chaining `/wiki-build` + `/wiki-graph` + `/wiki-lint` manually.
+It is the canonical one-shot "CI-ready site" command to run after `/wiki-sync`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -411,6 +411,37 @@ to build the graph.
 
 ---
 
+## `all` — run the full pipeline
+
+Convenience entry point that runs `build` → `graph` → `export all` → `lint`
+in order. This is the one command to run after `sync` to produce a
+CI-ready site.
+
+```bash
+python3 -m llmwiki all
+python3 -m llmwiki all --graph-engine builtin   # skip optional graphify
+python3 -m llmwiki all --skip-graph --strict    # fail CI on any lint issue
+```
+
+### Flags
+
+| Flag | What |
+|---|---|
+| `--out DIR` | Output dir for build + export. Default: `site/`. |
+| `--search-mode {auto,tree,flat}` | Forwarded to `build`. Default: `auto`. |
+| `--graph-engine {builtin,graphify}` | Forwarded to `graph`. Default: `graphify`. |
+| `--skip-graph` | Skip the graph step entirely (useful when graphify is not installed). |
+| `--fail-fast` | Stop at the first non-zero step. Default: continue, report the worst exit code. |
+| `--strict` | Exit `2` if `lint` reports any errors/warnings. |
+
+Exit codes:
+
+- `0` — every step succeeded.
+- non-zero — forwarded from the first (or worst) failing step.
+- `2` — `--strict` and lint reported issues.
+
+---
+
 ## Exit codes (conventions)
 
 | Code | Meaning |

--- a/docs/reference/slash-commands.md
+++ b/docs/reference/slash-commands.md
@@ -11,11 +11,11 @@ what it does, what it runs under the hood, and a realistic invocation
 example. Use these inside **Claude Code** — Codex CLI picks the same
 files up via `install-skills`.
 
-Summary of **17 commands in 4 groups**:
+Summary of **18 commands in 4 groups**:
 
 | Group | Commands |
 |---|---|
-| **Wiki pipeline** (13) | `/wiki-init` `/wiki-sync` `/wiki-ingest` `/wiki-query` `/wiki-update` `/wiki-lint` `/wiki-candidates` `/wiki-synthesize` `/wiki-graph` `/wiki-reflect` `/wiki-build` `/wiki-serve` `/wiki-export-marp` |
+| **Wiki pipeline** (14) | `/wiki-init` `/wiki-sync` `/wiki-ingest` `/wiki-query` `/wiki-update` `/wiki-lint` `/wiki-candidates` `/wiki-synthesize` `/wiki-graph` `/wiki-reflect` `/wiki-build` `/wiki-serve` `/wiki-export-marp` `/wiki-all` |
 | **Governance / maintainer** (4) | `/maintainer` `/release` `/review-pr` `/triage-issue` |
 
 ---
@@ -352,6 +352,29 @@ Claude will pass `--host 0.0.0.0`.
 /wiki-export-marp topic "cache tiers"
 /wiki-export-marp topic Karpathy save to ~/slides/karpathy.marp.md
 ```
+
+---
+
+### `/wiki-all`
+
+**What:** run the full pipeline end-to-end — build → graph → export all → lint.
+
+**Wraps:** `python3 -m llmwiki all`.
+
+**When to use:** after `/wiki-sync`, when you want a CI-ready site in one shot
+instead of chaining `/wiki-build` + `/wiki-graph` + `/wiki-lint` yourself.
+
+**Example:**
+
+```
+/wiki-all
+/wiki-all --graph-engine builtin
+/wiki-all --skip-graph --strict
+```
+
+Pass `--strict` to turn any lint warning into a non-zero exit, which is
+exactly what CI wants. Pass `--skip-graph` or `--graph-engine builtin`
+when the optional Graphify backend is not installed.
 
 ---
 

--- a/examples/demo-sessions/demo-blog-engine/2026-03-12-scaffolding-the-rust-blog-engine.md
+++ b/examples/demo-sessions/demo-blog-engine/2026-03-12-scaffolding-the-rust-blog-engine.md
@@ -13,12 +13,12 @@ cwd: /Users/demo/code/demo-blog-engine
 gitBranch: main
 permissionMode: default
 model: claude-sonnet-4-6
-user_messages: 6
-tool_calls: 18
-tools_used: [Read, Write, Edit, Bash, Glob, Grep]
-tool_counts: {"Write": 6, "Read": 5, "Edit": 4, "Bash": 2, "Glob": 1}
+user_messages: 3
+tool_calls: 8
+tools_used: [Bash, Edit, Read, Write]
+tool_counts: {"Write": 4, "Bash": 2, "Edit": 1, "Read": 1}
 token_totals: {"input": 8400, "cache_creation": 12000, "cache_read": 31000, "output": 4200}
-turn_count: 6
+turn_count: 3
 hour_buckets: {"2026-03-12T09": 7, "2026-03-12T10": 11, "2026-03-12T11": 4}
 duration_seconds: 7912
 is_subagent: false

--- a/examples/demo-sessions/demo-blog-engine/2026-03-18-adding-syntax-highlighting.md
+++ b/examples/demo-sessions/demo-blog-engine/2026-03-18-adding-syntax-highlighting.md
@@ -13,12 +13,12 @@ cwd: /Users/demo/code/demo-blog-engine
 gitBranch: feat/syntax-highlight
 permissionMode: default
 model: claude-sonnet-4-6
-user_messages: 4
-tool_calls: 12
-tools_used: [Read, Edit, Bash, Grep]
-tool_counts: {"Edit": 5, "Read": 4, "Bash": 2, "Grep": 1}
+user_messages: 2
+tool_calls: 5
+tools_used: [Bash, Edit, Read]
+tool_counts: {"Edit": 2, "Bash": 2, "Read": 1}
 token_totals: {"input": 6100, "cache_creation": 9400, "cache_read": 22000, "output": 3100}
-turn_count: 4
+turn_count: 2
 hour_buckets: {"2026-03-18T14": 6, "2026-03-18T15": 8, "2026-03-18T16": 2}
 duration_seconds: 6342
 is_subagent: false

--- a/examples/demo-sessions/demo-blog-engine/2026-03-25-rss-feed-and-sitemap.md
+++ b/examples/demo-sessions/demo-blog-engine/2026-03-25-rss-feed-and-sitemap.md
@@ -13,12 +13,12 @@ cwd: /Users/demo/code/demo-blog-engine
 gitBranch: feat/feeds
 permissionMode: default
 model: claude-sonnet-4-6
-user_messages: 3
-tool_calls: 9
-tools_used: [Read, Write, Bash]
-tool_counts: {"Write": 4, "Read": 3, "Bash": 2}
+user_messages: 2
+tool_calls: 4
+tools_used: [Bash, Edit, Write]
+tool_counts: {"Write": 2, "Edit": 1, "Bash": 1}
 token_totals: {"input": 4800, "cache_creation": 7200, "cache_read": 18000, "output": 2400}
-turn_count: 3
+turn_count: 2
 hour_buckets: {"2026-03-25T10": 6, "2026-03-25T11": 3}
 duration_seconds: 5400
 is_subagent: false

--- a/examples/demo-sessions/demo-blog-engine/2026-04-01-dark-mode-toggle.md
+++ b/examples/demo-sessions/demo-blog-engine/2026-04-01-dark-mode-toggle.md
@@ -13,12 +13,12 @@ cwd: /Users/demo/code/demo-blog-engine
 gitBranch: feat/dark-mode
 permissionMode: default
 model: gemini-2.5-pro
-user_messages: 3
-tool_calls: 8
-tools_used: [Read, Edit, Write]
-tool_counts: {"Edit": 4, "Read": 2, "Write": 2}
+user_messages: 1
+tool_calls: 3
+tools_used: [Edit, Write]
+tool_counts: {"Edit": 2, "Write": 1}
 token_totals: {"input": 3800, "cache_creation": 6000, "cache_read": 15000, "output": 1900}
-turn_count: 3
+turn_count: 1
 hour_buckets: {"2026-04-01T15": 6, "2026-04-01T16": 2}
 duration_seconds: 4500
 is_subagent: false

--- a/examples/demo-sessions/demo-ml-pipeline/2026-01-20-training-data-pipeline.md
+++ b/examples/demo-sessions/demo-ml-pipeline/2026-01-20-training-data-pipeline.md
@@ -13,12 +13,12 @@ cwd: /Users/demo/code/demo-ml-pipeline
 gitBranch: main
 permissionMode: default
 model: gpt-5.4
-user_messages: 7
-tool_calls: 24
-tools_used: [Read, Write, Edit, Bash, Glob, Grep]
-tool_counts: {"Read": 8, "Edit": 6, "Write": 5, "Bash": 3, "Grep": 2}
+user_messages: 2
+tool_calls: 5
+tools_used: [Bash, Write]
+tool_counts: {"Write": 4, "Bash": 1}
 token_totals: {"input": 14000, "cache_creation": 22000, "cache_read": 52000, "output": 6400}
-turn_count: 7
+turn_count: 2
 hour_buckets: {"2026-01-20T09": 8, "2026-01-20T10": 10, "2026-01-20T11": 4, "2026-01-20T12": 2}
 duration_seconds: 11700
 is_subagent: false

--- a/examples/demo-sessions/demo-ml-pipeline/2026-02-02-model-training-loop.md
+++ b/examples/demo-sessions/demo-ml-pipeline/2026-02-02-model-training-loop.md
@@ -13,12 +13,12 @@ cwd: /Users/demo/code/demo-ml-pipeline
 gitBranch: feat/train-loop
 permissionMode: default
 model: gpt-5.4
-user_messages: 9
-tool_calls: 31
-tools_used: [Read, Write, Edit, Bash, Grep, WebFetch]
-tool_counts: {"Edit": 12, "Read": 9, "Write": 5, "Bash": 3, "Grep": 1, "WebFetch": 1}
+user_messages: 2
+tool_calls: 2
+tools_used: [Bash, Write]
+tool_counts: {"Write": 1, "Bash": 1}
 token_totals: {"input": 18000, "cache_creation": 28000, "cache_read": 71000, "output": 8200}
-turn_count: 9
+turn_count: 2
 hour_buckets: {"2026-02-02T11": 6, "2026-02-02T12": 10, "2026-02-02T13": 8, "2026-02-02T14": 5, "2026-02-02T15": 2}
 duration_seconds: 16200
 is_subagent: false

--- a/examples/demo-sessions/demo-todo-api/2026-02-08-fastapi-project-bootstrap.md
+++ b/examples/demo-sessions/demo-todo-api/2026-02-08-fastapi-project-bootstrap.md
@@ -13,12 +13,12 @@ cwd: /Users/demo/code/demo-todo-api
 gitBranch: main
 permissionMode: default
 model: copilot/claude-sonnet-4
-user_messages: 5
-tool_calls: 15
-tools_used: [Read, Write, Edit, Bash]
-tool_counts: {"Write": 7, "Edit": 4, "Read": 2, "Bash": 2}
+user_messages: 2
+tool_calls: 6
+tools_used: [Bash, Write]
+tool_counts: {"Write": 5, "Bash": 1}
 token_totals: {"input": 7200, "cache_creation": 10000, "cache_read": 25000, "output": 3600}
-turn_count: 5
+turn_count: 2
 hour_buckets: {"2026-02-08T08": 5, "2026-02-08T09": 7, "2026-02-08T10": 3}
 duration_seconds: 8100
 is_subagent: false

--- a/examples/demo-sessions/demo-todo-api/2026-02-15-adding-oauth-login.md
+++ b/examples/demo-sessions/demo-todo-api/2026-02-15-adding-oauth-login.md
@@ -13,12 +13,12 @@ cwd: /Users/demo/code/demo-todo-api
 gitBranch: feat/oauth
 permissionMode: default
 model: claude-sonnet-4-6
-user_messages: 8
-tool_calls: 22
-tools_used: [Read, Write, Edit, Bash, WebFetch, Grep]
-tool_counts: {"Edit": 8, "Read": 6, "Write": 3, "Bash": 3, "WebFetch": 1, "Grep": 1}
+user_messages: 2
+tool_calls: 5
+tools_used: [Bash, Edit, Write]
+tool_counts: {"Edit": 2, "Bash": 2, "Write": 1}
 token_totals: {"input": 12000, "cache_creation": 18000, "cache_read": 45000, "output": 5600}
-turn_count: 8
+turn_count: 2
 hour_buckets: {"2026-02-15T13": 8, "2026-02-15T14": 10, "2026-02-15T15": 4}
 duration_seconds: 9600
 is_subagent: false

--- a/llmwiki/build.py
+++ b/llmwiki/build.py
@@ -140,6 +140,48 @@ def group_by_project(
     return g
 
 
+def ensure_project_stubs(
+    groups: dict[str, list[tuple[Path, dict[str, Any], str]]],
+    meta_dir: Path,
+) -> list[Path]:
+    """Auto-seed ``wiki/projects/<slug>.md`` for any discovered project
+    that doesn't already have one (`issues-commands.md` I-12).
+
+    Without this, real projects render a bare hero — no description, no
+    topic chips, no homepage — because those fields come from a hand-
+    authored file that never gets created on sync. Seeding an empty stub
+    gets every real project to demo-parity the moment the user fills in
+    two or three fields. Existing files are never overwritten.
+
+    Returns the list of stub paths actually written (empty if all project
+    metadata files already existed).
+    """
+    meta_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    for slug in sorted(groups):
+        target = meta_dir / f"{slug}.md"
+        if target.exists():
+            continue
+        stub = (
+            f"---\n"
+            f'title: "{slug}"\n'
+            f"type: entity\n"
+            f"entity_type: project\n"
+            f"project: {slug}\n"
+            f"topics: []\n"
+            f'description: ""\n'
+            f'homepage: ""\n'
+            f"---\n\n"
+            f"# {slug}\n\n"
+            f"*Auto-generated project stub. Fill in `description`, "
+            f"`topics`, and `homepage` in the frontmatter above to "
+            f"enable the rich hero rendering on this project's page.*\n"
+        )
+        target.write_text(stub, encoding="utf-8")
+        written.append(target)
+    return written
+
+
 # ─── markdown normaliser + renderer ───────────────────────────────────────
 
 _H1_LINE_RE = re.compile(r"^#\s+.*\n", re.MULTILINE)
@@ -1787,6 +1829,12 @@ def build_site(
     print(f"  found {len(sources)} source markdowns")
     groups = group_by_project(sources)
     print(f"  grouped into {len(groups)} projects")
+
+    # I-12 (issues-commands.md): auto-seed wiki/projects/<slug>.md stubs
+    # so real projects get the same hero surface area as demo projects.
+    stubs_written = ensure_project_stubs(groups, PROJECTS_META_DIR)
+    if stubs_written:
+        print(f"  seeded {len(stubs_written)} new wiki/projects/ stubs")
 
     # Reset output dir (clear contents only — the HTTP server may be cwd'd here)
     if out_dir.exists():

--- a/llmwiki/cli.py
+++ b/llmwiki/cli.py
@@ -14,6 +14,7 @@ Subcommands:
     lint              Run lint rules against the wiki
     candidates        List / promote / merge / discard candidate pages
     synthesize        Synthesize wiki source pages from raw sessions via LLM
+    all               Run the full pipeline: build → graph → export all → lint
     version           Print version and exit
 """
 
@@ -31,6 +32,77 @@ from llmwiki.adapters import REGISTRY, discover_adapters
 def cmd_version(args: argparse.Namespace) -> int:
     print(f"llmwiki {__version__}")
     return 0
+
+
+def cmd_all(args: argparse.Namespace) -> int:
+    """Run the full wiki pipeline end-to-end: build → graph → export all → lint.
+
+    This is the convenience entry point advertised as ``wiki-all`` in docs and
+    slash commands. It executes the usual post-sync steps in the canonical
+    order so a single command reproduces a CI-ready site.
+
+    Exit codes:
+      0  every step succeeded (lint warnings are informational).
+      1  at least one step returned a non-zero exit status.
+      2  ``--strict`` was passed and lint reported any error or warning.
+    """
+    import shlex
+
+    steps: list[tuple[str, list[str]]] = []
+    build_args = ["build", "--out", str(args.out)]
+    if args.search_mode:
+        build_args.extend(["--search-mode", args.search_mode])
+    steps.append(("build", build_args))
+
+    if not args.skip_graph:
+        steps.append(("graph", ["graph", "--format", "both", "--engine", args.graph_engine]))
+
+    steps.append(("export", ["export", "all", "--out", str(args.out)]))
+    # ``lint --fail-on-errors`` so error-severity issues already fail the step;
+    # ``--strict`` additionally escalates warnings (checked below).
+    lint_argv = ["lint", "--fail-on-errors"] if args.strict else ["lint"]
+    steps.append(("lint", lint_argv))
+
+    overall_rc = 0
+    lint_rc: Optional[int] = None
+    for name, argv in steps:
+        print(f"\n==> llmwiki {' '.join(shlex.quote(a) for a in argv)}")
+        sub_args = build_parser().parse_args(argv)
+        rc = sub_args.func(sub_args)
+        if name == "lint":
+            lint_rc = rc
+            continue  # lint's own exit policy is handled below
+        if rc != 0:
+            overall_rc = rc if overall_rc == 0 else overall_rc
+            if args.fail_fast:
+                print(f"error: step '{name}' exited {rc}; stopping (--fail-fast).", file=sys.stderr)
+                return rc
+
+    if args.strict:
+        # ``--strict`` escalates *any* lint signal — errors OR warnings —
+        # into a pipeline failure. Re-read the lint report directly so we
+        # don't depend on lint's own exit code, which by design only fires
+        # on error-severity issues.
+        from llmwiki.lint import load_pages, run_all, summarize
+        wiki_dir = REPO_ROOT / "wiki"
+        if wiki_dir.is_dir():
+            pages = load_pages(wiki_dir)
+            issues = run_all(pages)
+            counts = summarize(issues) if issues else {}
+            errors = counts.get("error", 0)
+            warnings = counts.get("warning", 0)
+            if errors or warnings:
+                print(
+                    f"error: --strict: lint reported "
+                    f"{errors} error(s) + {warnings} warning(s).",
+                    file=sys.stderr,
+                )
+                return 2
+
+    if lint_rc not in (None, 0) and overall_rc == 0:
+        overall_rc = lint_rc
+
+    return overall_rc
 
 
 def cmd_init(args: argparse.Namespace) -> int:
@@ -59,7 +131,7 @@ def cmd_init(args: argparse.Namespace) -> int:
         "wiki/hot.md": '---\ntitle: "Hot Cache"\ntype: navigation\nlast_updated: ""\nauto_maintained: true\n---\n\n# Hot Cache\n\n*Auto-maintained. Last 10 session summaries.*\n',
         "wiki/MEMORY.md": '---\ntitle: "Cross-Session Memory"\ntype: navigation\nlast_updated: ""\nmax_lines: 200\n---\n\n# MEMORY\n\n*200-line cap. Auto-consolidated by Auto Dream.*\n\n## User\n\n## Feedback\n\n## Project\n\n## Reference\n',
         "wiki/SOUL.md": '---\ntitle: "Wiki Identity"\ntype: navigation\nlast_updated: ""\n---\n\n# SOUL\n\nThis wiki compiles raw session transcripts into structured, interlinked pages.\nCustomize this file to set your wiki\'s voice and purpose.\n',
-        "wiki/CRITICAL_FACTS.md": '---\ntitle: "Critical Facts"\ntype: navigation\nlast_updated: ""\n---\n\n# Critical Facts\n\n- raw/ is immutable — never modify files under raw/\n- Wiki uses [[wikilinks]] for cross-references\n- Confidence: 0.0-1.0, 4-factor formula\n- Lifecycle: draft > reviewed > verified > stale > archived\n',
+        "wiki/CRITICAL_FACTS.md": '---\ntitle: "Critical Facts"\ntype: navigation\nlast_updated: ""\n---\n\n# Critical Facts\n\n- raw/ is immutable — never modify files under raw/\n- Wiki uses Obsidian-style double-bracket syntax for cross-references\n- Confidence: 0.0-1.0, 4-factor formula\n- Lifecycle: draft > reviewed > verified > stale > archived\n',
     }
 
     # v1.0 (#153): seed dashboard.md from examples/wiki_dashboard.md template
@@ -301,7 +373,7 @@ def cmd_query(args: argparse.Namespace) -> int:
     """Query the knowledge graph with a natural language question."""
     from llmwiki.graphify_bridge import is_available, query_graph
     if not is_available():
-        print("error: graphifyy not installed. Run: pip install llmwiki[graph]", file=sys.stderr)
+        print("error: graphify not installed. Run: pip install llmwiki[graph]", file=sys.stderr)
         return 2
     question = " ".join(args.question)
     result = query_graph(question, depth=args.depth, token_budget=args.budget)
@@ -315,7 +387,7 @@ def cmd_graph(args: argparse.Namespace) -> int:
     if engine == "graphify":
         from llmwiki.graphify_bridge import is_available, build_graphify_graph
         if not is_available():
-            print("  graphifyy not installed — falling back to builtin engine", file=sys.stderr)
+            print("  graphify not installed — falling back to builtin engine", file=sys.stderr)
             print("  install with: pip install llmwiki[graph]", file=sys.stderr)
             engine = "builtin"
         else:
@@ -1086,6 +1158,37 @@ def build_parser() -> argparse.ArgumentParser:
     # version
     ver = sub.add_parser("version", help="Print version")
     ver.set_defaults(func=cmd_version)
+
+    # all — run build + graph + export all + lint in sequence
+    all_p = sub.add_parser(
+        "all",
+        help="Run the full pipeline: build → graph → export all → lint",
+    )
+    all_p.add_argument(
+        "--out", type=Path, default=REPO_ROOT / "site",
+        help="Output dir for build + export (default: site/)",
+    )
+    all_p.add_argument(
+        "--search-mode", choices=["auto", "tree", "flat"], default="auto",
+        help="Search index mode passed through to build (default: auto)",
+    )
+    all_p.add_argument(
+        "--graph-engine", choices=["builtin", "graphify"], default="graphify",
+        help="Graph engine passed through to graph (default: graphify)",
+    )
+    all_p.add_argument(
+        "--skip-graph", action="store_true",
+        help="Skip the graph step (useful when graphify is not installed)",
+    )
+    all_p.add_argument(
+        "--fail-fast", action="store_true",
+        help="Stop at the first non-zero step (default: continue, report worst exit code)",
+    )
+    all_p.add_argument(
+        "--strict", action="store_true",
+        help="Exit 2 if lint reports any errors/warnings",
+    )
+    all_p.set_defaults(func=cmd_all)
 
     return p
 

--- a/llmwiki/convert.py
+++ b/llmwiki/convert.py
@@ -1019,6 +1019,13 @@ def convert_all(
         })
         c[field] = c.get(field, 0) + 1
 
+    # Names claimed by this sync run. Independent of --force and of the
+    # state file — its sole purpose is to stop two source jsonls in this
+    # single run from writing to the same canonical filename. Without this
+    # set, `sync --force` silently overwrote colliding outputs because the
+    # disambiguator on disk was gated on ``not force`` (bug #339).
+    names_written_this_run: set[str] = set()
+
     for cls in selected:
         adapter = cls(config)
         print(f"==> adapter: {cls.name}")
@@ -1154,23 +1161,30 @@ def convert_all(
             date_str = started.strftime("%Y-%m-%d")
             out_name = flat_output_name(started, project_slug, slug)
             out_path = out_dir / out_name
-            # #339: if the canonical name already exists on disk AND
-            # the state file doesn't record US as the writer (different
-            # source jsonl), this is a real collision — retry with the
-            # jsonl's path-hash appended so both sources land side by
-            # side.  Parent session stays at the canonical filename;
-            # subagents + same-minute siblings carry a --<hash8> suffix.
-            if (
-                not dry_run
-                and not force
-                and out_path.exists()
-                and state.get(key) != mtime
-            ):
+            # #339: disambiguate when the canonical name would collide with
+            # a different source. Two cases, both must trigger the retry:
+            #   (a) Another source in THIS sync run already claimed the
+            #       canonical name. Independent of --force — otherwise
+            #       `sync --force` silently overwrites sibling sessions
+            #       whose project+date+slug happen to collide (~200
+            #       dropped sessions on a real claude-code corpus).
+            #   (b) Canonical exists on disk from a prior run AND the
+            #       state file does not record us as its writer. Only
+            #       consulted when --force is off; under --force the user
+            #       has explicitly asked to overwrite their own prior
+            #       outputs.
+            needs_disambig = not dry_run and (
+                out_name in names_written_this_run
+                or (not force and out_path.exists() and state.get(key) != mtime)
+            )
+            if needs_disambig:
                 out_name = flat_output_name(
                     started, project_slug, slug,
                     disambiguator=_source_hash8(path),
                 )
                 out_path = out_dir / out_name
+            if not dry_run:
+                names_written_this_run.add(out_name)
             if dry_run:
                 print(f"  [dry-run] {out_path.relative_to(REPO_ROOT)} ({len(md)} bytes)")
             else:

--- a/llmwiki/exporters.py
+++ b/llmwiki/exporters.py
@@ -31,9 +31,20 @@ from llmwiki import REPO_ROOT, __version__
 
 
 def _plain_text(markdown_body: str) -> str:
-    """Strip markdown to plain text (for llms-full and per-page .txt)."""
+    """Strip markdown to plain text (for llms-full and per-page .txt).
+
+    Fenced code blocks are unwrapped (fences removed, body preserved) so that
+    code in transcripts survives into AI-consumable exports. Previously this
+    replaced the entire block with a single space, which destroyed the most
+    valuable content in coding session transcripts.
+    """
     text = markdown_body
-    text = re.sub(r"```.*?```", " ", text, flags=re.DOTALL)
+    text = re.sub(
+        r"```[a-zA-Z0-9_+\-.]*\n?(.*?)```",
+        lambda m: m.group(1).rstrip() + "\n",
+        text,
+        flags=re.DOTALL,
+    )
     text = re.sub(r"`([^`]*)`", r"\1", text)
     text = re.sub(r"\[([^\]]*)\]\([^\)]*\)", r"\1", text)
     text = re.sub(r"\[\[([^\]]*)\]\]", r"\1", text)
@@ -55,6 +66,41 @@ def _page_id(project: str, slug: str) -> str:
     """Stable content-addressable ID for a page. Used in JSON-LD @id and
     cross-reference tables."""
     return f"{project}/{slug}"
+
+
+def _as_int(value: Any) -> Any:
+    """Coerce frontmatter scalars to int where possible; leave other types alone."""
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        s = value.strip()
+        if s.lstrip("-").isdigit():
+            try:
+                return int(s)
+            except ValueError:
+                return value
+    return value
+
+
+def _as_bool(value: Any) -> Any:
+    """Coerce frontmatter scalars to bool. Strings like 'false'/'0' map to False.
+
+    Critical because raw YAML-loaded strings like ``"false"`` are truthy in both
+    Python and JavaScript, which silently flips downstream boolean checks.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        s = value.strip().lower()
+        if s in ("true", "1", "yes"):
+            return True
+        if s in ("false", "0", "no", ""):
+            return False
+    return bool(value)
 
 
 # ─── per-page sibling files (A3 + A4) ────────────────────────────────────
@@ -87,10 +133,10 @@ def write_page_json(
         "cwd": meta.get("cwd"),
         "git_branch": meta.get("gitBranch"),
         "permission_mode": meta.get("permissionMode"),
-        "user_messages": meta.get("user_messages"),
-        "tool_calls": meta.get("tool_calls"),
+        "user_messages": _as_int(meta.get("user_messages")),
+        "tool_calls": _as_int(meta.get("tool_calls")),
         "tools_used": meta.get("tools_used"),
-        "is_subagent": meta.get("is_subagent"),
+        "is_subagent": _as_bool(meta.get("is_subagent")),
         "wikilinks_out": sorted(set(wikilinks_out)),
         "body_text": _plain_text(markdown_body),
         "sha256": _sha256_16(markdown_body),

--- a/llmwiki/graphify_bridge.py
+++ b/llmwiki/graphify_bridge.py
@@ -1,12 +1,12 @@
 """Graphify integration bridge for llmwiki.
 
 Delegates graph building, community detection, and analysis to the
-``graphifyy`` package (https://github.com/safishamsi/graphify) when
+``graphify`` package (https://github.com/safishamsi/graphify) when
 installed.  Falls back gracefully when not available.
 
-Install:  pip install graphifyy          # or: pip install llmwiki[graph]
-Extras:   pip install graphifyy[mcp]     # MCP server
-          pip install graphifyy[leiden]   # better community detection
+Install:  pip install graphify          # or: pip install llmwiki[graph]
+Extras:   pip install graphify[mcp]     # MCP server
+          pip install graphify[leiden]   # better community detection
 
 Usage from CLI:
     python3 -m llmwiki graph                  # graphify is default
@@ -33,7 +33,7 @@ GRAPHIFY_OUT = REPO_ROOT / "graphify-out"
 
 
 def is_available() -> bool:
-    """Return True when graphifyy is importable."""
+    """Return True when graphify is importable."""
     try:
         import graphify  # noqa: F401
         return True

--- a/llmwiki/lint/rules.py
+++ b/llmwiki/lint/rules.py
@@ -20,6 +20,8 @@ Post-v1.0 rules:
   13. cache_tier_consistency      (v1.2 · #52)
   14. tags_topics_convention      (G-16 · #302)
   15. stale_reference_detection   (G-17 · #303)
+  16. frontmatter_count_consistency  (v1.2 · issues.md #2)
+  17. tools_consistency              (v1.2 · issues.md #4)
 
 The live rule count lives in ``llmwiki.lint.REGISTRY`` — prefer
 ``len(REGISTRY)`` over hard-coded numbers in docs + help strings.
@@ -652,4 +654,139 @@ class StaleReferenceDetection(LintRule):
                     f"this page updated {stale.source_last_updated}): {excerpt!r}"
                 ),
             })
+        return issues
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  RULE 16 — frontmatter_count_consistency  (issues.md #2)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+_TURN_USER_RE = re.compile(r"^### Turn \d+ — User\s*$", re.MULTILINE)
+_TOOL_BULLET_RE = re.compile(
+    r"^- `(Read|Write|Edit|Bash|Glob|Grep|Task|WebFetch|WebSearch|TodoWrite)`:",
+    re.MULTILINE,
+)
+
+
+@register
+class FrontmatterCountConsistency(LintRule):
+    """Source pages: frontmatter counts must match the rendered body.
+
+    Catches the class of bug in `issues.md` #2 where `user_messages`,
+    `turn_count`, or `tool_calls` in the frontmatter claim more activity
+    than the body actually contains. This matters because the values
+    surface on the site, in the JSON sibling, and in the search index —
+    if they're wrong everywhere downstream is wrong.
+
+    Only runs on ``type: source`` pages. Counts come from:
+      - user_messages / turn_count → ``### Turn N — User`` headings
+      - tool_calls                 → ``- `ToolName`:`` bullet lines
+    """
+
+    name = "frontmatter_count_consistency"
+    severity = "warning"
+
+    def run(self, pages, *, llm_callback=None):
+        issues: list[dict[str, Any]] = []
+        for rel, page in pages.items():
+            meta = page["meta"]
+            if meta.get("type") != "source":
+                continue
+            body = page.get("body", "")
+            actual_turns = len(_TURN_USER_RE.findall(body))
+            actual_tool_calls = len(_TOOL_BULLET_RE.findall(body))
+
+            for field, actual in (
+                ("user_messages", actual_turns),
+                ("turn_count", actual_turns),
+                ("tool_calls", actual_tool_calls),
+            ):
+                claimed_raw = meta.get(field)
+                if claimed_raw in (None, ""):
+                    continue
+                try:
+                    claimed = int(claimed_raw)
+                except (TypeError, ValueError):
+                    continue
+                if claimed != actual:
+                    issues.append({
+                        "rule": self.name,
+                        "severity": self.severity,
+                        "page": rel,
+                        "message": (
+                            f"frontmatter {field}={claimed} but body has "
+                            f"{actual}"
+                        ),
+                    })
+        return issues
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  RULE 17 — tools_consistency  (issues.md #4)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+_TOOLS_USED_RE = re.compile(r"\[([^\]]*)\]")
+_TOOL_COUNTS_KEYS_RE = re.compile(r'"([A-Za-z_]+)"\s*:')
+
+
+@register
+class ToolsConsistency(LintRule):
+    """Source pages: ``tools_used`` and ``tool_counts.keys()`` must agree.
+
+    Catches the class of bug in `issues.md` #4 where a page lists a tool
+    in the ``tools_used`` frontmatter array but the corresponding
+    ``tool_counts`` object is missing that tool's entry (or vice-versa).
+    Both surface on the session page, so divergence silently misleads
+    anyone looking at the stats.
+    """
+
+    name = "tools_consistency"
+    severity = "warning"
+
+    def run(self, pages, *, llm_callback=None):
+        issues: list[dict[str, Any]] = []
+        for rel, page in pages.items():
+            meta = page["meta"]
+            if meta.get("type") != "source":
+                continue
+            tools_used_raw = meta.get("tools_used", "")
+            tool_counts_raw = meta.get("tool_counts", "")
+            if not tools_used_raw or not tool_counts_raw:
+                # One side missing — that's a different lint concern, skip.
+                continue
+
+            m = _TOOLS_USED_RE.search(tools_used_raw)
+            if not m:
+                continue
+            tools_used = {
+                t.strip().strip('"\'')
+                for t in m.group(1).split(",")
+                if t.strip()
+            }
+            tool_counts_keys = set(_TOOL_COUNTS_KEYS_RE.findall(tool_counts_raw))
+
+            only_used = tools_used - tool_counts_keys
+            only_counted = tool_counts_keys - tools_used
+            if only_used:
+                issues.append({
+                    "rule": self.name,
+                    "severity": self.severity,
+                    "page": rel,
+                    "message": (
+                        f"tools_used has {sorted(only_used)} but tool_counts "
+                        f"has no key for them"
+                    ),
+                })
+            if only_counted:
+                issues.append({
+                    "rule": self.name,
+                    "severity": self.severity,
+                    "page": rel,
+                    "message": (
+                        f"tool_counts has keys {sorted(only_counted)} but "
+                        f"tools_used does not list them"
+                    ),
+                })
         return issues

--- a/setup.sh
+++ b/setup.sh
@@ -34,10 +34,11 @@ python3 -m llmwiki init
 # 5. Show available adapters
 python3 -m llmwiki adapters
 
-# 6. First sync (dry-run so users see what would happen)
+# 6. First sync (status probe so users see how many sessions exist
+#    without actually converting them yet)
 echo
-echo "==> dry-run of first sync:"
-python3 -m llmwiki sync --dry-run || true
+echo "==> sync status:"
+python3 -m llmwiki sync --status || true
 
 echo
 echo "================================================================"

--- a/tests/test_collision_retry.py
+++ b/tests/test_collision_retry.py
@@ -148,3 +148,136 @@ def test_resync_same_source_is_idempotent(tmp_path, monkeypatch):
                   state_file=state, include_current=True)
     second = sorted(out_dir.rglob("*.md"))
     assert first == second, f"re-sync grew the tree: {first} → {second}"
+
+
+def test_force_sync_does_not_drop_colliding_sources(tmp_path, monkeypatch):
+    """Regression: sync --force used to gate the collision disambiguator
+    on ``not force``, so two sources producing the same canonical name
+    silently overwrote each other. On real corpora this cost ~200
+    sessions out of 495. Fix: disambiguation now keys off the set of
+    names written in THIS run, independent of --force.
+    """
+    home, proj, out_dir, state = _seed_env(tmp_path)
+    ts = "2026-04-16T10:00:00Z"
+
+    # Three sources, all collide on (date, project, slug) → same canonical.
+    _write_jsonl(proj / "a.jsonl", "sess-a", ts, slug="dup")
+    _write_jsonl(proj / "b.jsonl", "sess-b", ts, slug="dup")
+    _write_jsonl(proj / "c.jsonl", "sess-c", ts, slug="dup")
+
+    _patch(monkeypatch, home, out_dir, state)
+    c.discover_adapters()
+
+    # --force wipes state, which used to also wipe the collision guard.
+    c.convert_all(
+        adapters=["claude_code"], out_dir=out_dir, state_file=state,
+        include_current=True, force=True,
+    )
+
+    outs = sorted(out_dir.rglob("*.md"))
+    canonical = [p for p in outs if "--" not in p.name]
+    disambig = [p for p in outs if "--" in p.name]
+
+    # All 3 sources must land on disk — one at canonical, two with hashes.
+    assert len(outs) == 3, (
+        f"expected 3 files on disk, got {len(outs)}: {[p.name for p in outs]}"
+    )
+    assert len(canonical) == 1 and len(disambig) == 2, (
+        f"expected 1 canonical + 2 disambiguated, got "
+        f"canonical={[p.name for p in canonical]}, "
+        f"disambig={[p.name for p in disambig]}"
+    )
+
+
+def test_three_way_collision_no_force_all_land(tmp_path, monkeypatch):
+    """Without --force, three colliding sources still all land (1 canonical +
+    2 disambiguated). This is the baseline the --force path must match."""
+    home, proj, out_dir, state = _seed_env(tmp_path)
+    ts = "2026-04-16T10:00:00Z"
+
+    _write_jsonl(proj / "a.jsonl", "sess-a", ts, slug="triple")
+    _write_jsonl(proj / "b.jsonl", "sess-b", ts, slug="triple")
+    _write_jsonl(proj / "c.jsonl", "sess-c", ts, slug="triple")
+
+    _patch(monkeypatch, home, out_dir, state)
+    c.discover_adapters()
+    c.convert_all(
+        adapters=["claude_code"], out_dir=out_dir, state_file=state,
+        include_current=True, force=False,
+    )
+
+    outs = sorted(out_dir.rglob("*.md"))
+    canonical = [p for p in outs if "--" not in p.name]
+    disambig = [p for p in outs if "--" in p.name]
+    assert len(outs) == 3, [p.name for p in outs]
+    assert len(canonical) == 1 and len(disambig) == 2
+
+
+def test_resync_preserves_disambiguated_filenames(tmp_path, monkeypatch):
+    """After an initial sync creates one canonical + one disambiguated
+    file, a second sync (no --force) must leave the tree exactly as it
+    was. The state file remembers which source owned the hashed name,
+    so neither source regenerates or clobbers."""
+    home, proj, out_dir, state = _seed_env(tmp_path)
+    ts = "2026-04-16T10:00:00Z"
+
+    _write_jsonl(proj / "a.jsonl", "sess-a", ts, slug="same")
+    _write_jsonl(proj / "b.jsonl", "sess-b", ts, slug="same")
+
+    _patch(monkeypatch, home, out_dir, state)
+    c.discover_adapters()
+    c.convert_all(adapters=["claude_code"], out_dir=out_dir,
+                  state_file=state, include_current=True)
+
+    first = sorted(p.name for p in out_dir.rglob("*.md"))
+    assert len(first) == 2, first
+
+    # Second sync, same inputs, no --force. State says these sources
+    # are already converted (mtime unchanged), so sync should short-
+    # circuit at the "unchanged" branch and touch nothing on disk.
+    c.convert_all(adapters=["claude_code"], out_dir=out_dir,
+                  state_file=state, include_current=True)
+
+    second = sorted(p.name for p in out_dir.rglob("*.md"))
+    assert first == second, (
+        f"re-sync grew or renamed the tree: {first} → {second}"
+    )
+
+
+def test_disambiguated_names_stable_across_incremental_sync(tmp_path, monkeypatch):
+    """A new colliding source added in a later sync must NOT retroactively
+    rename already-written siblings. The original canonical + original
+    hash survive; only the newcomer gets its own hash.
+
+    Regression guard: a naive implementation of the "rewrite on collision"
+    path could re-assign hashes based on sort order, which would make
+    every existing disambiguated file orphan on the next sync — a silent
+    corruption that's much worse than the data-loss bug this module
+    already guards against.
+    """
+    home, proj, out_dir, state = _seed_env(tmp_path)
+    ts = "2026-04-16T10:00:00Z"
+
+    # Sync 1: two colliding sources → one canonical, one hashed.
+    _write_jsonl(proj / "first.jsonl", "sess-1", ts, slug="stable")
+    _write_jsonl(proj / "second.jsonl", "sess-2", ts, slug="stable")
+    _patch(monkeypatch, home, out_dir, state)
+    c.discover_adapters()
+    c.convert_all(adapters=["claude_code"], out_dir=out_dir,
+                  state_file=state, include_current=True)
+    after_first = sorted(p.name for p in out_dir.rglob("*.md"))
+    assert len(after_first) == 2
+
+    # Sync 2: add a third colliding source. The two from sync 1 must
+    # remain byte-identical; only a new file lands for sync-3's source.
+    _write_jsonl(proj / "third.jsonl", "sess-3", ts, slug="stable")
+    c.convert_all(adapters=["claude_code"], out_dir=out_dir,
+                  state_file=state, include_current=True)
+    after_second = sorted(p.name for p in out_dir.rglob("*.md"))
+
+    assert len(after_second) == 3, after_second
+    # Every filename from sync 1 must still exist verbatim in sync 2.
+    for name in after_first:
+        assert name in after_second, (
+            f"sync-2 renamed or removed {name!r}: {after_second}"
+        )

--- a/tests/test_graphify_bridge.py
+++ b/tests/test_graphify_bridge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -9,6 +10,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from llmwiki.graphify_bridge import is_available, GRAPHIFY_OUT
+
+_GRAPHIFY_INSTALLED = importlib.util.find_spec("graphify") is not None
 
 
 # ─── availability check ─────────────────────────────────────────────
@@ -19,8 +22,12 @@ def test_is_available_returns_bool():
     assert isinstance(result, bool)
 
 
+@pytest.mark.skipif(
+    not _GRAPHIFY_INSTALLED,
+    reason="graphify is an optional dependency; install with `pip install llmwiki[graph]`",
+)
 def test_is_available_true_when_graphify_installed():
-    """graphifyy is installed in our dev environment."""
+    """When graphify is installed in the dev environment, is_available() is True."""
     assert is_available() is True
 
 

--- a/tests/test_lint_rules.py
+++ b/tests/test_lint_rules.py
@@ -37,9 +37,11 @@ def _mk_page(meta: dict, body: str) -> dict:
 def test_all_14_rules_registered():
     # 11 v1.0 + stale_candidates (v1.1 #51)
     # + tags_topics_convention (G-16 · #302) + stale_reference_detection (G-17 · #303)
+    # + frontmatter_count_consistency (issues.md #2)
+    # + tools_consistency (issues.md #4)
     # cache_tier_consistency removed (cache_tiers module deleted)
     from llmwiki.lint import rules  # noqa: F401
-    assert len(REGISTRY) == 14
+    assert len(REGISTRY) == 16
 
 
 def test_registered_rule_names():
@@ -59,6 +61,8 @@ def test_registered_rule_names():
         "stale_candidates",             # v1.1 (#51)
         "tags_topics_convention",       # G-16 · #302
         "stale_reference_detection",    # G-17 · #303
+        "frontmatter_count_consistency", # issues.md #2
+        "tools_consistency",             # issues.md #4
     }
     assert set(REGISTRY.keys()) == expected
 
@@ -508,3 +512,89 @@ def test_load_pages_reads_markdown(tmp_path: Path):
     assert "entities/Foo.md" in pages
     assert pages["entities/Foo.md"]["meta"]["title"] == "Foo"
     assert pages["entities/Foo.md"]["meta"]["type"] == "entity"
+
+
+# ─── frontmatter_count_consistency (issues.md #2) ───────────────────────
+
+
+def test_count_consistency_flags_inflated_user_messages():
+    body = "### Turn 1 — User\nhi\n\n### Turn 2 — User\nhello\n"
+    page = _mk_page(
+        {"title": "s", "type": "source", "user_messages": 6, "turn_count": 6,
+         "tool_calls": 0},
+        body,
+    )
+    issues = run_all({"sources/s.md": page},
+                     selected=["frontmatter_count_consistency"])
+    messages = {i["message"] for i in issues}
+    assert any("user_messages=6 but body has 2" in m for m in messages)
+    assert any("turn_count=6 but body has 2" in m for m in messages)
+
+
+def test_count_consistency_passes_when_counts_match():
+    body = "### Turn 1 — User\nhi\n- `Bash`: ls\n- `Write`: /tmp/x\n"
+    page = _mk_page(
+        {"title": "s", "type": "source", "user_messages": 1, "turn_count": 1,
+         "tool_calls": 2},
+        body,
+    )
+    issues = run_all({"sources/s.md": page},
+                     selected=["frontmatter_count_consistency"])
+    assert issues == []
+
+
+def test_count_consistency_skips_non_source_pages():
+    body = "### Turn 1 — User\nhi\n"
+    page = _mk_page(
+        {"title": "e", "type": "entity", "user_messages": 99},
+        body,
+    )
+    issues = run_all({"entities/e.md": page},
+                     selected=["frontmatter_count_consistency"])
+    assert issues == []
+
+
+# ─── tools_consistency (issues.md #4) ────────────────────────────────────
+
+
+def test_tools_consistency_flags_missing_tool_count_entry():
+    body = "# s"
+    page = _mk_page(
+        {
+            "title": "s", "type": "source",
+            "tools_used": "[Read, Write, Grep]",
+            "tool_counts": '{"Read": 1, "Write": 2}',
+        },
+        body,
+    )
+    issues = run_all({"sources/s.md": page}, selected=["tools_consistency"])
+    assert any("['Grep']" in i["message"] for i in issues)
+
+
+def test_tools_consistency_passes_when_sets_match():
+    body = "# s"
+    page = _mk_page(
+        {
+            "title": "s", "type": "source",
+            "tools_used": "[Read, Write]",
+            "tool_counts": '{"Read": 1, "Write": 2}',
+        },
+        body,
+    )
+    issues = run_all({"sources/s.md": page}, selected=["tools_consistency"])
+    assert issues == []
+
+
+def test_tools_consistency_flags_extra_tool_count_key():
+    """The reverse direction — tool_counts has a key that tools_used omits."""
+    body = "# s"
+    page = _mk_page(
+        {
+            "title": "s", "type": "source",
+            "tools_used": "[Read]",
+            "tool_counts": '{"Read": 1, "Bash": 3}',
+        },
+        body,
+    )
+    issues = run_all({"sources/s.md": page}, selected=["tools_consistency"])
+    assert any("['Bash']" in i["message"] for i in issues)

--- a/tests/test_project_stubs.py
+++ b/tests/test_project_stubs.py
@@ -1,0 +1,133 @@
+"""Tests for the project-stub auto-seeder (issues-commands.md I-12).
+
+On a real user's corpus, ``wiki/projects/<slug>.md`` files don't exist,
+so every project page renders bare — no description, no topic chips, no
+homepage link. The demo corpus ships curated files, so the demo site
+looks richer than a fresh real one. ``ensure_project_stubs`` closes
+that gap by auto-seeding an empty stub per discovered project slug.
+
+Key invariants:
+
+* A new stub is created when the target file does not exist.
+* Existing files (hand-authored by the user) are NEVER overwritten.
+* Re-running the helper is a no-op on the second call.
+* The stub frontmatter is valid (parseable by ``load_project_profile``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _groups_with(*slugs: str) -> dict[str, list]:
+    """Helper: mimic the ``group_by_project`` return shape."""
+    return {slug: [] for slug in slugs}
+
+
+def test_ensure_project_stubs_creates_missing(tmp_path: Path):
+    from llmwiki.build import ensure_project_stubs
+
+    meta_dir = tmp_path / "wiki" / "projects"
+    groups = _groups_with("alpha", "beta")
+
+    written = ensure_project_stubs(groups, meta_dir)
+
+    assert sorted(p.name for p in written) == ["alpha.md", "beta.md"]
+    for slug in ("alpha", "beta"):
+        stub = meta_dir / f"{slug}.md"
+        assert stub.is_file()
+        content = stub.read_text()
+        assert f'title: "{slug}"' in content
+        assert "type: entity" in content
+        assert "entity_type: project" in content
+        assert "topics: []" in content
+        assert 'description: ""' in content
+        assert 'homepage: ""' in content
+
+
+def test_ensure_project_stubs_never_clobbers_existing(tmp_path: Path):
+    from llmwiki.build import ensure_project_stubs
+
+    meta_dir = tmp_path / "wiki" / "projects"
+    meta_dir.mkdir(parents=True)
+
+    # Hand-authored file the user already filled in.
+    curated = meta_dir / "alpha.md"
+    curated_text = (
+        "---\n"
+        'title: "alpha"\n'
+        "type: entity\n"
+        "entity_type: project\n"
+        "project: alpha\n"
+        "topics: [python, api]\n"
+        'description: "real description"\n'
+        'homepage: "https://example.com/alpha"\n'
+        "---\n\n# alpha\n\nHand-authored content.\n"
+    )
+    curated.write_text(curated_text, encoding="utf-8")
+
+    groups = _groups_with("alpha", "beta")
+    written = ensure_project_stubs(groups, meta_dir)
+
+    # Only beta should be newly created.
+    assert sorted(p.name for p in written) == ["beta.md"]
+    # Alpha's contents must be byte-identical.
+    assert curated.read_text() == curated_text
+
+
+def test_ensure_project_stubs_is_idempotent(tmp_path: Path):
+    from llmwiki.build import ensure_project_stubs
+
+    meta_dir = tmp_path / "wiki" / "projects"
+    groups = _groups_with("alpha", "beta", "gamma")
+
+    first = ensure_project_stubs(groups, meta_dir)
+    assert len(first) == 3
+
+    # Second call must be a no-op — every stub already on disk.
+    second = ensure_project_stubs(groups, meta_dir)
+    assert second == []
+
+
+def test_ensure_project_stubs_creates_meta_dir(tmp_path: Path):
+    """Helper must create the wiki/projects/ directory if it's missing."""
+    from llmwiki.build import ensure_project_stubs
+
+    meta_dir = tmp_path / "wiki" / "projects"
+    assert not meta_dir.exists()
+
+    ensure_project_stubs(_groups_with("alpha"), meta_dir)
+    assert meta_dir.is_dir()
+    assert (meta_dir / "alpha.md").is_file()
+
+
+def test_stub_frontmatter_is_loadable_by_project_profile(tmp_path: Path):
+    """Stub must parse cleanly via the existing metadata loader.
+
+    The loader drops empty ``description`` / ``homepage`` by design so
+    the hero block skips rendering them. We only assert that the call
+    succeeds and that ``topics`` round-trips as an empty list — that's
+    enough to prove the stub's frontmatter is syntactically valid.
+    """
+    from llmwiki.build import ensure_project_stubs
+    from llmwiki.project_topics import load_project_profile
+
+    meta_dir = tmp_path / "wiki" / "projects"
+    ensure_project_stubs(_groups_with("my-proj"), meta_dir)
+
+    profile = load_project_profile(meta_dir, "my-proj")
+    assert profile is not None
+    assert profile.get("topics") == []
+    # Empty description/homepage are intentionally omitted by the loader
+    # so they don't render an empty row on the project page.
+    assert "description" not in profile or profile["description"] == ""
+    assert "homepage" not in profile or profile["homepage"] == ""
+
+
+def test_ensure_project_stubs_empty_groups(tmp_path: Path):
+    from llmwiki.build import ensure_project_stubs
+
+    meta_dir = tmp_path / "wiki" / "projects"
+    assert ensure_project_stubs({}, meta_dir) == []

--- a/tests/test_v04.py
+++ b/tests/test_v04.py
@@ -73,7 +73,10 @@ def test_plain_text_strips_markdown():
     text = _plain_text(md)
     assert "**" not in text
     assert "```" not in text
-    assert "print('x')" not in text
+    # Fenced code blocks have their fences stripped but the inner source is
+    # preserved — otherwise AI-consumable exports lose the most valuable
+    # content in coding transcripts (regression test for exporters.py).
+    assert "print('x')" in text
     assert "Heading" in text
     assert "wikilink" in text
 

--- a/wiki/CRITICAL_FACTS.md
+++ b/wiki/CRITICAL_FACTS.md
@@ -1,0 +1,12 @@
+---
+title: "Critical Facts"
+type: navigation
+last_updated: ""
+---
+
+# Critical Facts
+
+- raw/ is immutable — never modify files under raw/
+- Wiki uses Obsidian-style double-bracket syntax for cross-references
+- Confidence: 0.0-1.0, 4-factor formula
+- Lifecycle: draft > reviewed > verified > stale > archived

--- a/wiki/concepts/ARC-AGI-2.md
+++ b/wiki/concepts/ARC-AGI-2.md
@@ -1,0 +1,24 @@
+---
+title: "ARC-AGI-2"
+type: concept
+tags: [benchmark, arc-agi, reasoning]
+last_updated: 2026-04-23
+sources: []
+confidence: 0.55
+lifecycle: draft
+---
+
+# ARC-AGI-2
+
+Second-generation Abstraction and Reasoning Corpus benchmark. Harder
+than the original ARC-AGI: each task requires visual-pattern reasoning
+that state-of-the-art LLMs struggle to compose from memorised
+training examples.
+
+Most 2025-era models scored in the low single digits. [[GPT5]]'s 16.4%
+was the first mainstream frontier-model score to break double digits,
+still far below the ~60-80% typical of unconstrained humans.
+
+## Connections
+
+- [[GPT5]] — first frontier LLM to score meaningfully on this benchmark

--- a/wiki/concepts/AgenticWorkloads.md
+++ b/wiki/concepts/AgenticWorkloads.md
@@ -1,0 +1,26 @@
+---
+title: "Agentic Workloads"
+type: concept
+tags: [llm, agents, workloads]
+last_updated: 2026-04-23
+sources: []
+confidence: 0.55
+lifecycle: draft
+---
+
+# Agentic Workloads
+
+Long-running LLM-driven tasks that involve tool use, iterative
+reasoning, and heavy context reuse across many turns — as opposed to
+one-shot completions. Examples: coding agents that edit files and run
+tests, research agents that browse and synthesise, customer support
+agents that chain tool calls to resolve tickets.
+
+Cost economics differ from chat: prompt-caching reads dominate total
+spend because the same system prompt, tool schemas, and prior-turn
+history are re-sent on every iteration.
+
+## Connections
+
+- [[ClaudeSonnet4]] — current primary model choice for this use case
+- [[CachePricing]] — why agentic workloads are so sensitive to cache cost

--- a/wiki/concepts/CachePricing.md
+++ b/wiki/concepts/CachePricing.md
@@ -1,0 +1,31 @@
+---
+title: "Cache Pricing"
+type: concept
+tags: [llm, pricing, prompt-cache]
+last_updated: 2026-04-23
+sources: []
+confidence: 0.55
+lifecycle: draft
+---
+
+# Cache Pricing
+
+The per-token cost of reading from an LLM provider's prompt cache,
+typically priced at ~10% of the regular input rate. Providers charge a
+one-time cache-write fee (often ~25% premium over input) but every
+subsequent read is the discounted cache-read rate.
+
+For [[AgenticWorkloads]] that re-send a large, stable prefix on every
+turn, caching flips the cost curve: total spend becomes dominated by
+the cheap cache-reads rather than fresh input tokens.
+
+## Reference rates (2026-04)
+
+| Provider | Input | Cache write | Cache read |
+|---|---|---|---|
+| Anthropic Claude Sonnet 4 | $3.00/1M | ~$3.75/1M | $0.30/1M |
+
+## Connections
+
+- [[ClaudeSonnet4]] — one of the more aggressively priced caches
+- [[AgenticWorkloads]] — the workload class that benefits most

--- a/wiki/concepts/MultimodalModels.md
+++ b/wiki/concepts/MultimodalModels.md
@@ -1,0 +1,24 @@
+---
+title: "Multimodal Models"
+type: concept
+tags: [llm, multimodal, vision, audio]
+last_updated: 2026-04-23
+sources: []
+confidence: 0.5
+lifecycle: draft
+---
+
+# Multimodal Models
+
+LLMs that accept more than one input modality in a single API call —
+typically some combination of text, image (vision), and audio. The 2026
+frontier generation ships multimodal by default rather than as a
+separate endpoint.
+
+Contrast with earlier "text-only with a vision sidecar" designs where
+image support required routing to a different model.
+
+## Connections
+
+- [[GPT5]] — 2026 text + vision + audio flagship
+- [[ClaudeSonnet4]] — text + vision

--- a/wiki/entities/Anthropic.md
+++ b/wiki/entities/Anthropic.md
@@ -1,0 +1,22 @@
+---
+title: "Anthropic"
+type: entity
+tags: [company, ai-lab, claude]
+entity_type: org
+entity_kind: company
+homepage: "https://www.anthropic.com"
+last_updated: 2026-04-23
+sources: []
+confidence: 0.6
+lifecycle: reviewed
+---
+
+# Anthropic
+
+AI safety company founded in 2021. Creator of the Claude family of
+large language models. Focus on building reliable, interpretable, and
+steerable AI systems.
+
+## Connections
+
+- [[ClaudeSonnet4]] — flagship mid-tier model

--- a/wiki/entities/GPT5.md
+++ b/wiki/entities/GPT5.md
@@ -38,4 +38,4 @@ input but comparable on output.
 
 - [[OpenAI]] — the provider
 - [[MultimodalModels]] — primary category
-- [[ARC-AGI 2]] — novel benchmark
+- [[ARC-AGI-2]] — novel benchmark

--- a/wiki/entities/OpenAI.md
+++ b/wiki/entities/OpenAI.md
@@ -1,0 +1,21 @@
+---
+title: "OpenAI"
+type: entity
+tags: [company, ai-lab, gpt]
+entity_type: org
+entity_kind: company
+homepage: "https://openai.com"
+last_updated: 2026-04-23
+sources: []
+confidence: 0.6
+lifecycle: reviewed
+---
+
+# OpenAI
+
+AI research and deployment company founded in 2015. Creator of the GPT
+family of language models and the ChatGPT product.
+
+## Connections
+
+- [[GPT5]] — flagship 2026 multimodal model

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,0 +1,26 @@
+# Wiki Index
+
+## Overview
+- [Overview](overview.md)
+
+## Sources
+
+## Entities
+- [Anthropic](entities/Anthropic.md)
+- [ClaudeSonnet4](entities/ClaudeSonnet4.md)
+- [GPT5](entities/GPT5.md)
+- [OpenAI](entities/OpenAI.md)
+
+## Projects
+- [demo-blog-engine](projects/demo-blog-engine.md)
+- [demo-ml-pipeline](projects/demo-ml-pipeline.md)
+- [demo-todo-api](projects/demo-todo-api.md)
+- [llm-wiki](projects/llm-wiki.md)
+
+## Concepts
+- [AgenticWorkloads](concepts/AgenticWorkloads.md)
+- [ARC-AGI-2](concepts/ARC-AGI-2.md)
+- [CachePricing](concepts/CachePricing.md)
+- [MultimodalModels](concepts/MultimodalModels.md)
+
+## Syntheses

--- a/wiki/projects/demo-blog-engine.md
+++ b/wiki/projects/demo-blog-engine.md
@@ -19,7 +19,7 @@ the final polish passes (RSS + dark mode).
 
 ## Connections
 
-- [[Rust]]
-- [[StaticSiteGeneration]]
-- [[pulldown-cmark]]
-- [[syntect]]
+- Rust
+- Static site generation
+- pulldown-cmark
+- syntect

--- a/wiki/projects/demo-ml-pipeline.md
+++ b/wiki/projects/demo-ml-pipeline.md
@@ -19,7 +19,7 @@ best-F1 checkpoint callback.
 
 ## Connections
 
-- [[Python]]
-- [[DistilBERT]]
-- [[HuggingFaceTransformers]]
-- [[WeightsAndBiases]]
+- Python
+- DistilBERT
+- HuggingFace Transformers
+- Weights & Biases

--- a/wiki/projects/demo-todo-api.md
+++ b/wiki/projects/demo-todo-api.md
@@ -19,7 +19,7 @@ auth" a week later — two sessions, one project.
 
 ## Connections
 
-- [[Python]]
-- [[FastAPI]]
-- [[OAuth2]]
-- [[REST]]
+- Python
+- FastAPI
+- OAuth2
+- REST

--- a/wiki/projects/llm-wiki.md
+++ b/wiki/projects/llm-wiki.md
@@ -19,7 +19,7 @@ static site → browse.
 
 ## Connections
 
-- [[AndrejKarpathy]]
-- [[ClaudeCode]]
-- [[StaticSiteGeneration]]
-- [[LLMWiki]]
+- Andrej Karpathy
+- Claude Code
+- Static site generation
+- llmwiki


### PR DESCRIPTION
## Summary

Full audit of every `/wiki-*` command uncovered 10 data-fidelity bugs and a missing pipeline runner. This PR fixes all of them plus adds the `llmwiki all` subcommand, 2 new lint rules, auto-seeded project stubs, and 6 entity/concept wiki pages.

Closes #376
Closes #377

### Bug fixes
- **Code blocks stripped from AI exports** — `_plain_text()` now unwraps fences instead of deleting code
- **JSON sibling types wrong** — `is_subagent: "false"` (truthy string) → `false` (bool); `user_messages`/`tool_calls` → int
- **`sync --force` lost ~200/495 sessions** — per-run collision disambiguation now independent of `--force`
- **Demo metadata inflated 2–10×** — all 8 demo files recomputed from body
- **22 broken wikilinks** — un-wikilinked dead references + created 6 stub pages
- **`graphifyy` typo** (7 locations), **`setup.sh --dry-run`** (doesn't exist → `--status`), **CRITICAL_FACTS seed**, **non-hermetic graphify test**

### New features
- **`llmwiki all`** CLI subcommand — build → graph → export → lint in one shot (`--strict` for CI gating)
- **`/wiki-all`** slash command
- **`ensure_project_stubs()`** — auto-seeds `wiki/projects/<slug>.md` for new projects on first build
- **2 lint rules**: `frontmatter_count_consistency` (#16), `tools_consistency` (#17)
- **6 entity/concept stub pages**: Anthropic, OpenAI, AgenticWorkloads, CachePricing, MultimodalModels, ARC-AGI-2

### Stats
- 36 files changed, +1082 -90
- 2085 tests pass, 27 skipped
- `llmwiki lint` → 0 errors, 0 warnings
- `llmwiki all --strict` → exit 0

## Checklist
- [x] Branch created from latest master
- [x] Issues addressed: #376 (fixes) + #377 (features) — referenced in title + description
- [x] All commits GPG-signed (`Good signature from "Pratiyush Kumar Singh"`)
- [x] Conventional commit message (`fix:` prefix)
- [x] Tests added/updated (15 new tests across 3 files)
- [x] CI pipeline passes (2085 pass locally)
- [x] Relevant documentation updated (`docs/reference/cli.md`, `slash-commands.md`)
- [x] No merge conflicts with master

## Test plan
- [x] `pytest tests/` — 2085 passed, 27 skipped
- [x] `python3 -m llmwiki lint` — 0 errors, 0 warnings
- [x] `python3 -m llmwiki all --graph-engine builtin --strict` — exit 0
- [x] `sync --force` on real 494-session corpus — 503 files on disk (no data loss)
- [x] JSON sibling `is_subagent` is `false` (bool), not `"false"` (string)
- [x] `llms-full.txt` preserves code blocks (grep for `pulldown-cmark =`)
- [x] Fresh init + build auto-seeds project stubs
- [x] Existing hand-authored project files never overwritten

Docs: No additional documentation changes required beyond the cli.md + slash-commands.md updates already included.