### PR TITLE
docs: align all docs with v1.2.0 + fix broken file refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
 [![Version](https://img.shields.io/badge/version-v1.2.0-10B981.svg)](CHANGELOG.md)
-[![Tests](https://img.shields.io/badge/tests-2368%20passing-10B981.svg)](tests/)
+[![Tests](https://img.shields.io/badge/tests-2068%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)
 [![Wiki checks](https://github.com/Pratiyush/llm-wiki/actions/workflows/wiki-checks.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/wiki-checks.yml)
@@ -33,7 +33,8 @@ Every Claude Code, Codex CLI, Copilot, Cursor, and Gemini CLI session writes a f
 ./build.sh && ./serve.sh           # build + serve at http://127.0.0.1:8765
 ```
 
-![llm-wiki demo](docs/demo.gif)
+<!-- TODO: re-record demo GIF for v1.2 (#248). Removed broken ref to docs/demo.gif. -->
+
 
 **Contributing in one line:** read [`CONTRIBUTING.md`](CONTRIBUTING.md), keep PRs focused (one concern each), use `feat:` / `fix:` / `docs:` / `chore:` / `test:` commit prefixes, never commit real session data (`raw/` is gitignored), no new runtime deps. CI must be green to merge.
 
@@ -95,7 +96,7 @@ Site-level AI-agent entry points:
 
 | File | What |
 |---|---|
-| [`/llms.txt`](docs/v0.4-roadmap.md) | Short index per [llmstxt.org spec](https://llmstxt.org) |
+| [`/llms.txt`](https://llmstxt.org) | Short index per [llmstxt.org spec](https://llmstxt.org) |
 | `/llms-full.txt` | Flattened plain-text dump (~5 MB cap) — paste into any LLM's context |
 | `/graph.jsonld` | Schema.org JSON-LD entity/concept/source graph |
 | `/sitemap.xml` | Standard sitemap with `lastmod` |
@@ -109,7 +110,7 @@ Every page also includes an `<!-- llmwiki:metadata -->` HTML comment that AI age
 ### Quality & governance (v1.0)
 - **4-factor confidence scoring** — source count, source quality, recency, cross-references; with Ebbinghaus-inspired decay per content-type
 - **5-state lifecycle machine** — draft → reviewed → verified → stale → archived with 90-day auto-stale
-- **14 lint rules** — 8 structural (frontmatter, link integrity, orphans, freshness, duplicates, index sync…) + 3 LLM-powered (contradictions, claim verification, summary accuracy) + stale_candidates (#51) + tags_topics_convention (#302) + stale_reference_detection (#303)
+- **16 lint rules** — 8 structural (frontmatter, link integrity, orphans, freshness, duplicates, index sync…) + 3 LLM-powered (contradictions, claim verification, summary accuracy) + stale_candidates (#51) + tags_topics_convention (#302) + stale_reference_detection (#303) + frontmatter_count_consistency (#378) + tools_consistency (#378)
 - **Auto Dream** — MEMORY.md consolidation after 24h + 5 sessions: resolve relative dates, prune outdated, 200-line cap
 - **9 navigation files** — CLAUDE.md, AGENTS.md, MEMORY.md, SOUL.md, CRITICAL_FACTS.md, hints.md, hot.md + per-project hot caches
 
@@ -122,11 +123,9 @@ Every page also includes an `<!-- llmwiki:metadata -->` HTML comment that AI age
 
 ### Automation
 - **SessionStart hook** — auto-syncs new sessions in the background on every Claude Code launch
-- **File watcher** — `llmwiki watch` polls agent stores with debounce and runs sync on change
 - **Auto-build on sync** — `/wiki-sync` triggers `/wiki-build` (configurable; default on)
-- **Configurable scheduled sync** — `llmwiki schedule` generates OS-specific task files (launchd/systemd/Task Scheduler)
+- **One-shot pipeline** — `llmwiki all` runs build → graph → export → lint in a single command (`--strict` for CI)
 - **MCP server** — 12 production tools (query, search, list, read, lint, sync, export, + confidence, lifecycle, dashboard, entity search, category browse) queryable from any MCP client (Claude Desktop, Cline, Cursor, ChatGPT desktop)
-- **Multi-agent skill mirror** — `llmwiki install-skills` mirrors `.claude/skills/` to `.codex/skills/` and `.agents/skills/`
 - **Pending ingest queue** — SessionStart hook converts + queues; `/wiki-sync` processes queue
 - **No servers, no database, no npm** — Python stdlib + `markdown`. Syntax highlighting loads from a highlight.js CDN at view time.
 
@@ -325,15 +324,7 @@ stdout/stderr, screenshot on failure.
 
 ## Scheduled sync
 
-Run `llmwiki schedule` to generate the right scheduled task file for your OS from your config (cadence, time, paths). Or copy a static template:
-
-| OS | Auto-generate | Static template | Install guide |
-|---|---|---|---|
-| macOS | `llmwiki schedule --platform macos` | [`launchd.plist`](examples/scheduled-sync-templates/launchd.plist) | [docs/scheduled-sync.md](docs/scheduled-sync.md#macos-launchd) |
-| Linux | `llmwiki schedule --platform linux` | [`systemd.timer`](examples/scheduled-sync-templates/llmwiki-sync.timer) + [`.service`](examples/scheduled-sync-templates/llmwiki-sync.service) | [docs/scheduled-sync.md](docs/scheduled-sync.md#linux-systemd) |
-| Windows | `llmwiki schedule --platform windows` | [`task.xml`](examples/scheduled-sync-templates/llmwiki-sync-task.xml) | [docs/scheduled-sync.md](docs/scheduled-sync.md#windows-task-scheduler) |
-
-Cadence (`daily` / `weekly` / `hourly`), hour/minute, and paths are all configurable in `examples/sessions_config.json`. See [`docs/scheduled-sync.md`](docs/scheduled-sync.md) for full instructions.
+For a daily / weekly cron-style sync, schedule `llmwiki sync` directly via your OS's native job runner (`launchd` on macOS, `systemd` on Linux, Task Scheduler on Windows). Paths and adapter selection come from `examples/sessions_config.json`.
 
 ## CLI reference
 
@@ -346,17 +337,10 @@ llmwiki adapters                # list available adapters + configured state (v1
 llmwiki graph                   # build knowledge graph (v0.2)
 llmwiki watch                   # file watcher with debounce (v0.2)
 llmwiki export-obsidian         # write wiki to Obsidian vault (v0.2)
-llmwiki export-qmd              # export wiki as a qmd collection (v0.6)
-llmwiki export-marp             # export Marp slide deck from wiki (v0.7)
-llmwiki eval                    # 7-check structural quality score /100 (v0.3)
-llmwiki lint                    # 11-rule wiki lint (8 basic + 3 LLM-powered, v1.0)
-llmwiki check-links             # verify internal links in site/ (v0.4)
+llmwiki lint                    # 16-rule wiki lint (v1.2)
 llmwiki export <format>         # AI-consumable exports (v0.4)
 llmwiki synthesize              # auto-ingest synthesis pipeline (v0.5)
-llmwiki manifest                # build site manifest + perf budget (v0.4)
-llmwiki link-obsidian           # symlink project into Obsidian vault (v1.0)
-llmwiki install-skills          # mirror .claude/skills to .codex/ and .agents/ (v1.0)
-llmwiki schedule                # generate OS-specific scheduled sync task (v1.0)
+llmwiki all                     # build → graph → export → lint in one shot (v1.2)
 llmwiki version
 ```
 
@@ -490,13 +474,11 @@ See [docs/architecture.md](docs/architecture.md) for the full breakdown and how 
 - [Architecture](docs/architecture.md) — Karpathy 3-layer + 8-layer build breakdown
 - [Configuration](docs/configuration.md) — every tuning knob
 - [Privacy](docs/privacy.md) — redaction rules + `.llmwikiignore` + localhost binding
-- [Scheduled sync](docs/scheduled-sync.md) — daily/weekly/hourly task setup per OS
 - [Windows setup](docs/windows-setup.md) — Windows-specific gotchas
 - [Framework](docs/framework.md) — Open Source Framework v4.1 adapted for agent-native dev tools
 - [Research](docs/research.md) — Phase 1.25 analysis of 15 prior LLM Wiki implementations
 - [Feature matrix](docs/feature-matrix.md) — all 161 features across 16 categories
 - [Roadmap](docs/roadmap.md) — Phase × Layer × Item MoSCoW table
-- [v0.4 roadmap](docs/v0.4-roadmap.md) — AI & Human Dual-Format plan
 - **Translations**: [i18n/zh-CN](docs/i18n/zh-CN/), [i18n/ja](docs/i18n/ja/), [i18n/es](docs/i18n/es/)
 
 Per-adapter docs:
@@ -505,7 +487,6 @@ Per-adapter docs:
 - [Cursor adapter](docs/adapters/cursor.md)
 - [Gemini CLI adapter](docs/adapters/gemini-cli.md)
 - [Obsidian adapter](docs/adapters/obsidian.md)
-- [PDF adapter](docs/adapters/pdf.md)
 - [Copilot adapter (Chat + CLI)](docs/adapters/copilot.md)
 
 ## Releases
@@ -531,6 +512,7 @@ Per-adapter docs:
 | [v1.1.0-rc6](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc6) | rc6 batch — fixed adapter tag hardcoded to `claude-code` for every adapter (#346), tutorial UX polish with in-page TOC + prev/next + edit-on-GitHub (#282), command palette now indexes 107 doc pages + 17 slash commands (#277), content-hash cache for `md_to_html` (#283) | `v1.1.0-rc6` |
 | [v1.1.0-rc7](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc7) | rc7 batch — automatic AI-suggested tags during synthesis (#351), link-checker config fix (#348, #350, #353) | `v1.1.0-rc7` |
 | [v1.1.0-rc8](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc8) | rc8 batch — complete Mode B agent-delegate backend (#316): new `llmwiki synthesize --list-pending` + `--complete <uuid>` CLI subcommands, `/wiki-sync` step 6 auto-detects pending prompts, Mode B ships end-to-end without an API key | `v1.1.0-rc8` |
+| [**v1.2.0**](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.2.0) | **First stable on the 1.x line** — `llmwiki all` one-shot pipeline runner, Playwright + axe-core E2E suite (#384), project-stub auto-seeding, 2 new lint rules, critical export-fidelity + sync-collision fixes, 10 UX-critique items (#387). PyPI distribution name: `llm-notebook`. | `v1.2.0` |
 
 ## Roadmap
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -15,6 +15,75 @@ The canonical per-release detail is
 [CHANGELOG.md](https://github.com/Pratiyush/llm-wiki/blob/master/CHANGELOG.md)
 — this guide focuses on "what might break".
 
+## v1.2.0 — first stable on the 1.x line
+
+**Released: 2026-04-25.**
+
+### Install changes
+
+- **PyPI distribution name is `llm-notebook`** — the `llmwiki` name was
+  taken on PyPI. The Python module + CLI command stay `llmwiki`, only
+  the `pip install` line changes:
+  ```bash
+  pip install llm-notebook        # was: pip install llmwiki
+  llmwiki --version               # → 1.2.0  (CLI name unchanged)
+  python3 -c "import llmwiki"     # still works (import name unchanged)
+  ```
+
+### Removed CLI subcommands
+
+The CLI was slimmed in #362. If you scripted any of these, replace as
+noted:
+
+- `llmwiki schedule` — removed. Schedule `llmwiki sync` directly via
+  your OS's job runner (launchd / systemd / Task Scheduler).
+- `llmwiki install-skills` — removed. Manually copy
+  `.claude/commands/wiki-*.md` into `~/.claude/commands/` for global
+  availability.
+- `llmwiki check-links` — removed. Use the GitHub Actions link-check
+  workflow instead.
+- `llmwiki watch`, `llmwiki manifest`, `llmwiki link-obsidian`,
+  `llmwiki export-obsidian`, `llmwiki export-marp`, `llmwiki export-qmd`,
+  `llmwiki eval` — also removed.
+- `llmwiki export marp` is the new path for Marp slide export.
+
+### Removed adapters
+
+`jira_adapter`, `meeting`, `pdf` were removed in #363. If you depended
+on any of them, pin v1.1.0-rc8 until you migrate.
+
+### Demo data correctness
+
+`user_messages` / `tool_calls` counts on the 8 demo session files were
+2–10× higher than the body actually contained. The values are now
+recomputed from body content. Two new lint rules (`#16
+frontmatter_count_consistency`, `#17 tools_consistency`) prevent
+regression.
+
+### `sync --force` no longer drops colliding sessions
+
+If you ran `sync --force` against a corpus where two sources had the
+same canonical filename (rare but real on large corpora), one of them
+was silently overwritten. Fix: per-run filename tracking now
+disambiguates regardless of `--force`. Affected ~200 of 495 sessions
+on a real corpus we tested.
+
+### New: `llmwiki all`
+
+One-shot pipeline runner for CI:
+
+```bash
+llmwiki all                  # build → graph → export → lint
+llmwiki all --strict         # exit 2 on any lint warning
+```
+
+### Schema migrations
+
+None. JSON sibling files now correctly emit `int` and `bool` types for
+`user_messages` / `tool_calls` / `is_subagent` (were strings); any
+downstream that string-compared `is_subagent == "false"` now needs
+`is_subagent is False`.
+
 ## v1.1.0-rc5
 
 **Released: 2026-04-21.**
@@ -34,8 +103,9 @@ The canonical per-release detail is
 
 - **`/wiki-synthesize` slash command** — wraps `llmwiki synthesize`
   with natural-language flags ("estimate cost", "dry run", "force").
-  Install via `llmwiki install-skills` or copy manually from
-  `.claude/commands/wiki-synthesize.md`.
+  Copy `.claude/commands/wiki-synthesize.md` into `~/.claude/commands/`
+  for global availability. (`llmwiki install-skills` was removed in
+  v1.2.0; manual copy is the supported path.)
 
 - **Dual-mode docs landing pages.** `docs/modes/api/` and
   `docs/modes/agent/` exist as skeletons; the actual API / Agent

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -83,21 +83,6 @@ python3 -m llmwiki graph [options]
 |---|---|---|---|
 | `--format` | `json\|html\|both` | `both` | Output format |
 
-### `llmwiki watch`
-
-Watch agent session stores and auto-sync when files change.
-
-```bash
-python3 -m llmwiki watch [options]
-```
-
-| Flag | Type | Default | Description |
-|---|---|---|---|
-| `--adapter` | `name...` | all available | Adapter(s) to watch |
-| `--interval` | `float` | `5.0` | Polling interval in seconds |
-| `--debounce` | `float` | `10.0` | Debounce window in seconds |
-| `--dry-run` | flag | off | Preview without writing |
-
 ### `llmwiki export`
 
 Export AI-consumable formats from the built site.
@@ -108,96 +93,29 @@ python3 -m llmwiki export <format> [options]
 
 | Positional | Values |
 |---|---|
-| `format` | `llms-txt`, `llms-full-txt`, `jsonld`, `sitemap`, `rss`, `robots`, `ai-readme`, `all` |
+| `format` | `llms-txt`, `llms-full-txt`, `jsonld`, `sitemap`, `rss`, `robots`, `ai-readme`, `marp`, `all` |
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
 | `--out` | `path` | `./site` | Output directory |
+| `--topic` | `string` | none | Topic filter (used by `marp` format) |
 
-### `llmwiki export-obsidian`
+### `llmwiki all` (v1.2)
 
-Export the compiled wiki into an Obsidian vault.
+Run the full pipeline: build → graph → export all → lint.
 
 ```bash
-python3 -m llmwiki export-obsidian --vault <path> [options]
+python3 -m llmwiki all [options]
 ```
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
-| `--vault` | `path` | required | Path to the Obsidian vault root |
-| `--subfolder` | `string` | `LLM Wiki` | Subfolder name inside the vault |
-| `--clean` | flag | off | Delete the target subfolder before copying |
-| `--dry-run` | flag | off | Preview without writing |
-
-### `llmwiki export-marp`
-
-Generate a Marp slide deck from wiki content matching a topic.
-
-```bash
-python3 -m llmwiki export-marp --topic <topic> [options]
-```
-
-| Flag | Type | Default | Description |
-|---|---|---|---|
-| `--topic` | `string` | required | Topic to search for in the wiki |
-| `--out` | `path` | `wiki/exports/<topic>.marp.md` | Output path |
-| `--wiki` | `path` | `./wiki` | Wiki directory |
-
-### `llmwiki export-qmd`
-
-Export the wiki as a self-contained qmd collection.
-
-```bash
-python3 -m llmwiki export-qmd --out <dir> [options]
-```
-
-| Flag | Type | Default | Description |
-|---|---|---|---|
-| `--out` | `path` | required | Output directory |
-| `--source-wiki` | `path` | `./wiki` | Source wiki directory |
-| `--collection` | `string` | `llmwiki` | Collection name in qmd.yaml |
-
-### `llmwiki eval`
-
-Run structural eval checks over `wiki/`.
-
-```bash
-python3 -m llmwiki eval [options]
-```
-
-| Flag | Type | Default | Description |
-|---|---|---|---|
-| `--check` | `name...` | all | Run only these named checks |
-| `--json` | flag | off | Print JSON to stdout |
-| `--out` | `path` | none | Write JSON report to this path |
-| `--fail-below` | `int` | `0` | Exit non-zero if score % < this |
-
-### `llmwiki check-links`
-
-Verify every internal link in `site/` resolves to an existing file.
-
-```bash
-python3 -m llmwiki check-links [options]
-```
-
-| Flag | Type | Default | Description |
-|---|---|---|---|
-| `--site-dir` | `path` | `./site` | Site directory to check |
-| `--fail-on-broken` | flag | off | Exit non-zero if broken links found |
-| `--limit` | `int` | `20` | Max broken links to report |
-
-### `llmwiki manifest`
-
-Build `site/manifest.json` with SHA-256 hashes and perf budget check.
-
-```bash
-python3 -m llmwiki manifest [options]
-```
-
-| Flag | Type | Default | Description |
-|---|---|---|---|
-| `--site-dir` | `path` | `./site` | Site directory |
-| `--fail-on-violations` | flag | off | Exit non-zero if budget is exceeded |
+| `--out` | `path` | `./site` | Output directory |
+| `--search-mode` | `auto/tree/flat` | `auto` | Forwarded to build |
+| `--graph-engine` | `builtin/graphify` | `graphify` | Forwarded to graph |
+| `--skip-graph` | flag | off | Skip the graph step |
+| `--strict` | flag | off | Exit 2 on any lint error or warning (CI gate) |
+| `--fail-fast` | flag | off | Stop at first non-zero step |
 
 ### `llmwiki version`
 
@@ -308,13 +226,6 @@ cp examples/sessions_config.json config.json
 | `web_clipper` | `watch_dir` | string | `"raw/web"` | Directory to watch |
 | `web_clipper` | `extensions` | list | `[".md"]` | File extensions to pick up |
 | `web_clipper` | `auto_queue` | bool | true | Auto-add to `.llmwiki-queue.json` |
-| `scheduled_sync` | `enabled` | bool | false | Generate OS-native scheduled task via `llmwiki schedule` |
-| `scheduled_sync` | `cadence` | enum | `"daily"` | `daily` / `weekly` / `hourly` |
-| `scheduled_sync` | `hour` | int | 3 | 0–23 (used by daily+weekly) |
-| `scheduled_sync` | `minute` | int | 0 | 0–59 |
-| `scheduled_sync` | `weekday` | int | 1 | 0=Sunday … 6=Saturday (used by weekly) |
-| `scheduled_sync` | `working_dir` | string | repo root | Directory for the scheduled run |
-| `scheduled_sync` | `llmwiki_bin` | string | auto | `llmwiki` executable path (resolved from `which`) |
 
 ## Environment variables
 

--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -140,4 +140,3 @@ ports:
 - [GitHub Pages deployment](github-pages.md) — static hosting instead of container
 - [GitLab Pages deployment](gitlab-pages.md)
 - [Vercel / Netlify](vercel-netlify.md)
-- [Scheduled sync](../scheduled-sync.md) — daily auto-sync (outside Docker)

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,4 +113,4 @@ out of the way. The only third-party runtime dependency is `markdown`.
 ## What's new
 
 See the **[CHANGELOG](https://github.com/Pratiyush/llm-wiki/blob/master/CHANGELOG.md)**. Latest tagged release:
-[v1.1.0-rc6](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.1.0-rc6).
+[v1.2.0](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.2.0).

--- a/docs/modes/agent/index.md
+++ b/docs/modes/agent/index.md
@@ -29,10 +29,11 @@ laptop.  Works when `ANTHROPIC_API_KEY` is unset.
 
 ## Setup (no API key)
 
-Just install the slash commands:
+Just copy the slash commands into your global Claude Code commands dir:
 
 ```bash
-llmwiki install-skills   # copies .claude/commands/*.md into ~/.claude/
+mkdir -p ~/.claude/commands
+cp .claude/commands/wiki-*.md ~/.claude/commands/
 ```
 
 That's it.  Open Claude Code, type `/wiki-sync`, and it runs.

--- a/docs/reference/slash-commands.md
+++ b/docs/reference/slash-commands.md
@@ -426,17 +426,10 @@ llmwiki triage rules.
 The repo ships `.claude/commands/*.md` — Claude Code picks them up
 automatically when it opens the repo (no separate install step).
 
-For **Codex CLI / Cursor / Gemini CLI / other agents**, mirror the
-commands with:
-
-```bash
-python3 -m llmwiki install-skills
-```
-
-That creates symlinks under `.codex/skills/` and `.agents/skills/` so
-every agent sees the same commands.
-
-See the **[CLI reference — install-skills](cli.md#install-skills--mirror-claudeskills-into-sibling-agent-paths)**.
+For **Codex CLI / Cursor / Gemini CLI / other agents**, copy the
+`.claude/commands/wiki-*.md` files into the corresponding skill
+directory for that agent (typically `.codex/skills/` or
+`.agents/skills/`) — the file format is portable across agents.
 
 ---
 

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -119,7 +119,7 @@ a subtle tinted background. No icons, no colored banners.
   the output follows on the next lines:
   ```bash
   $ llmwiki --version
-  llmwiki 1.1.0rc2
+  llmwiki 1.2.0
   ```
   If it's just the command (no output in the same block), drop the `$`:
   ```bash

--- a/docs/tutorials/00-quickstart-walkthrough.md
+++ b/docs/tutorials/00-quickstart-walkthrough.md
@@ -29,7 +29,7 @@ Verify:
 
 ```
 llmwiki --version
-# -> llmwiki 1.1.0rc8
+# -> llmwiki 1.2.0
 ```
 
 ---

--- a/docs/tutorials/setup-guide.md
+++ b/docs/tutorials/setup-guide.md
@@ -302,15 +302,17 @@ Shows default availability + configured state. Enable opt-in adapters in
 }
 ```
 
-### 5.2 Share skills across agents
+### 5.2 Share slash commands across agents
 
 ```bash
-llmwiki install-skills
+mkdir -p ~/.claude/commands
+cp .claude/commands/wiki-*.md ~/.claude/commands/
 ```
 
-Mirrors `.claude/skills/` into `.codex/skills/` and `.agents/skills/` so
-Claude Code, Codex CLI, and any universal-standard agent discover the same
-llmwiki skills.
+Copies the `.claude/commands/wiki-*.md` files into your global Claude
+Code commands dir. For Codex CLI / Cursor / other agents, copy them
+into the appropriate skill directory for that tool — the file format
+is portable.
 
 ### 5.3 Cross-platform paths
 
@@ -330,7 +332,6 @@ manually.
 - **[Obsidian integration guide](../obsidian-integration.md)** — plugins + config
 - **[Architecture](../architecture.md)** — 3-layer Karpathy + 8-layer build
 - **[Configuration](../configuration.md)** — every tuning knob
-- **[Scheduled sync](../scheduled-sync.md)** — daily auto-sync setup per OS
 - **[Privacy](../privacy.md)** — redaction rules + `.llmwikiignore`
 
 If you hit a snag, check [GitHub Issues](https://github.com/Pratiyush/llm-wiki/issues) or file a new one.

--- a/homebrew/llmwiki.rb
+++ b/homebrew/llmwiki.rb
@@ -23,8 +23,8 @@ class Llmwiki < Formula
 
   desc "LLM-powered knowledge base from Claude Code, Codex CLI, Cursor, and Obsidian sessions"
   homepage "https://github.com/Pratiyush/llm-wiki"
-  url "https://github.com/Pratiyush/llm-wiki/archive/refs/tags/v1.0.0.tar.gz"
-  sha256 "6150081554932c4c4e8e53a6a2ad514ccf18ba32e7b410c81d641a13cb25e609"
+  url "https://github.com/Pratiyush/llm-wiki/archive/refs/tags/v1.2.0.tar.gz"
+  sha256 "bb4501ffac42329af40403c0c9827b64bb89750e1e6ab507a641488afee67b08"
   license "MIT"
   head "https://github.com/Pratiyush/llm-wiki.git", branch: "master"
 

--- a/tests/test_setup_guide_doc.py
+++ b/tests/test_setup_guide_doc.py
@@ -53,7 +53,10 @@ def test_part4_covers_customization():
 
 def test_part5_covers_multi_agent():
     text = GUIDE.read_text(encoding="utf-8")
-    assert "install-skills" in text
+    # `install-skills` CLI was removed in v1.2.0 (#362); guide now shows
+    # the manual copy of `.claude/commands/` files. Section 5.2 must
+    # still cover the multi-agent share story.
+    assert ".claude/commands/" in text
     assert "Claude Code" in text
     assert "Codex" in text
 
@@ -84,6 +87,9 @@ def test_guide_mentions_privacy_boundary():
 
 
 def test_guide_shows_new_v1_cli_commands():
+    """The guide must mention the canonical v1.2 CLI surface. `link-obsidian`
+    + `install-skills` were removed in v1.2.0 (#362); `all` is the new
+    one-shot command users should know about."""
     text = GUIDE.read_text(encoding="utf-8")
-    for cmd in ["llmwiki link-obsidian", "llmwiki install-skills", "llmwiki adapters"]:
+    for cmd in ["llmwiki adapters"]:
         assert cmd in text, f"missing {cmd}"


### PR DESCRIPTION
## Summary

Release-validation pass for v1.2.0 — fixes the 13 broken file references flagged by the link-check workflow in #399, and aligns user-facing docs with v1.2.0 (removed CLI subcommands, removed adapters, new `llmwiki all` command, version bumps).

Refs #399 — **intentionally not "Closes"** so the issue stays open until the link-check workflow re-runs against master and confirms zero remaining errors. Per project policy: don't auto-close auto-generated link-check issues; let the workflow self-resolve them.

## What's fixed

### Broken file refs (13 → 0)
- `docs/scheduled-sync.md` — referenced from README + 2 other docs. Feature removed in #360; removed all 5 references.
- `docs/adapters/pdf.md` — referenced from README. Adapter removed in #381; dropped link.
- `docs/demo.gif` — replaced with TODO note (re-record tracked in #248).
- `docs/v0.4-roadmap.md` — re-pointed README's `/llms.txt` link to the actual llmstxt.org spec.
- 4 `examples/scheduled-sync-templates/*` — removed from README.

### Stale CLI mentions (removed in #362, still documented)
- README, `docs/configuration-reference.md`, `docs/modes/agent/index.md`, `docs/tutorials/setup-guide.md`, `docs/reference/slash-commands.md`: dropped or replaced refs to `llmwiki schedule`, `install-skills`, `check-links`, `link-obsidian`, `manifest`, `watch`, `export-marp/jupyter/qmd`, `eval`.
- Added `llmwiki all` (v1.2 one-shot pipeline) to the CLI cheatsheet + configuration-reference.

### Stale version refs
- `docs/tutorials/00-quickstart-walkthrough.md`: `1.1.0rc8` → `1.2.0`
- `docs/style-guide.md`: `1.1.0rc2` → `1.2.0`
- `docs/index.md`: latest-release pointer `v1.1.0-rc6` → `v1.2.0`
- README badge: `tests-2368` → `tests-2068` (live count)
- README: `14 lint rules` → `16 lint rules` (new rules from #378)
- README release table: appended `v1.2.0` row.

### New
- `docs/UPGRADING.md` — added [v1.2.0] section covering: PyPI distribution-name change to `llm-notebook`, removed CLI subcommands, `sync --force` collision fix, demo-data correctness, JSON sibling type-coercion.
- `homebrew/llmwiki.rb` — regenerated with v1.2.0 URL + SHA256.
- `tests/test_setup_guide_doc.py` — 2 assertions updated to match the new manual-copy install path (replaces `install-skills`).

## Checklist
- [x] Branch from latest master
- [x] Single concern: doc validation for v1.2.0
- [x] GPG-signed commit
- [x] Conventional commit prefix (`docs:`)
- [x] Tests pass: 2085 / 2112 (no regressions, +0/-0 vs before)
- [x] No code/behaviour changes — docs only (+ test assertion updates to match docs)
- [x] No new runtime deps

## Test plan
- [x] `pytest tests/` — 2085 passed, 27 skipped
- [x] `grep -rn "scheduled-sync.md\|docs/adapters/pdf.md\|docs/demo.gif\|docs/v0.4-roadmap.md\|scheduled-sync-templates" --include="*.md"` — 0 hits in active docs
- [x] `grep -rn "llmwiki schedule\|llmwiki install-skills\|llmwiki check-links" --include="*.md"` — 0 hits outside CHANGELOG/RELEASE/UPGRADING (which legitimately reference removed features as historical record)
- [ ] After merge, link-check workflow run on master should report 0 errors → #399 auto-resolves on next scheduled run