### PR TITLE
docs(graphify): fix stale pip install reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 - **Claude Code CI actions now use Opus 4.7** (#401) — both `claude-code-review.yml` (auto-fires on every PR) and `claude.yml` (`@claude` mention) now pass `--model claude-opus-4-7` via `claude_args`. Was the action's default Sonnet. Catches more subtle bugs and handles multi-file refactor requests better, at ~3-5× the per-review cost (still well within Anthropic Pro/Max plan quota).
 
+### Fixed
+
+- **Stale `pip install llmwiki[graph]` reference in `graphify_bridge.py` docstring** (#402) — the PyPI distribution was renamed to `llm-notebook` in #398; the module docstring missed the rename. Fixed: now reads `pip install llm-notebook[graph]`. Python import name (`import llmwiki`) unchanged.
+
 ## [1.2.0] — 2026-04-25
 
 First stable release on the 1.x line. Promotes the eight rc1-rc8 prereleases into one stable tag and bundles the post-rc8 audit fixes, the new `wiki-all` one-shot pipeline runner, the Playwright/axe-core E2E suite, and ten UX-critique items into a single shippable cut.

--- a/llmwiki/graphify_bridge.py
+++ b/llmwiki/graphify_bridge.py
@@ -4,7 +4,7 @@ Delegates graph building, community detection, and analysis to the
 ``graphify`` package (https://github.com/safishamsi/graphify) when
 installed.  Falls back gracefully when not available.
 
-Install:  pip install graphify          # or: pip install llmwiki[graph]
+Install:  pip install graphify          # or: pip install llm-notebook[graph]
 Extras:   pip install graphify[mcp]     # MCP server
           pip install graphify[leiden]   # better community detection
 


### PR DESCRIPTION
## Summary

Tiny doc fix to verify the Opus 4.7 upgrade on `claude-code-review.yml` actually fires on real PRs (the upgrade itself couldn't self-test on #401 due to GitHub Actions self-modification protection).

## Real fix

`llmwiki/graphify_bridge.py` docstring still said `pip install llmwiki[graph]`. The PyPI distribution was renamed to `llm-notebook` in #398, so the line should read `pip install llm-notebook[graph]`. The Python import name (`import llmwiki`) doesn't change.

## Checklist
- [x] Branch from latest master
- [x] Single concern: stale install string
- [x] GPG-signed commit
- [x] Conventional commit prefix (`docs(graphify):`)
- [x] No code changes — docstring only

## Probe

Once CI runs, claude-review will fire on Opus 4.7 instead of the previous Sonnet default. Compare review output here vs e.g. PR #400 (which got Sonnet) to see the model upgrade in practice.