### PR TITLE
feat: 5 more UX wins from #387 (U1/U3/U4/U5/U9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,15 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ### Added
 
+- **Sticky table of contents on the docs hub** (#387 U9) — the docs hub at `site/docs/index.html` enumerates ~80 editorial pages and was scrolling to ~5000 px without in-page navigation. The build now emits a `tutorial-toc` block on the hub the same way it does on tutorials, and on viewports ≥ 1024 px the TOC sticks to the top so users always have a way to jump.
 - **Branded 404 page** (#387 U8) — `llmwiki build` now emits `site/404.html` with the standard nav + footer + a "try one of these" panel linking back to home / projects / sessions / changelog. `llmwiki serve` overrides `SimpleHTTPRequestHandler.send_error` to use the branded body for any 404 response (status code stays 404 — this is the response body, not a redirect). Dead wikilinks now land users on something they can navigate from instead of the stdlib's plain-text default.
 
 ### Changed
 
+- **`llmwiki export` help text** (#387 U1) — the help string for the `export` subcommand previously listed three formats and trailed off with `...`. Now spells out the full set: `llms-txt`, `llms-full-txt`, `jsonld`, `sitemap`, `rss`, `robots`, `ai-readme`, `marp` (or `all`).
+- **`llmwiki sync --auto-build` / `--auto-lint` help text** (#387 U3) — the wording "if schedule allows" sounded calendar-based; updated to point explicitly at the `examples/sessions_config.json` `schedule.build` / `schedule.lint` config keys with the `on-sync` value that triggers them.
+- **`llmwiki synthesize --estimate` row label** (#387 U4) — renamed the second row from `Synthesized (history):` to `Already synthesized:`. Plain English without the parenthetical aside.
+- **Copy as markdown button** (#387 U5) — added an explicit `aria-label="Copy session content as markdown"` + `title` so a future icon-only variant doesn't lose its accessible name.
 - **`llmwiki adapters` column names** (#387 U2) — renamed `default` → `present`, `configured` → `enabled`, `will_fire` → `active`. The new names are immediately legible without consulting the legend below the table. The legend itself was tightened. No behavioural change.
 - **Hero-subtitle plural inflection** (#387 U7) — count strings on the homepage, projects index, and sessions index use the new `_pluralize(n, singular)` helper so users no longer see `"1 sessions"` / `"1 projects"`. Examples: `"1 main session · 0 sub-agent runs · 1 project"`, `"1 session total"`.
 

--- a/llmwiki/build.py
+++ b/llmwiki/build.py
@@ -791,7 +791,7 @@ def render_session(
     html_stem = path.stem
     raw_md_path = f"../../sources/{project_slug}/{path.name}"
     actions_html = f"""<div class="session-actions">
-  <button class="btn btn-primary" onclick="copyMarkdown(this)">Copy as markdown</button>
+  <button class="btn btn-primary" type="button" aria-label="Copy session content as markdown" title="Copy as markdown" onclick="copyMarkdown(this)">Copy as markdown</button>
   <a class="btn" href="../../projects/{html.escape(project_slug)}.html">← {html.escape(project_slug)}</a>
   <a class="btn" href="{html.escape(raw_md_path)}" download>Download .md</a>
   <a class="btn" href="{html.escape(html_stem + '.txt')}" title="plain-text sibling for AI agents">.txt</a>

--- a/llmwiki/cli.py
+++ b/llmwiki/cli.py
@@ -10,7 +10,7 @@ Subcommands:
     serve             Start local HTTP server
     adapters          List available session-store adapters
     graph             Build the knowledge graph (graph/graph.json + graph.html)
-    export            Export AI-consumable formats (llms-txt, jsonld, sitemap, ...)
+    export            Export AI-consumable formats: llms-txt, llms-full-txt, jsonld, sitemap, rss, robots, ai-readme, marp
     lint              Run lint rules against the wiki
     candidates        List / promote / merge / discard candidate pages
     synthesize        Synthesize wiki source pages from raw sessions via LLM
@@ -886,7 +886,7 @@ def _synthesize_estimate() -> int:
         print(f"warning: {w}")
 
     print(f"Corpus:                {report['corpus']:>6} sessions in raw/sessions/")
-    print(f"Synthesized (history): {report['synthesized']:>6} already in wiki/sources/")
+    print(f"Already synthesized:   {report['synthesized']:>6} pages in wiki/sources/")
     print(f"New since last run:    {report['new']:>6}")
     print()
     print(f"Prefix: {report['prefix_tokens']:,} tok  Model: {report['model']}")
@@ -990,11 +990,13 @@ def build_parser() -> argparse.ArgumentParser:
     sync.add_argument("--force", action="store_true", help="Ignore state file, reconvert everything")
     sync.add_argument(
         "--auto-build", action=argparse.BooleanOptionalAction, default=True,
-        help="After sync, auto-rebuild the static site if schedule allows (default: on)",
+        help="After sync, rebuild the site when sessions_config.json's "
+             "schedule.build is 'on-sync' (default: on; pass --no-auto-build to skip)",
     )
     sync.add_argument(
         "--auto-lint", action=argparse.BooleanOptionalAction, default=True,
-        help="After sync, auto-run lint if schedule allows (default: on)",
+        help="After sync, run lint when sessions_config.json's "
+             "schedule.lint is 'on-sync' (default: on; pass --no-auto-lint to skip)",
     )
     sync.add_argument(
         "--vault", type=Path, default=None,
@@ -1060,7 +1062,10 @@ def build_parser() -> argparse.ArgumentParser:
     graph.set_defaults(func=cmd_graph)
 
     # export (v0.4)
-    exp2 = sub.add_parser("export", help="Export AI-consumable formats (llms-txt, jsonld, sitemap, ...)")
+    exp2 = sub.add_parser(
+        "export",
+        help="Export AI-consumable formats: llms-txt, llms-full-txt, jsonld, sitemap, rss, robots, ai-readme, marp (or 'all')",
+    )
     exp2.add_argument(
         "format",
         choices=["llms-txt", "llms-full-txt", "jsonld", "sitemap", "rss", "robots", "ai-readme", "marp", "all"],

--- a/llmwiki/docs_pages.py
+++ b/llmwiki/docs_pages.py
@@ -377,8 +377,11 @@ def compile_docs_site(
 
         # #282: insert an in-page table of contents on tutorials that
         # have ≥2 section headings. Slots in right after the <h1>.
+        # #387 U9: also emit a TOC on the docs hub — it's a 5000+ px
+        # page that enumerates all editorial pages, and without
+        # in-page navigation users have to scroll blind.
         toc_html = ""
-        if page.rel.startswith("tutorials/"):
+        if page.rel.startswith("tutorials/") or page.is_hub:
             toc_html = _tutorial_toc_html(body_without_meta)
 
         # Splice the meta strip (then TOC) right after the <h1>…</h1> line.

--- a/llmwiki/render/docs_css.py
+++ b/llmwiki/render/docs_css.py
@@ -378,6 +378,25 @@ DOCS_SHELL_CSS = """
   text-decoration: underline;
 }
 
+/* #387 U9: on the docs hub specifically, make the TOC sticky on desktop
+   so a user scrolling through 80+ enumerated editorial pages always has
+   in-page navigation in view. Falls back to the inline TOC at narrow
+   viewports. */
+@media (min-width: 1024px) {
+  .docs-shell.docs-hub .tutorial-toc {
+    position: sticky;
+    top: 80px;
+    max-height: calc(100vh - 100px);
+    overflow-y: auto;
+    margin: 0 0 24px 0;
+  }
+  .docs-shell.docs-hub .tutorial-toc summary {
+    /* On the hub, the TOC is the primary nav — surface it open by default
+       (the <details open> already does this) and use a clearer label. */
+    color: var(--accent);
+  }
+}
+
 .docs-shell .tutorial-footer-rule {
   margin-top: 48px;
   border: 0;

--- a/tests/test_synthesize_estimate.py
+++ b/tests/test_synthesize_estimate.py
@@ -218,7 +218,9 @@ def test_prefix_tokens_auto_computed_from_real_files(tmp_path, monkeypatch):
 def test_cli_estimate_prints_three_bucket_header():
     cp = _run_cli("synthesize", "--estimate")
     assert cp.returncode == 0, cp.stderr
-    for line in ("Corpus:", "Synthesized (history):", "New since last run:"):
+    # #387 U4: the "Synthesized (history)" row label was confusing; renamed to
+    # "Already synthesized" for plainer English.
+    for line in ("Corpus:", "Already synthesized:", "New since last run:"):
         assert line in cp.stdout, f"missing `{line}`"
 
 


### PR DESCRIPTION
## Summary

Second batch of UX critique fixes from #387, building on the first batch in #389. After this lands, 8 of 9 items in the tracker are addressed.

| Item | What changed | File |
|---|---|---|
| **U1** | `llmwiki export` help no longer trails off with `...` — lists every format | `llmwiki/cli.py` |
| **U3** | `--auto-build` / `--auto-lint` help text points at the actual config key | `llmwiki/cli.py` |
| **U4** | `synthesize --estimate` row renamed `Synthesized (history)` → `Already synthesized` | `llmwiki/cli.py` |
| **U5** | Copy-as-markdown button gains an explicit `aria-label` + `title` | `llmwiki/build.py` |
| **U9** | **Docs hub sticky TOC** — the 5097px hub is now navigable | `llmwiki/docs_pages.py`, `llmwiki/render/docs_css.py` |

## Test plan

- [x] `pytest tests/ -q` — 2068 passed (one updated for the U4 row label change)
- [x] `pytest tests/e2e/ --browser=chromium -q` — 152 passed
- [x] `python -m llmwiki adapters` / `--wide` / `version` / `synthesize --estimate` / `synthesize --check` / `export --help` — all render with the new wording
- [x] Built site spot-check: `site/docs/index.html` now contains a `tutorial-toc` block with 37 anchors (the section headings); on desktop (≥1024px) it sticks to the top
- [ ] CI Playwright + a11y suite

## Out of scope

**U6** (`wiki/index.md` sortable table) — more structural, requires building a sortable table component or moving the index to a generated cards-grid. Deferred to a follow-up so this PR stays focused.