### PR TITLE
feat(wiki): add (count) to wiki/index.md section headings (#387 U6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ### Changed
 
+- **`wiki/index.md` section headings carry a `(count)`** (#387 U6) — past ~50 pages the flat bullet lists per section became hard to scan at a glance. Each section heading now reads `## Entities (4)` / `## Projects (4)` etc., so a reader can see the size of each bucket without scrolling. The seed in `cmd_init` and the documented format in `CLAUDE.md` both updated so future ingest agents preserve the format. Closes the last open item in #387.
 - **`llmwiki export` help text** (#387 U1) — the help string for the `export` subcommand previously listed three formats and trailed off with `...`. Now spells out the full set: `llms-txt`, `llms-full-txt`, `jsonld`, `sitemap`, `rss`, `robots`, `ai-readme`, `marp` (or `all`).
 - **`llmwiki sync --auto-build` / `--auto-lint` help text** (#387 U3) — the wording "if schedule allows" sounded calendar-based; updated to point explicitly at the `examples/sessions_config.json` `schedule.build` / `schedule.lint` config keys with the `on-sync` value that triggers them.
 - **`llmwiki synthesize --estimate` row label** (#387 U4) — renamed the second row from `Synthesized (history):` to `Already synthesized:`. Plain English without the parenthetical aside.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,22 +160,27 @@ Output a report to the chat. Ask the user if they want it saved to `wiki/lint-re
 
 ## Index Format
 
+Every section heading carries a `(count)` of pages in that section. Update the count when adding/removing a page so the index stays scannable past ~50 pages (#387 U6).
+
 ```markdown
 # Wiki Index
 
-## Overview
+## Overview (1)
 - [Overview](overview.md)
 
-## Sources
+## Sources (N)
 - [Source Title](sources/slug.md) — one-line summary
 
-## Entities
+## Entities (N)
 - [Entity Name](entities/EntityName.md) — one-line description
 
-## Concepts
+## Projects (N)
+- [project-slug](projects/project-slug.md) — one-line description
+
+## Concepts (N)
 - [Concept Name](concepts/ConceptName.md) — one-line description
 
-## Syntheses
+## Syntheses (N)
 - [Analysis Title](syntheses/slug.md) — what question it answers
 ```
 

--- a/llmwiki/cli.py
+++ b/llmwiki/cli.py
@@ -124,7 +124,20 @@ def cmd_init(args: argparse.Namespace) -> int:
 
     # Seed index/log/overview + navigation files if not present
     seeds = {
-        "wiki/index.md": "# Wiki Index\n\n## Overview\n- [Overview](overview.md)\n\n## Sources\n\n## Entities\n\n## Concepts\n\n## Syntheses\n",
+        "wiki/index.md": (
+            "# Wiki Index\n\n"
+            "<!-- #387 U6: each section heading carries a (count) so the index\n"
+            "stays scannable as the wiki grows past ~50 pages. Update the count\n"
+            "in the heading when adding/removing pages. The index is otherwise\n"
+            "kept flat (no nested folders) so a single grep/scan can find any\n"
+            "page without descending into a tree. -->\n\n"
+            "## Overview (1)\n- [Overview](overview.md)\n\n"
+            "## Sources (0)\n\n"
+            "## Entities (0)\n\n"
+            "## Projects (0)\n\n"
+            "## Concepts (0)\n\n"
+            "## Syntheses (0)\n"
+        ),
         "wiki/overview.md": '---\ntitle: "Overview"\ntype: synthesis\nsources: []\nlast_updated: ""\n---\n\n# Overview\n\n*This page is maintained by your coding agent.*\n',
         "wiki/log.md": "# Wiki Log\n\nAppend-only chronological record of all operations.\n\nFormat: `## [YYYY-MM-DD] <operation> | <title>`\n\n---\n",
         "wiki/hints.md": '---\ntitle: "Navigation Hints"\ntype: navigation\nlast_updated: ""\n---\n\n# Hints\n\nWriting conventions, entity naming rules, and navigation guidance.\nCustomize this file for your project.\n',

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,26 +1,32 @@
 # Wiki Index
 
-## Overview
+<!-- #387 U6: each section heading carries a (count) so the index
+stays scannable as the wiki grows past ~50 pages. Update the count
+in the heading when adding/removing pages. The index is otherwise
+kept flat (no nested folders) so a single grep/scan can find any
+page without descending into a tree. -->
+
+## Overview (1)
 - [Overview](overview.md)
 
-## Sources
+## Sources (0)
 
-## Entities
+## Entities (4)
 - [Anthropic](entities/Anthropic.md)
 - [ClaudeSonnet4](entities/ClaudeSonnet4.md)
 - [GPT5](entities/GPT5.md)
 - [OpenAI](entities/OpenAI.md)
 
-## Projects
+## Projects (4)
 - [demo-blog-engine](projects/demo-blog-engine.md)
 - [demo-ml-pipeline](projects/demo-ml-pipeline.md)
 - [demo-todo-api](projects/demo-todo-api.md)
 - [llm-wiki](projects/llm-wiki.md)
 
-## Concepts
+## Concepts (4)
 - [AgenticWorkloads](concepts/AgenticWorkloads.md)
 - [ARC-AGI-2](concepts/ARC-AGI-2.md)
 - [CachePricing](concepts/CachePricing.md)
 - [MultimodalModels](concepts/MultimodalModels.md)
 
-## Syntheses
+## Syntheses (0)


### PR DESCRIPTION
## Summary

Closes the last open item in the UX critique tracker #387. With this merge, all 9 items (U1–U9) are addressed.

The flat bullet lists per section in `wiki/index.md` become unscannable past ~50 pages. Adding `(N)` to each section heading lets a reader see the size of each bucket at a glance:

```diff
-## Entities
+## Entities (4)
 - [Anthropic](entities/Anthropic.md)
```

## Files changed

- `wiki/index.md` — section headings updated with current counts
- `llmwiki/cli.py` — `cmd_init` seed for `wiki/index.md` uses the new format on every fresh init
- `CLAUDE.md` — updated the documented Index Format so `/wiki-ingest` agents preserve the count when adding pages
- `CHANGELOG.md` — entry under `[Unreleased]` Changed

## Test plan

- [x] `python -m llmwiki lint --fail-on-errors` — passes (no new errors)
- [x] `pytest tests/ -q` — 2068 passed
- [ ] CI Playwright + a11y suite

## After merge

Close #387 entirely — every U1–U9 item now has a merged fix.