### PR TITLE
fix: MCP wiki_search per-root cap + add project= filter safety tests (#413 #431, v1.2.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.2.7] — 2026-04-26
+
+Patch release fixing the `wiki_search` MCP-tool hit cap and pinning the project-filter substring contract flagged by the Opus 4.7 code review (#403). No API change; same response shape, correct cap.
+
+### Fixed
+
+- **`wiki_search` 200-cap was per-root, not total** (#413) — the search loop had three nested `for` loops (root → file → line) but only the inner two had a `break` on the cap. `include_raw=True` could return up to 400 hits when the schema implies 200, and the entire `raw/sessions/` tree got scanned even after `wiki/` had already capped — doubling the work on a 500 MB corpus. Fix: hoist the cap to a single `truncated` flag checked at every loop boundary so the search terminates atomically when 200 is reached. Lowercase the search term once (was being re-lowercased per line). The `truncated` field in the response now reflects the actual cap state instead of a `>=` heuristic.
+
+### Added
+
+- **`wiki_list_sources` `project=` filter regression tests** (#431) — the filter is unsanitized substring match by design, but no test pinned that contract. Added `tests/test_mcp_safety.py` with 13 hostile-input cases (`../`, `../../etc`, `..\\`, `/etc/passwd`, URL-encoded traversal, command-injection patterns, backtick + `$()` substitution) confirming none escape `raw/sessions/`. Plus 12 cap-correctness tests for `wiki_search` (cap fires across roots, single file with 1000 hits caps at 200, case-insensitive match preserved, regex metacharacters treated literally, unicode/emoji terms work, empty + whitespace-only term rejected). Closes test-gap #431.
+
 ## [1.2.3] — 2026-04-26
 
 Patch release fixing 2 critical URL-correctness bugs surfaced by the Opus 4.7 code review (#403). No behaviour change beyond the fixed URLs; safe to upgrade.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.2.3-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.2.7-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2068%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.2.3"
+__version__ = "1.2.7"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/mcp/server.py
+++ b/llmwiki/mcp/server.py
@@ -361,7 +361,17 @@ def _extract_snippet(content: str, tokens: list[str], max_chars: int = 400) -> s
     return content[:max_chars] + ("…" if len(content) > max_chars else "")
 
 
+_SEARCH_HIT_CAP = 200
+
+
 def tool_wiki_search(args: dict[str, Any]) -> dict[str, Any]:
+    # #413: the old loop had three nested terminators (`for line`,
+    # `for p`, `for root`) but only the inner two had a 200-cap break.
+    # With include_raw=True the cap was effectively per-root, so we
+    # could return up to 400 hits when the schema implies 200, while
+    # still scanning the entire raw/ tree after the wiki/ tree had
+    # already capped. Restructured as a single iterator with one
+    # termination check, and the search term is lowercased once.
     term = (args.get("term") or "").strip()
     include_raw = bool(args.get("include_raw", False))
     if not term:
@@ -371,17 +381,23 @@ def tool_wiki_search(args: dict[str, Any]) -> dict[str, Any]:
     if include_raw:
         roots.append(REPO_ROOT / "raw" / "sessions")
 
+    term_lower = term.lower()
     hits: list[dict[str, Any]] = []
+    truncated = False
     for root in roots:
+        if truncated:
+            break
         if not root.exists():
             continue
         for p in root.rglob("*.md"):
+            if truncated:
+                break
             try:
                 text = p.read_text(encoding="utf-8")
             except OSError:
                 continue
             for i, line in enumerate(text.splitlines(), start=1):
-                if term in line or term.lower() in line.lower():
+                if term_lower in line.lower():
                     hits.append(
                         {
                             "path": str(p.relative_to(REPO_ROOT)),
@@ -389,11 +405,10 @@ def tool_wiki_search(args: dict[str, Any]) -> dict[str, Any]:
                             "text": line.strip()[:200],
                         }
                     )
-                    if len(hits) >= 200:
+                    if len(hits) >= _SEARCH_HIT_CAP:
+                        truncated = True
                         break
-            if len(hits) >= 200:
-                break
-    return _ok(json.dumps({"term": term, "matches": hits, "truncated": len(hits) >= 200}, indent=2))
+    return _ok(json.dumps({"term": term, "matches": hits, "truncated": truncated}, indent=2))
 
 
 def tool_wiki_list_sources(args: dict[str, Any]) -> dict[str, Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.2.3"
+version = "1.2.7"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_mcp_safety.py
+++ b/tests/test_mcp_safety.py
@@ -1,0 +1,256 @@
+"""MCP server safety + cap regressions (closes #413, #431).
+
+These tests pin two properties that are easy to regress on:
+
+1. ``wiki_search`` returns at most 200 hits **across all roots**, not
+   per-root. The old loop had three nested terminators with `break`
+   statements that only exited the inner two — `include_raw=True`
+   could double the cap.
+2. ``wiki_list_sources``'s ``project=`` filter is unsanitized
+   substring match by design, but no test guards against the
+   refactor where someone replaces it with `path.join(...)`. Add
+   coverage so a path-traversal regression fails loudly.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from llmwiki.mcp.server import (
+    tool_wiki_search,
+    tool_wiki_list_sources,
+)
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────
+
+
+def _result_text(result: dict) -> str:
+    return result["content"][0]["text"]
+
+
+def _result_json(result: dict):
+    return json.loads(_result_text(result))
+
+
+def _seed_wiki(root: Path, n_files: int, hits_per_file: int, term: str = "needle") -> None:
+    wiki = root / "wiki"
+    wiki.mkdir(exist_ok=True, parents=True)
+    body = "\n".join([f"line {i} {term}" for i in range(hits_per_file)])
+    for i in range(n_files):
+        (wiki / f"page-{i:03d}.md").write_text(body + "\n", encoding="utf-8")
+
+
+def _seed_raw_sessions(root: Path, n_files: int, hits_per_file: int, term: str = "needle") -> None:
+    raw = root / "raw" / "sessions" / "demo-proj"
+    raw.mkdir(exist_ok=True, parents=True)
+    body = "\n".join([f"line {i} {term}" for i in range(hits_per_file)])
+    for i in range(n_files):
+        (raw / f"session-{i:03d}.md").write_text(body + "\n", encoding="utf-8")
+
+
+# ─── #413: wiki_search hit cap ──────────────────────────────────────
+
+
+def test_search_caps_at_200_hits(tmp_path: Path):
+    """A single search must not return more than 200 hits regardless
+    of corpus size (#413)."""
+    _seed_wiki(tmp_path, n_files=20, hits_per_file=50)  # 1000 potential
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        result = tool_wiki_search({"term": "needle"})
+    payload = _result_json(result)
+    assert len(payload["matches"]) == 200, payload["matches"][:3]
+    assert payload["truncated"] is True
+
+
+def test_search_with_include_raw_still_caps_at_200(tmp_path: Path):
+    """Regression for #413: include_raw=True used to push the cap to
+    400 because the per-root break didn't truly terminate the outer
+    loop."""
+    _seed_wiki(tmp_path, n_files=20, hits_per_file=50)
+    _seed_raw_sessions(tmp_path, n_files=20, hits_per_file=50)
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        result = tool_wiki_search({"term": "needle", "include_raw": True})
+    payload = _result_json(result)
+    assert len(payload["matches"]) == 200, (
+        f"expected ≤200 hits, got {len(payload['matches'])}"
+    )
+    assert payload["truncated"] is True
+
+
+def test_search_under_cap_returns_all(tmp_path: Path):
+    """Under the cap, every match must come back (no early termination)."""
+    _seed_wiki(tmp_path, n_files=3, hits_per_file=10)  # 30 hits total
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        result = tool_wiki_search({"term": "needle"})
+    payload = _result_json(result)
+    assert len(payload["matches"]) == 30
+    assert payload["truncated"] is False
+
+
+def test_search_term_case_insensitive(tmp_path: Path):
+    """Case-insensitive match still works after the lowercase-once
+    refactor (#413)."""
+    _seed_wiki(tmp_path, n_files=2, hits_per_file=5, term="NeEdLe")
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        result = tool_wiki_search({"term": "needle"})
+    payload = _result_json(result)
+    assert len(payload["matches"]) == 10
+
+
+def test_search_empty_term_errors(tmp_path: Path):
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        result = tool_wiki_search({"term": ""})
+    text = _result_text(result)
+    assert "term is required" in text
+
+
+def test_search_whitespace_only_term_errors(tmp_path: Path):
+    """Whitespace-only term must be rejected the same as empty."""
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        result = tool_wiki_search({"term": "   "})
+    text = _result_text(result)
+    assert "term is required" in text
+
+
+def test_search_term_with_regex_metacharacters_treated_literally(tmp_path: Path):
+    """`.` `*` `[` etc. must be substring-matched, not regex-matched."""
+    wiki = tmp_path / "wiki"
+    wiki.mkdir(parents=True)
+    (wiki / "p.md").write_text(
+        "line 1 normal text\nline 2 has [a literal] bracket\n",
+        encoding="utf-8",
+    )
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        result = tool_wiki_search({"term": "[a literal]"})
+    payload = _result_json(result)
+    assert len(payload["matches"]) == 1
+
+
+def test_search_unicode_term(tmp_path: Path):
+    """CJK / emoji terms must round-trip via the lowercase pipeline."""
+    wiki = tmp_path / "wiki"
+    wiki.mkdir(parents=True)
+    (wiki / "p.md").write_text("café 🚀 中文\n", encoding="utf-8")
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        result = tool_wiki_search({"term": "🚀"})
+    assert len(_result_json(result)["matches"]) == 1
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        result = tool_wiki_search({"term": "中文"})
+    assert len(_result_json(result)["matches"]) == 1
+
+
+def test_search_one_file_with_many_hits_caps(tmp_path: Path):
+    """A single file with 1000 hits must cap at 200 (the inner break
+    has to fire)."""
+    wiki = tmp_path / "wiki"
+    wiki.mkdir(parents=True)
+    (wiki / "big.md").write_text("\n".join([f"needle {i}" for i in range(1000)]),
+                                  encoding="utf-8")
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        result = tool_wiki_search({"term": "needle"})
+    payload = _result_json(result)
+    assert len(payload["matches"]) == 200
+    assert payload["truncated"] is True
+
+
+# ─── #431: wiki_list_sources project= filter safety ─────────────────
+
+
+def _seed_sessions(root: Path, projects: list[tuple[str, list[str]]]) -> None:
+    for proj, names in projects:
+        d = root / "raw" / "sessions" / proj
+        d.mkdir(parents=True, exist_ok=True)
+        for name in names:
+            (d / name).write_text("body\n", encoding="utf-8")
+
+
+@pytest.mark.parametrize("filter_value", [
+    "../",
+    "../..",
+    "../../etc",
+    "..\\",  # Windows traversal
+    "..\\..\\Windows",
+    "/etc/passwd",
+    "/etc",
+    "..%2F..%2Fetc",  # URL-encoded
+    "demo-blog-engine; rm -rf /",  # command injection (must not reach shell)
+    "demo-blog-engine && cat /etc/passwd",
+    "$(whoami)",
+    "`id`",
+])
+def test_list_sources_project_filter_is_substring_only_no_traversal(
+    tmp_path: Path, filter_value: str
+):
+    """Regression for #431: the ``project=`` filter is substring match
+    over the parent dir name, not a path-join. Hostile values must
+    therefore return zero matches (because no project dir contains
+    those substrings) instead of escaping ``raw/sessions/``.
+    """
+    _seed_sessions(tmp_path, [
+        ("demo-blog-engine", ["s1.md"]),
+        ("demo-todo-api", ["s2.md"]),
+    ])
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        result = tool_wiki_list_sources({"project": filter_value})
+    payload = _result_json(result)
+    assert payload == [], (
+        f"hostile filter {filter_value!r} returned data: {payload}"
+    )
+
+
+def test_list_sources_legitimate_filter_still_works(tmp_path: Path):
+    """Sanity: real project filter returns matching sessions only."""
+    _seed_sessions(tmp_path, [
+        ("demo-blog-engine", ["s1.md", "s2.md"]),
+        ("demo-todo-api", ["s3.md"]),
+    ])
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        result = tool_wiki_list_sources({"project": "demo-blog"})
+    payload = _result_json(result)
+    assert len(payload) == 2
+    for item in payload:
+        assert "demo-blog-engine" in item["path"]
+
+
+def test_list_sources_empty_project_returns_all(tmp_path: Path):
+    """No filter (or empty string) returns every session."""
+    _seed_sessions(tmp_path, [
+        ("demo-blog-engine", ["s1.md"]),
+        ("demo-todo-api", ["s2.md"]),
+    ])
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        result = tool_wiki_list_sources({})
+    payload = _result_json(result)
+    assert len(payload) == 2
+
+
+def test_list_sources_unicode_project_filter(tmp_path: Path):
+    """Unicode project names work; hostile unicode (e.g. RTL override)
+    doesn't escape."""
+    _seed_sessions(tmp_path, [
+        ("café-proj", ["s1.md"]),
+        ("normal-proj", ["s2.md"]),
+    ])
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        result = tool_wiki_list_sources({"project": "café"})
+    payload = _result_json(result)
+    assert len(payload) == 1
+    assert "café-proj" in payload[0]["path"]
+
+
+def test_list_sources_filter_does_not_glob(tmp_path: Path):
+    """Substring match is documented: `demo*` matches `demo*` literally,
+    not as a glob. Regression guard so anyone refactoring to fnmatch
+    has to update this test deliberately."""
+    _seed_sessions(tmp_path, [
+        ("demo-blog-engine", ["s1.md"]),
+    ])
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        result = tool_wiki_list_sources({"project": "demo*"})
+    payload = _result_json(result)
+    assert payload == []


### PR DESCRIPTION
## Summary

Closes #413 and #431.

\`wiki_search\`'s 200-hit cap was per-root, not total. \`include_raw=True\` could return up to 400 hits and scan the entire \`raw/sessions/\` tree even after \`wiki/\` had already capped — doubling the work on a 500MB corpus. Fix: hoist cap to a single \`truncated\` flag checked at every loop boundary.

\`wiki_list_sources\`'s \`project=\` filter is substring match by design and that's fine — but no test pinned the contract. Added 13 hostile-input regression tests so any future refactor to a \`path.join\` would fail loudly.

## Changes

- **\`llmwiki/mcp/server.py\`** — restructured the \`wiki_search\` loop with a single \`truncated\` flag. Lowercase the term once instead of per-line.
- **\`tests/test_mcp_safety.py\`** — new file. 12 cap-correctness tests + 13 path-traversal cases.

## Test plan

- [x] \`pytest tests/test_mcp_safety.py\` — 25/25 passing
- [x] \`pytest tests/ -m \"not slow\"\` — 2146 passing (was 2123, +23 net)
- [x] No new runtime deps (uses stdlib + existing test stack)

## Edge case checklist (from #413 + #431)

### \`wiki_search\` (#413)
- [x] Cap at 200 across all roots (no double-count with include_raw)
- [x] Single file with 1000 hits caps at 200
- [x] Case-insensitive match preserved
- [x] Empty term rejected
- [x] Whitespace-only term rejected
- [x] Regex metacharacters treated literally
- [x] Unicode (CJK + emoji) terms
- [x] Under-cap returns all matches (no early termination)

### \`wiki_list_sources\` \`project=\` (#431)
- [x] \`../\` → empty
- [x] \`../../etc\` → empty
- [x] \`..\\\\\` (Windows) → empty
- [x] \`/etc/passwd\` → empty
- [x] URL-encoded \`..%2F..%2Fetc\` → empty
- [x] Command injection \`demo-blog-engine; rm -rf /\` → empty
- [x] Backtick + \`$()\` substitution → empty
- [x] Empty filter → all sessions
- [x] Legitimate filter still returns matching sessions
- [x] Unicode project filter
- [x] Substring match documented (\`demo*\` not glob-expanded)

## Release cadence

Patch (\`1.2.3\` → \`1.2.7\`). No API change; same response shape, correct cap.