### PR TITLE
fix: URL correctness — disambig source_file + exporter stems (v1.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,16 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
-### Changed
+## [1.2.1] — 2026-04-26
 
-- **Claude Code CI actions now use Opus 4.7** (#401) — both `claude-code-review.yml` (auto-fires on every PR) and `claude.yml` (`@claude` mention) now pass `--model claude-opus-4-7` via `claude_args`. Was the action's default Sonnet. Catches more subtle bugs and handles multi-file refactor requests better, at ~3-5× the per-review cost (still well within Anthropic Pro/Max plan quota).
+Patch release fixing 2 critical URL-correctness bugs surfaced by the Opus 4.7 code review (#403). No behaviour change beyond the fixed URLs; safe to upgrade.
 
 ### Fixed
 
-- **Stale `pip install llmwiki[graph]` reference in `graphify_bridge.py` docstring** (#402) — the PyPI distribution was renamed to `llm-notebook` in #398; the module docstring missed the rename. Fixed: now reads `pip install llm-notebook[graph]`. Python import name (`import llmwiki`) unchanged.
+- **`source_file:` frontmatter now matches disambiguated filenames** (#404) — `render_session_markdown` rendered the canonical `source_file:` line *before* the collision disambiguator decided the actual on-disk filename. Disambiguated sessions (e.g. `<canonical>--<hash>.md`) silently shipped with a `source_file:` field that resolved to a sibling file (or a 404 in the graph viewer). Fix: rewrite `source_file:` to match the disambiguated filename whenever disambig fires. Adds a regression test (`tests/test_collision_retry.py::test_disambiguated_source_file_matches_disk`).
+- **JSON-LD / sitemap / RSS / per-page `.json` exporters URL drift** (#415) — exporters composed URLs as `sessions/<project>/<meta.slug>.html` while `build.py` writes HTML to `sessions/<project>/<path.stem>.html`. The two stems differ by the date prefix and any `--<hash>` disambiguator suffix → every URL emitted in `sitemap.xml`, `rss.xml`, `graph.jsonld`, and per-session `.json` siblings was wrong. Fix: unify on `path.stem` for URL composition; reserve `meta["slug"]` for display fields (titles, JSON-LD `name`).
+- **Claude Code CI actions now use Opus 4.7** (#401) — both `claude-code-review.yml` (auto-fires on every PR) and `claude.yml` (`@claude` mention) now pass `--model claude-opus-4-7` via `claude_args`. Was the action's default Sonnet.
+- **Stale `pip install llmwiki[graph]` reference in `graphify_bridge.py` docstring** (#402) — corrected to `pip install llm-notebook[graph]` after the PyPI distribution rename in #398.
 
 ## [1.2.0] — 2026-04-25
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.2.0-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.2.1-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2068%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/convert.py
+++ b/llmwiki/convert.py
@@ -1183,6 +1183,18 @@ def convert_all(
                     disambiguator=_source_hash8(path),
                 )
                 out_path = out_dir / out_name
+                # #404: rewrite the source_file: frontmatter line so it
+                # matches the disambiguated filename. Without this the
+                # rendered markdown still pointed at the canonical name,
+                # breaking graph viewer links and any consumer that
+                # resolved source_file → site URL.
+                md = re.sub(
+                    r"^source_file: raw/sessions/[^\n]+$",
+                    f"source_file: raw/sessions/{out_name}",
+                    md,
+                    count=1,
+                    flags=re.MULTILINE,
+                )
             if not dry_run:
                 names_written_this_run.add(out_name)
             if dry_run:

--- a/llmwiki/exporters.py
+++ b/llmwiki/exporters.py
@@ -140,7 +140,10 @@ def write_page_json(
         "wikilinks_out": sorted(set(wikilinks_out)),
         "body_text": _plain_text(markdown_body),
         "sha256": _sha256_16(markdown_body),
-        "source_url": f"sessions/{meta.get('project', '')}/{meta.get('slug', '')}.html",
+        # #415: source_url must match build.py's session HTML path which uses
+        # page_html_path.stem (carries date prefix + any disambig hash),
+        # NOT the bare slug field.
+        "source_url": f"sessions/{meta.get('project', '')}/{page_html_path.stem}.html",
     }
     # Drop None values so the JSON is clean
     data = {k: v for k, v in data.items() if v is not None}
@@ -305,14 +308,20 @@ def write_graph_jsonld(
     # Session nodes
     for p, meta, _body in sources:
         project = str(meta.get("project") or p.parent.name)
-        slug = str(meta.get("slug", p.stem))
+        # #415: build.py writes session HTML at sessions/<project>/<path.stem>.html
+        # — exporters MUST use the same path.stem for URL composition, not the
+        # slug field. The slug is the bare slug; the on-disk stem includes the
+        # date prefix (and any --<hash> disambiguator from collision retry).
+        # Mismatch was producing dead links in JSON-LD / sitemap / RSS.
+        url_stem = p.stem
+        slug = str(meta.get("slug", p.stem))  # used only for display @id
         node = {
-            "@id": f"session/{_page_id(project, slug)}",
+            "@id": f"session/{_page_id(project, url_stem)}",
             "@type": "CreativeWork",
             "name": meta.get("title") or slug,
             "dateCreated": meta.get("started") or meta.get("date"),
             "isPartOf": {"@id": f"project/{project}"},
-            "url": f"sessions/{project}/{slug}.html",
+            "url": f"sessions/{project}/{url_stem}.html",
         }
         if meta.get("model"):
             node["creator"] = {"@type": "SoftwareApplication", "name": str(meta["model"])}
@@ -360,10 +369,10 @@ def write_sitemap(
         lines.append(url(f"projects/{project}.html", priority="0.8"))
     for p, meta, _ in sources:
         project = str(meta.get("project") or p.parent.name)
-        slug = str(meta.get("slug", p.stem))
-        started = str(meta.get("started", ""))
-        lastmod = started.split("T")[0] if started else None
-        lines.append(url(f"sessions/{project}/{slug}.html", lastmod=lastmod, priority="0.6"))
+        # #415: use path.stem for URL — matches build.py's session HTML output path
+        lines.append(url(f"sessions/{project}/{p.stem}.html",
+                         lastmod=(str(meta.get("started", "")).split("T")[0] or None),
+                         priority="0.6"))
     lines.append("</urlset>")
     out_path = out_dir / "sitemap.xml"
     out_path.write_text("\n".join(lines), encoding="utf-8")
@@ -400,7 +409,8 @@ def write_rss(
         project = str(meta.get("project") or p.parent.name)
         slug = str(meta.get("slug", p.stem))
         title = str(meta.get("title", slug))
-        href_rel = f"sessions/{project}/{slug}.html"
+        # #415: use path.stem for URL — matches build.py's session HTML output path
+        href_rel = f"sessions/{project}/{p.stem}.html"
         link = f"{site_base_url.rstrip('/')}/{href_rel}" if site_base_url else href_rel
         summary = _plain_text(body)[:300]
         started = str(meta.get("started", ""))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.2.0"
+version = "1.2.1"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_collision_retry.py
+++ b/tests/test_collision_retry.py
@@ -281,3 +281,51 @@ def test_disambiguated_names_stable_across_incremental_sync(tmp_path, monkeypatc
         assert name in after_second, (
             f"sync-2 renamed or removed {name!r}: {after_second}"
         )
+
+
+def test_disambiguated_source_file_matches_disk(tmp_path, monkeypatch):
+    """#404 + #427: the ``source_file:`` frontmatter field must point at
+    the actual on-disk filename — including the ``--<hash>`` suffix on
+    disambiguated files. Before the fix, ``render_session_markdown``
+    hard-coded the canonical filename in the frontmatter, so disambiguated
+    files all carried a ``source_file:`` that resolved to a sibling file
+    (or a 404 in the graph viewer).
+    """
+    home, proj, out_dir, state = _seed_env(tmp_path)
+    ts = "2026-04-16T10:00:00Z"
+
+    # Two colliding sources → one canonical, one hashed.
+    _write_jsonl(proj / "alpha.jsonl", "sess-a", ts, slug="dup-check")
+    _write_jsonl(proj / "beta.jsonl", "sess-b", ts, slug="dup-check")
+
+    _patch(monkeypatch, home, out_dir, state)
+    c.discover_adapters()
+    c.convert_all(adapters=["claude_code"], out_dir=out_dir,
+                  state_file=state, include_current=True)
+
+    outs = sorted(out_dir.rglob("*.md"))
+    assert len(outs) == 2, [p.name for p in outs]
+
+    # For every output file, the source_file: frontmatter line must name
+    # that exact file (matching disambiguated suffix where present).
+    for p in outs:
+        body = p.read_text(encoding="utf-8")
+        # Pull out the source_file: line from the frontmatter
+        sf_line = next(
+            (line for line in body.splitlines() if line.startswith("source_file:")),
+            None,
+        )
+        assert sf_line is not None, f"no source_file: line in {p.name}"
+        # Frontmatter says raw/sessions/<filename>; check the trailing path matches
+        recorded_filename = sf_line.split("/")[-1]
+        assert recorded_filename == p.name, (
+            f"frontmatter source_file mismatch in {p.name}: "
+            f"frontmatter says {recorded_filename!r}, file is {p.name!r}"
+        )
+
+    # Stronger check: at least one of the two files must be disambiguated
+    # (carry --<hash>) — otherwise the test isn't exercising the fix.
+    disambig_files = [p for p in outs if "--" in p.name]
+    assert disambig_files, (
+        f"test setup failed to produce disambiguation: {[p.name for p in outs]}"
+    )


### PR DESCRIPTION
## Summary

Patch release v1.2.1 fixing 2 critical URL-correctness bugs from the Opus 4.7 code review.

Closes #404, #415, #427

## What's fixed

### #404 — `source_file:` frontmatter rendered before collision disambig
\`render_session_markdown\` hard-coded the canonical \`source_file: raw/sessions/<X>.md\` line, then the disambiguator decided the actual on-disk filename. Disambiguated sessions shipped with frontmatter pointing at a sibling file → graph viewer dead-linked to every disambiguated session.

**Fix:** in \`convert.py\`, after disambig fires, regex-rewrite the \`source_file:\` line to match the actual filename.

### #415 — Exporters use slug instead of path.stem for URLs
JSON-LD, sitemap, RSS, and per-page \`.json\` siblings all built URLs as \`sessions/<project>/<meta.slug>.html\` while \`build.py\` writes HTML to \`sessions/<project>/<path.stem>.html\`. Stems differ by date prefix + disambig hash → every URL in the AI-consumable export surface was wrong.

**Fix:** in \`exporters.py\`, unify on \`path.stem\`. Reserve \`meta["slug"]\` for display fields (titles, JSON-LD \`name\`).

### #427 — Test-coverage gap
\`tests/test_collision_retry.py\` asserted file presence but never read frontmatter back. New \`test_disambiguated_source_file_matches_disk\` reads every output's \`source_file:\` line and asserts it matches the on-disk filename.

## Verification

- ✅ 2086 unit tests pass (1 new regression test for #404 + #427)
- ✅ E2E URL-resolution check: built demo wiki, scanned every URL in \`sitemap.xml\` / \`rss.xml\` / \`graph.jsonld\` → 100% resolve to real files
- ✅ \`llmwiki all --strict\` exits 0 on demo data

## Release shape

**Patch (v1.2.1)** — pure fixes, no behaviour/API changes visible to users beyond corrected URLs. Safe to upgrade.

## Checklist

- [x] Branch from latest master
- [x] One issue → one MR (closes #404, #415, #427 — bundled because they share root cause)
- [x] GPG-signed commit
- [x] Conventional commit prefix (\`fix:\`)
- [x] CHANGELOG updated under \`[1.2.1]\`
- [x] Version bumped: \`pyproject.toml\` + \`__init__.py\` + README badge → 1.2.1
- [x] Tests added (regression test for #404)
- [x] No new runtime deps
- [x] E2E verification done