### PR TITLE
fix: unify frontmatter parsers + handle BOM/CRLF (#409 #423, v1.2.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.2.4] — 2026-04-26
+
+Patch release unifying the frontmatter parsers and fixing two correctness bugs surfaced by the Opus 4.7 code review (#403). Windows-authored files (CRLF, BOM-prefixed) now parse identically to LF input. No user-visible behaviour change beyond formerly-dropped frontmatter now landing.
+
+### Fixed
+
+- **Two divergent frontmatter parsers unified** (#409) — `build.py` shipped its own regex (`^---\n(.*?)\n---\n`) and a simpler list parser that disagreed with `_frontmatter.py` on CRLF input and quoted list elements. A Windows-authored `wiki/projects/<slug>.md` silently produced an empty meta dict on the build path while every other consumer saw the populated dict. Fix: delete the duplicate parser; `build.py` re-exports `parse_frontmatter` from `_frontmatter.py`. The canonical regex now accepts LF, CRLF, and CR after each fence.
+- **UTF-8 BOM dropped frontmatter silently** (#423) — files saved by Notepad on Windows ship with `\ufeff` at offset 0; the `^---` regex never matched, so the page was treated as headerless. Fix: `_strip_bom()` runs before the regex in every public entry point (`parse_frontmatter`, `parse_frontmatter_dict`, `parse_frontmatter_or_none`).
+
+### Added
+
+- **14 new tests** covering CRLF, CR-only, mixed line-endings, UTF-8 BOM, BOM+CRLF combination, and end-to-end `discover_sources` paths for Windows-authored files. `tests/test_frontmatter_shared.py` is now 43 cases.
+
 ## [1.2.2] — 2026-04-26
 
 Patch release closing the path-traversal vector flagged by the Opus 4.7 code review (#403). No user-visible behaviour change beyond rejecting poisoned slugs.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.2.2-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.2.4-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2068%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.2.2"
+__version__ = "1.2.4"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/_frontmatter.py
+++ b/llmwiki/_frontmatter.py
@@ -19,15 +19,32 @@ from __future__ import annotations
 import re
 from typing import Any, Optional, Tuple
 
-_FRONTMATTER_RE = re.compile(r"^---\n?(.*?)\n?---\n?(.*)$", re.DOTALL)
+# Accept LF, CRLF, or CR after each fence so Windows-authored (CRLF) and
+# old-Mac (CR) files parse identically to LF input. The optional newline
+# slots match the historical regex (`\n?(.*?)\n?---\n?`) so empty
+# frontmatter (`---\n---\nbody`) still parses. BOM is handled separately
+# in `_strip_bom()` before the regex runs. See #409, #423.
+_FRONTMATTER_RE = re.compile(
+    r"^---[ \t]*(?:\r\n|\r|\n)?(.*?)(?:\r\n|\r|\n)?---[ \t]*(?:\r\n|\r|\n)?(.*)$",
+    re.DOTALL,
+)
+
+
+def _strip_bom(text: str) -> str:
+    """Strip leading UTF-8 BOM if present (#423)."""
+    if text and text[0] == "\ufeff":
+        return text[1:]
+    return text
 
 
 def parse_frontmatter(text: str) -> Tuple[dict[str, Any], str]:
     """Return ``(meta, body)`` — the canonical shape.
 
     Empty or malformed input returns ``({}, text)`` so callers can
-    treat every file uniformly.
+    treat every file uniformly. Handles UTF-8 BOM and CR/LF/CRLF
+    line endings transparently.
     """
+    text = _strip_bom(text)
     m = _FRONTMATTER_RE.match(text)
     if not m:
         return {}, text
@@ -53,6 +70,7 @@ def parse_frontmatter_or_none(text: str) -> Tuple[Optional[str], str]:
     """Return ``(raw_frontmatter_text | None, body)`` — legacy shape
     used by ``llmwiki/tags.py`` which does its own line-level parsing
     inside the frontmatter block."""
+    text = _strip_bom(text)
     m = _FRONTMATTER_RE.match(text)
     if not m:
         return None, text

--- a/llmwiki/build.py
+++ b/llmwiki/build.py
@@ -81,30 +81,15 @@ PROJECTS_META_DIR = REPO_ROOT / "wiki" / "projects"
 
 # ─── frontmatter ───────────────────────────────────────────────────────────
 
-_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)$", re.DOTALL)
-
-
-def parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
-    m = _FRONTMATTER_RE.match(text)
-    if not m:
-        return {}, text
-    raw, body = m.group(1), m.group(2)
-    meta: dict[str, Any] = {}
-    for line in raw.splitlines():
-        if ":" not in line:
-            continue
-        k, _, v = line.partition(":")
-        v = v.strip()
-        if len(v) >= 2 and v[0] == v[-1] and v[0] in ("'", '"'):
-            v = v[1:-1]
-        if v.startswith("[") and v.endswith("]"):
-            inner = v[1:-1].strip()
-            meta[k.strip()] = (
-                [x.strip() for x in inner.split(",") if x.strip()] if inner else []
-            )
-        else:
-            meta[k.strip()] = v
-    return meta, body
+# #409 / #423: build.py used to ship a divergent regex (LF-only, no BOM
+# handling, simpler list parser) which silently dropped frontmatter on
+# Windows-authored files. Unified to the canonical parser in
+# `_frontmatter.py`. Re-exported under the historical name so external
+# consumers (and `tests/test_render_split.py`) keep working.
+from llmwiki._frontmatter import (  # noqa: E402
+    _FRONTMATTER_RE,
+    parse_frontmatter,
+)
 
 
 # ─── discovery ─────────────────────────────────────────────────────────────

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.2.2"
+version = "1.2.4"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_frontmatter_shared.py
+++ b/tests/test_frontmatter_shared.py
@@ -127,3 +127,157 @@ def test_round_trip_simple_case():
     meta, body = parse_frontmatter(text)
     assert meta == {"title": "Round trip", "type": "source"}
     assert body.strip() == "# Body"
+
+
+# ─── #409 / #423: line-ending + BOM handling ─────────────────────────
+
+
+def test_crlf_line_endings_parsed_identically_to_lf():
+    """Windows-authored files (CRLF) must parse like LF input (#409)."""
+    text = '---\r\ntitle: "Win"\r\ntype: source\r\n---\r\nbody\r\n'
+    meta, body = parse_frontmatter(text)
+    assert meta == {"title": "Win", "type": "source"}
+    assert body == "body\r\n"
+
+
+def test_cr_only_line_endings_parsed():
+    """Old-Mac CR-only line endings (#409 edge case)."""
+    text = '---\rtitle: "OldMac"\r---\rbody\r'
+    meta, body = parse_frontmatter(text)
+    assert meta == {"title": "OldMac"}
+    assert body == "body\r"
+
+
+def test_mixed_crlf_and_lf_in_same_file():
+    """Mixed line endings (e.g. file copied across platforms) (#409)."""
+    text = '---\r\ntitle: A\nkey: B\r\n---\nbody\n'
+    meta, _ = parse_frontmatter(text)
+    assert meta == {"title": "A", "key": "B"}
+
+
+def test_utf8_bom_stripped(tmp_path):
+    """UTF-8 BOM at start (Notepad default) (#423)."""
+    text = '\ufeff---\ntitle: "BOM"\n---\nbody\n'
+    meta, body = parse_frontmatter(text)
+    assert meta == {"title": "BOM"}
+    assert body == "body\n"
+
+
+def test_bom_plus_crlf_combination():
+    """BOM + CRLF (Notepad on Windows is the worst case) (#423)."""
+    text = '\ufeff---\r\ntitle: "WinBOM"\r\n---\r\nbody\r\n'
+    meta, _ = parse_frontmatter(text)
+    assert meta == {"title": "WinBOM"}
+
+
+def test_bom_inside_file_preserved():
+    """A BOM inside the body is content, not metadata (#423)."""
+    text = '---\ntitle: X\n---\nbody \ufeff middle\n'
+    _, body = parse_frontmatter(text)
+    assert "\ufeff" in body
+
+
+def test_bom_only_no_frontmatter():
+    """File starts with BOM but has no frontmatter — body is the rest (#423)."""
+    text = '\ufeff# Heading\n\nBody.\n'
+    meta, body = parse_frontmatter(text)
+    assert meta == {}
+    # BOM is stripped at the parser entry, so body comes back without it
+    assert body == "# Heading\n\nBody.\n"
+
+
+def test_legacy_or_none_wrapper_strips_bom():
+    """parse_frontmatter_or_none must also strip BOM (#423)."""
+    text = '\ufeff---\ntitle: X\n---\nbody\n'
+    fm, body = parse_frontmatter_or_none(text)
+    assert fm is not None
+    assert "title: X" in fm
+    assert body == "body\n"
+
+
+# ─── #409 — build.py must use the same parser ────────────────────────
+
+
+def test_build_py_parse_frontmatter_is_canonical():
+    """`build.py:parse_frontmatter` must be the canonical one — not a
+    divergent copy. Regression for #409: divergent regexes silently
+    dropped CRLF input on the build-side parser only.
+    """
+    from llmwiki.build import parse_frontmatter as build_pf
+    from llmwiki._frontmatter import parse_frontmatter as canonical_pf
+    assert build_pf is canonical_pf
+
+
+def test_build_py_parses_crlf_now():
+    """Regression for #409: build.py used to fail on CRLF and silently
+    return ``({}, text)`` for any Windows-authored ``wiki/projects/*.md``.
+    """
+    from llmwiki.build import parse_frontmatter
+    text = '---\r\nproject: my-proj\r\ntopics: [a, b]\r\n---\r\nbody\r\n'
+    meta, _ = parse_frontmatter(text)
+    assert meta["project"] == "my-proj"
+    assert meta["topics"] == ["a", "b"]
+
+
+def test_build_py_parses_bom_now():
+    """Regression for #423: BOM-prefixed files used to silently lose
+    frontmatter on the build path, leaving project pages headerless.
+    """
+    from llmwiki.build import parse_frontmatter
+    text = '\ufeff---\ntitle: "BOM Project"\n---\nbody\n'
+    meta, _ = parse_frontmatter(text)
+    assert meta == {"title": "BOM Project"}
+
+
+def test_build_py_parses_inline_list_with_quoted_values():
+    """Regression for #409: build.py's old list parser didn't unquote
+    list elements, so `topics: ["a, b", c]` came back as
+    `['"a', 'b"', 'c']` instead of `["a, b", "c"]`. Note: even the new
+    canonical parser splits naively on ',' so quoted commas become
+    distinct elements — this test pins current behaviour rather than
+    aspirational quoted-comma support.
+    """
+    from llmwiki.build import parse_frontmatter
+    text = '---\ntopics: ["foo", "bar"]\n---\n'
+    meta, _ = parse_frontmatter(text)
+    assert meta["topics"] == ["foo", "bar"]
+
+
+# ─── #409 / #423: end-to-end via discover_sources ────────────────────
+
+
+def test_discover_sources_reads_crlf_file(tmp_path, monkeypatch):
+    """E2E: a Windows-authored file under raw/ must surface its
+    frontmatter through ``discover_sources`` (#409 acceptance)."""
+    from llmwiki import build as build_mod
+
+    raw = tmp_path / "raw"
+    sessions = raw / "sessions" / "my-proj"
+    sessions.mkdir(parents=True)
+    text = '---\r\ntitle: "CRLF"\r\nproject: my-proj\r\nslug: crlf-test\r\n---\r\n# CRLF body\r\n'
+    (sessions / "2026-04-26T10-00-my-proj-crlf.md").write_bytes(text.encode("utf-8"))
+
+    found = build_mod.discover_sources(sessions)
+    assert len(found) == 1
+    _, meta, body = found[0]
+    assert meta.get("title") == "CRLF"
+    assert meta["project"] == "my-proj"
+    assert meta["slug"] == "crlf-test"
+
+
+def test_discover_sources_reads_bom_file(tmp_path):
+    """E2E: a Notepad-authored (BOM + CRLF) file surfaces its frontmatter
+    instead of falling back to the parent dir name (#423 acceptance).
+    """
+    from llmwiki import build as build_mod
+
+    sessions = tmp_path / "raw" / "sessions" / "bom-proj"
+    sessions.mkdir(parents=True)
+    text = '\ufeff---\r\ntitle: "Notepad"\r\nproject: bom-proj\r\n---\r\nbody\r\n'
+    (sessions / "2026-04-26T10-00-bom-proj-x.md").write_bytes(text.encode("utf-8"))
+
+    found = build_mod.discover_sources(sessions)
+    assert len(found) == 1
+    _, meta, _ = found[0]
+    assert meta.get("title") == "Notepad"
+    assert meta["project"] == "bom-proj"


### PR DESCRIPTION
## Summary

Closes #409 and #423.

Two divergent frontmatter parsers in `build.py` and `_frontmatter.py` were silently dropping frontmatter on Windows-authored input — CRLF line endings + UTF-8 BOM both made the build-side regex fail. Unified to the canonical parser; the regex now accepts LF/CRLF/CR; BOM is stripped at every public entry point.

A Notepad-saved \`wiki/projects/<slug>.md\` used to render headerless on the build path while every other consumer (`tags.py`, `synth/pipeline.py`, `lint/`) saw the populated dict.

## Changes

- **Delete duplicate parser** in \`build.py\` (~24 lines).
- **Re-export** \`parse_frontmatter\` and \`_FRONTMATTER_RE\` from \`_frontmatter.py\` so existing callers keep working.
- **Line-ending agnostic regex** — \`\r\n\`, \`\r\`, \`\n\` accepted after each fence.
- **\`_strip_bom()\`** runs at the entry of \`parse_frontmatter\`, \`parse_frontmatter_dict\`, \`parse_frontmatter_or_none\`.

## Test plan

- [x] \`pytest tests/test_frontmatter_shared.py\` — 30 → 43 cases (covers CRLF, CR-only, mixed line-endings, UTF-8 BOM, BOM+CRLF, BOM-without-frontmatter, legacy \`_or_none\` wrapper, end-to-end \`discover_sources\` for Windows-authored files)
- [x] \`pytest tests/\` (excluding e2e) — 2120 → 2134 passing
- [x] \`tests/test_render_split.py::test_parse_frontmatter_still_exported\` still passes (back-compat contract)

## Edge case checklist (from #409 + #423)

- [x] Empty frontmatter \`---\n\n---\n\`
- [x] Frontmatter with only a closing \`---\` (no content between)
- [x] CRLF newlines on every field type
- [x] Mixed CRLF + LF in the same file
- [x] CR-only line endings (old Mac)
- [x] Leading BOM \`\ufeff---\n...\`
- [x] BOM + CRLF combination
- [x] BOM inside the body (preserved as content)
- [x] BOM with no frontmatter (gracefully passes through)
- [x] Inline list with quoted entries: \`topics: ["foo", "bar"]\`

## Release cadence

Patch (\`1.2.2\` → \`1.2.4\`). Pure correctness fix — no API change, no new behaviour beyond formerly-dropped frontmatter now landing.