### PR TITLE
feat: branded 404 + plural inflection + clearer adapter column names (#387 U2/U7/U8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+### Added
+
+- **Branded 404 page** (#387 U8) — `llmwiki build` now emits `site/404.html` with the standard nav + footer + a "try one of these" panel linking back to home / projects / sessions / changelog. `llmwiki serve` overrides `SimpleHTTPRequestHandler.send_error` to use the branded body for any 404 response (status code stays 404 — this is the response body, not a redirect). Dead wikilinks now land users on something they can navigate from instead of the stdlib's plain-text default.
+
+### Changed
+
+- **`llmwiki adapters` column names** (#387 U2) — renamed `default` → `present`, `configured` → `enabled`, `will_fire` → `active`. The new names are immediately legible without consulting the legend below the table. The legend itself was tightened. No behavioural change.
+- **Hero-subtitle plural inflection** (#387 U7) — count strings on the homepage, projects index, and sessions index use the new `_pluralize(n, singular)` helper so users no longer see `"1 sessions"` / `"1 projects"`. Examples: `"1 main session · 0 sub-agent runs · 1 project"`, `"1 session total"`.
+
 ### Fixed
 
 - **JS pageerror in graph.html** (#386) — `Cannot read properties of null (reading 'addEventListener')` fired during cross-page navigation when the graph viewer's chrome controls (`#theme-toggle`, `#ctx-menu`, `#search-input`, `#cluster-toggle`) were missing or rendered in a minimal layout. Added defensive null-guards on every `getElementById` → `addEventListener` chain in `llmwiki/graph.py`. The `test_full_navigation_journey` E2E test now passes (xfail marker removed).

--- a/llmwiki/build.py
+++ b/llmwiki/build.py
@@ -685,6 +685,16 @@ def page_foot(js_prefix: str = "") -> str:
 
 # ─── page renderers ────────────────────────────────────────────────────────
 
+def _pluralize(n: int, singular: str, plural: str | None = None) -> str:
+    """Return ``"1 session"`` for n=1, ``"3 sessions"`` for n=3.
+
+    Closes #387 U7. The hero subtitle and any other count-bearing
+    user-facing string should never read as ``"1 sessions"``."""
+    if plural is None:
+        plural = singular + "s"
+    return f"{n} {singular if n == 1 else plural}"
+
+
 def calc_reading_time(body: str, wpm: int = 225) -> int:
     """Estimate reading time in minutes from a markdown body."""
     words = len(re.findall(r"\w+", body))
@@ -1030,7 +1040,7 @@ def render_projects_index(
     page = (
         page_head("Projects — LLM Wiki", "All projects with Claude Code session history", css_prefix="../")
         + nav_bar("projects", link_prefix="../")
-        + hero("Projects", f"{len(groups)} projects")
+        + hero("Projects", _pluralize(len(groups), "project"))
         + body
         + page_foot(js_prefix="../")
     )
@@ -1138,7 +1148,7 @@ def render_sessions_index(
     page = (
         page_head("Sessions — LLM Wiki", "All Claude Code sessions, newest first", css_prefix="../")
         + nav_bar("sessions", link_prefix="../")
-        + hero("All sessions", f"{len(sources)} sessions total")
+        + hero("All sessions", _pluralize(len(sources), "session") + " total")
         + body
         + page_foot(js_prefix="../")
     )
@@ -1244,7 +1254,7 @@ def render_index(
         + nav_bar("home", link_prefix="")
         + hero(
             "LLM Wiki",
-            f"{mains} main sessions · {subs} sub-agent runs · {len(groups)} projects",
+            f"{_pluralize(mains, 'main session')} · {_pluralize(subs, 'sub-agent run')} · {_pluralize(len(groups), 'project')}",
         )
         + synth_block
         + body
@@ -1311,6 +1321,46 @@ def _render_root_md_page(
         + page_foot(js_prefix="")
     )
     out_path = out_dir / out_name
+    out_path.write_text(page, encoding="utf-8")
+    return out_path
+
+
+def render_404(out_dir: Path) -> Path:
+    """Emit ``site/404.html`` with the standard site chrome and a "Page not
+    found" panel. Closes #387 U8 — without this, ``llmwiki serve`` falls
+    back to the stdlib ``http.server`` default 404 (an unstyled error string
+    with no nav). The page itself is not linked from the index, but
+    ``serve.py`` injects it as the body of every 404 response.
+    """
+    head = page_head(
+        title="Page not found · llmwiki",
+        description="The page you tried to open doesn't exist on this site.",
+    )
+    nav = nav_bar(active="")
+    foot = page_foot()
+    body = """<main id="main-content">
+<section class="hero">
+  <div class="container">
+    <h1>Page not found</h1>
+    <p class="hero-sub">The page you tried to open doesn't exist on this site. The link may be stale, the page may have been removed, or the URL may have a typo.</p>
+  </div>
+</section>
+<section class="section">
+  <div class="container">
+    <p>Try one of these:</p>
+    <ul style="list-style: disc; padding-left: 24px; margin: 12px 0;">
+      <li><a href="index.html">Home</a> — overview and recent activity</li>
+      <li><a href="projects/index.html">Projects</a> — every project with sessions</li>
+      <li><a href="sessions/index.html">Sessions</a> — every session, sortable + filterable</li>
+      <li><a href="changelog.html">Changelog</a> — what's shipped recently</li>
+    </ul>
+    <p class="muted">Or press <kbd>⌘K</kbd> / <kbd>Ctrl+K</kbd> to open the command palette and search.</p>
+  </div>
+</section>
+</main>
+"""
+    page = head + nav + body + foot
+    out_path = out_dir / "404.html"
     out_path.write_text(page, encoding="utf-8")
     return out_path
 
@@ -1894,13 +1944,16 @@ def build_site(
     render_sessions_index(sources, groups, out_dir)
     render_index(groups, sources, out_dir, synthesis=synthesis)
     cl_path = render_changelog(out_dir)
+    # #387 U8: branded 404 page that serve.py returns as the body of any
+    # 404 response, instead of the stdlib http.server default.
+    not_found_path = render_404(out_dir)
     # #284: compile README + CONTRIBUTING as standalone site pages so
     # they don't bounce visitors out to GitHub for content we're already
     # shipping as HTML.
     readme_path = render_readme_page(out_dir)
     contributing_path = render_contributing_page(out_dir)
     print(
-        "  wrote index.html, projects/index.html, sessions/index.html"
+        "  wrote index.html, projects/index.html, sessions/index.html, 404.html"
         + (", changelog.html" if cl_path else "")
     )
 

--- a/llmwiki/cli.py
+++ b/llmwiki/cli.py
@@ -328,41 +328,44 @@ def cmd_adapters(args: argparse.Namespace) -> int:
 
     # Description column width: 40 by default, full line with --wide,
     # or auto-fit to terminal (minus the four fixed columns + gutters).
+    # #387 U2: column names renamed from default/configured/will_fire to
+    # present/enabled/active — they read at a glance without needing the
+    # legend below.
     wide = bool(getattr(args, "wide", False))
     if wide:
         desc_width: Optional[int] = None  # no cap
     else:
         term_cols = _shutil.get_terminal_size(fallback=(80, 24)).columns
-        # Layout: "  name(16)  default(8)  configured(10)  will_fire(9)  desc" — fixed overhead ~55.
-        desc_width = max(30, term_cols - 57)
+        # Layout: "  name(16)  present(8)  enabled(10)  active(7)  desc"
+        desc_width = max(30, term_cols - 55)
 
     print("Registered adapters:")
     dash = "-"
     header = (
-        f"  {'name':<16}  {'default':<8}  {'configured':<10}  "
-        f"{'will_fire':<9}  description"
+        f"  {'name':<16}  {'present':<8}  {'enabled':<10}  "
+        f"{'active':<7}  description"
     )
     print(header)
     sep_desc = "-" * (desc_width if desc_width is not None else len("description"))
     print(
-        f"  {dash * 16}  {dash * 8}  {dash * 10}  {dash * 9}  {sep_desc}"
+        f"  {dash * 16}  {dash * 8}  {dash * 10}  {dash * 7}  {sep_desc}"
     )
     for name, adapter_cls in sorted(REGISTRY.items()):
-        default_avail = "yes" if adapter_cls.is_available() else "no"
-        configured, will_fire = _adapter_status(name, adapter_cls, config)
+        present = "yes" if adapter_cls.is_available() else "no"
+        enabled, active = _adapter_status(name, adapter_cls, config)
         desc = adapter_cls.description()
         if desc_width is not None and len(desc) > desc_width:
             desc = desc[: max(desc_width - 3, 1)] + "..."
         print(
-            f"  {name:<16}  {default_avail:<8}  {configured:<10}  "
-            f"{will_fire:<9}  {desc}"
+            f"  {name:<16}  {present:<8}  {enabled:<10}  "
+            f"{active:<7}  {desc}"
         )
 
     print()
     print("Columns:")
-    print("  default    — is the adapter's session store present on disk?")
-    print("  configured — auto (default), explicit (enabled:true in config), off (enabled:false)")
-    print("  will_fire  — will `sync` pick this adapter up on its next run?")
+    print("  present  — is the adapter's session store visible on disk?")
+    print("  enabled  — auto (default), explicit (enabled:true in config), off (enabled:false)")
+    print("  active   — yes/no — will `sync` pick this adapter up on its next run?")
     if not wide:
         print()
         print("Pass --wide to see untruncated descriptions.")

--- a/llmwiki/serve.py
+++ b/llmwiki/serve.py
@@ -14,11 +14,38 @@ from pathlib import Path
 
 
 class _QuietHandler(http.server.SimpleHTTPRequestHandler):
-    """Like SimpleHTTPRequestHandler but with prettier logs."""
+    """Like SimpleHTTPRequestHandler but with prettier logs and a branded
+    404 response that pulls ``site/404.html`` (closes #387 U8) instead of
+    falling back to the stdlib's plain-text error page."""
 
     def log_message(self, format: str, *args) -> None:  # noqa: A002
         # Suppress per-request logs for a cleaner terminal.
         return
+
+    def send_error(self, code: int, message: str | None = None,
+                   explain: str | None = None) -> None:
+        """Override the default error page so 404s pick up the branded
+        ``404.html`` shipped by ``llmwiki build``. We deliberately keep the
+        404 status code intact — the page is the *body* of the 404 response,
+        not a redirect — so crawlers still see the right HTTP code.
+
+        Falls back to the stdlib default for anything other than 404, or
+        when ``404.html`` is missing (e.g. a partially-built site)."""
+        if code == 404:
+            try:
+                # cwd has been os.chdir'd to the site root by serve_site below.
+                with open("404.html", "rb") as f:
+                    body = f.read()
+                self.send_response(404, message)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            except (FileNotFoundError, OSError):
+                # 404.html doesn't exist — fall through to default behavior.
+                pass
+        super().send_error(code, message, explain)
 
 
 class _ReusableTCPServer(socketserver.TCPServer):

--- a/tests/e2e/test_cli_smoke.py
+++ b/tests/e2e/test_cli_smoke.py
@@ -185,9 +185,10 @@ def test_adapters_lists_at_least_one_adapter() -> None:
     assert result.returncode == 0, result.stderr
     # Header row + at least one data row.
     assert "Registered adapters:" in result.stdout
-    # The columns contract (G-01 #287): name, default, configured, will_fire.
-    assert "configured" in result.stdout
-    assert "will_fire" in result.stdout
+    # #387 U2: columns are now name / present / enabled / active / description.
+    assert "present" in result.stdout
+    assert "enabled" in result.stdout
+    assert "active" in result.stdout
 
 
 def test_adapters_wide_disables_truncation() -> None:

--- a/tests/test_cli_observability.py
+++ b/tests/test_cli_observability.py
@@ -98,12 +98,15 @@ def test_adapter_status_invalid_config_entry_defaults_to_auto():
 def test_adapters_cli_shows_new_columns():
     cp = _run_cli("adapters")
     assert cp.returncode == 0
-    # Header names present
-    for header in ("name", "default", "configured", "will_fire", "description"):
-        assert header in cp.stdout
-    # Legacy labels no longer present in data rows
-    assert "enabled" not in cp.stdout or "Pass --wide" in cp.stdout
-    # Human-readable column legend at the bottom
+    # #387 U2: column names renamed to present / enabled / active.
+    for header in ("name", "present", "enabled", "active", "description"):
+        assert header in cp.stdout, (
+            f"adapters table missing the {header!r} column header"
+        )
+    # Old column names should be gone — they're confusing without the legend.
+    assert "configured" not in cp.stdout, "old 'configured' column header still rendered"
+    assert "will_fire" not in cp.stdout, "old 'will_fire' column header still rendered"
+    # Human-readable column legend at the bottom describes the new names.
     assert "auto (default)" in cp.stdout
     assert "explicit (enabled:true" in cp.stdout
 


### PR DESCRIPTION
## Summary

Addresses three of the nine UX critique items in #387:

- **U8** — `llmwiki build` now emits a branded `site/404.html`. `llmwiki serve` returns it as the body of any 404 response, so dead wikilinks land users on a styled page with nav + a "try one of these" panel instead of the stdlib `http.server` plain-text default.
- **U7** — Hero subtitles on home / projects / sessions indices now use a `_pluralize(n, singular)` helper. No more `"1 sessions"`, no more `"1 projects"`.
- **U2** — `llmwiki adapters` table column names renamed from `default | configured | will_fire` to `present | enabled | active`. The new names are immediately legible without consulting the legend.

## Files changed

- `llmwiki/build.py` — `_pluralize()` helper, `render_404()` page renderer, three `_pluralize` call sites in the index renderers, build-step wiring + log line update.
- `llmwiki/serve.py` — `_QuietHandler.send_error()` override that pulls `site/404.html` for 404 responses with graceful fallback to stdlib default.
- `llmwiki/cli.py` — adapter table header, data rows, and legend updated.
- `tests/test_cli_observability.py` — `test_adapters_cli_shows_new_columns` updated to assert on the new column names + ensure the old names are gone.
- `CHANGELOG.md` — three new entries under `[Unreleased]` (Added: 404, Changed: column names + inflection).

## Test plan

- [x] `pytest tests/ -q` — 2068 passed, 44 skipped (one test fixed for the column rename)
- [x] `python -m llmwiki adapters` — verified new headers (`present`/`enabled`/`active`) render with the right widths
- [x] `python -m llmwiki build` — verified `site/404.html` is emitted (9 KB, valid HTML)
- [ ] Manual: `python -m llmwiki serve` and curl an unknown path — should get the branded 404 body
- [ ] CI Playwright + a11y suite

## Out of scope

The remaining items in #387 (U1 export help wording, U3 sync flag wording, U4 synthesize estimate row label, U5 copy button aria-label, U6 wiki/index.md sortable table, U9 docs hub TOC) are deferred — each is its own discrete change and shipping them in one PR would bloat the diff.