### PR TITLE
fix: ToolsConsistency TypeError on list-typed tools_used (#410, v1.2.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.2.11] — 2026-04-26
+
+Patch release fixing the `ToolsConsistency` lint rule's silent `TypeError` on list-typed `tools_used` flagged by the Opus 4.7 code review (#403). Pure correctness fix — no API change; the rule now actually runs on every page instead of aborting after the first list-typed value.
+
+### Fixed
+
+- **`ToolsConsistency` raised `TypeError` on list-typed `tools_used`** (#410) — `lint/rules.py:754` did `re.search(_TOOLS_USED_RE, tools_used_raw)` directly. Frontmatter parsed by `_frontmatter.py`'s inline-list path returns `tools_used` as a real Python `list`, not a string, so `re.search(regex, list)` raised `TypeError` and silently aborted the whole rule (16 → 15 effective rules). One source page with parsed-list `tools_used` was enough to take the rule out. Fix: new `_normalise_tools_used(value)` and `_normalise_tool_counts_keys(value)` helpers coerce list / str / dict / None / number / bool into a consistent `set[str]` before the comparison runs. Adds 7 regression tests covering the type matrix (list, quoted-list, empty list, str, missing, dict tool_counts, hostile types).
+
 ## [1.2.7] — 2026-04-26
 
 Patch release fixing the `wiki_search` MCP-tool hit cap and pinning the project-filter substring contract flagged by the Opus 4.7 code review (#403). No API change; same response shape, correct cap.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.2.7-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.2.11-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2068%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.2.7"
+__version__ = "1.2.11"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/lint/rules.py
+++ b/llmwiki/lint/rules.py
@@ -731,6 +731,51 @@ _TOOLS_USED_RE = re.compile(r"\[([^\]]*)\]")
 _TOOL_COUNTS_KEYS_RE = re.compile(r'"([A-Za-z_]+)"\s*:')
 
 
+def _normalise_tools_used(value: Any) -> set[str]:
+    """Coerce a frontmatter ``tools_used`` value into a set of tool names.
+
+    Frontmatter parsers return either a Python ``list`` (when the value
+    is parsed as ``[a, b]``) or a raw ``str`` (legacy paths or
+    string-typed coercion). Older code did
+    ``re.search(_TOOLS_USED_RE, value)`` directly — which raises
+    ``TypeError`` on a list and silently aborted the whole lint rule
+    (#410). This helper normalises both shapes plus the other types
+    that have appeared in real frontmatter (number, bool, dict, None).
+    Anything that isn't sensibly stringifiable returns an empty set.
+    """
+    if value is None or value == "":
+        return set()
+    if isinstance(value, list):
+        return {str(x).strip().strip('"\'') for x in value if str(x).strip()}
+    if isinstance(value, str):
+        m = _TOOLS_USED_RE.search(value)
+        if not m:
+            return set()
+        return {
+            t.strip().strip('"\'')
+            for t in m.group(1).split(",")
+            if t.strip()
+        }
+    # Numbers, bools, dicts — not a tools list.
+    return set()
+
+
+def _normalise_tool_counts_keys(value: Any) -> set[str]:
+    """Coerce a frontmatter ``tool_counts`` value into the set of keys.
+
+    Symmetric to :func:`_normalise_tools_used`. Frontmatter often ships
+    ``tool_counts`` as the raw inline JSON-looking string the converter
+    wrote, but some pipelines (or future fixes) may return a real dict.
+    """
+    if value is None or value == "":
+        return set()
+    if isinstance(value, dict):
+        return {str(k) for k in value.keys()}
+    if isinstance(value, str):
+        return set(_TOOL_COUNTS_KEYS_RE.findall(value))
+    return set()
+
+
 @register
 class ToolsConsistency(LintRule):
     """Source pages: ``tools_used`` and ``tool_counts.keys()`` must agree.
@@ -751,21 +796,14 @@ class ToolsConsistency(LintRule):
             meta = page["meta"]
             if meta.get("type") != "source":
                 continue
-            tools_used_raw = meta.get("tools_used", "")
-            tool_counts_raw = meta.get("tool_counts", "")
-            if not tools_used_raw or not tool_counts_raw:
+            # #410: tools_used can be list (post-parser), str (legacy),
+            # or None — _normalise handles all three without a
+            # TypeError on `re.search(regex, list)`.
+            tools_used = _normalise_tools_used(meta.get("tools_used"))
+            tool_counts_keys = _normalise_tool_counts_keys(meta.get("tool_counts"))
+            if not tools_used or not tool_counts_keys:
                 # One side missing — that's a different lint concern, skip.
                 continue
-
-            m = _TOOLS_USED_RE.search(tools_used_raw)
-            if not m:
-                continue
-            tools_used = {
-                t.strip().strip('"\'')
-                for t in m.group(1).split(",")
-                if t.strip()
-            }
-            tool_counts_keys = set(_TOOL_COUNTS_KEYS_RE.findall(tool_counts_raw))
 
             only_used = tools_used - tool_counts_keys
             only_counted = tool_counts_keys - tools_used

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.2.7"
+version = "1.2.11"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_lint_rules.py
+++ b/tests/test_lint_rules.py
@@ -598,3 +598,108 @@ def test_tools_consistency_flags_extra_tool_count_key():
     )
     issues = run_all({"sources/s.md": page}, selected=["tools_consistency"])
     assert any("['Bash']" in i["message"] for i in issues)
+
+
+# ─── #410 — tools_used type-coercion (regression for the TypeError) ──
+
+
+def test_tools_consistency_handles_list_tools_used():
+    """Regression for #410: when frontmatter is parsed by `_frontmatter.py`'s
+    inline-list path, `tools_used` comes back as a real Python list, not a
+    string. Old code did `re.search(regex, list)` and raised TypeError —
+    silently aborting the whole rule."""
+    body = "# s"
+    page = _mk_page({}, body)
+    page["meta"] = {
+        "title": "s", "type": "source",
+        "tools_used": ["Read", "Write", "Grep"],  # list, not str
+        "tool_counts": '{"Read": 1, "Write": 2}',
+    }
+    issues = run_all({"sources/s.md": page}, selected=["tools_consistency"])
+    assert any("['Grep']" in i["message"] for i in issues), (
+        f"list-typed tools_used didn't surface the missing-key warning: {issues}"
+    )
+
+
+def test_tools_consistency_handles_quoted_list_elements():
+    """tools_used: [\"Read\", \"Write\"] — quoted elements get unquoted."""
+    body = "# s"
+    page = _mk_page({}, body)
+    page["meta"] = {
+        "title": "s", "type": "source",
+        "tools_used": ['"Read"', '"Write"'],
+        "tool_counts": '{"Read": 1, "Write": 2}',
+    }
+    issues = run_all({"sources/s.md": page}, selected=["tools_consistency"])
+    assert issues == [], (
+        f"quoted list elements caused false positives: {issues}"
+    )
+
+
+def test_tools_consistency_handles_empty_list():
+    """tools_used: [] should be treated like tools_used missing."""
+    body = "# s"
+    page = _mk_page({}, body)
+    page["meta"] = {
+        "title": "s", "type": "source",
+        "tools_used": [],
+        "tool_counts": '{"Read": 1}',
+    }
+    issues = run_all({"sources/s.md": page}, selected=["tools_consistency"])
+    assert issues == []
+
+
+def test_tools_consistency_handles_dict_tool_counts():
+    """tool_counts can be a real dict (after JSON parsing) — must work."""
+    body = "# s"
+    page = _mk_page({}, body)
+    page["meta"] = {
+        "title": "s", "type": "source",
+        "tools_used": ["Read", "Write"],
+        "tool_counts": {"Read": 1, "Write": 2, "Bash": 3},
+    }
+    issues = run_all({"sources/s.md": page}, selected=["tools_consistency"])
+    assert any("['Bash']" in i["message"] for i in issues)
+
+
+def test_tools_consistency_skips_unsupported_types():
+    """Numbers, bools, dicts in tools_used → silently skip (not crash)."""
+    for hostile in [42, True, {"unexpected": "shape"}]:
+        page = _mk_page({}, "# s")
+        page["meta"] = {
+            "title": "s", "type": "source",
+            "tools_used": hostile,
+            "tool_counts": '{"Read": 1}',
+        }
+        # Must not raise.
+        issues = run_all({"sources/s.md": page}, selected=["tools_consistency"])
+        # And must not flag — we have no idea what to compare against.
+        assert issues == [], (
+            f"unsupported tools_used={hostile!r} produced spurious issue: {issues}"
+        )
+
+
+def test_tools_consistency_unit_normalise_tools_used():
+    """Direct unit test for the helper — covers the type matrix in one shot."""
+    from llmwiki.lint.rules import _normalise_tools_used
+    assert _normalise_tools_used(None) == set()
+    assert _normalise_tools_used("") == set()
+    assert _normalise_tools_used([]) == set()
+    assert _normalise_tools_used(["Read", "Write"]) == {"Read", "Write"}
+    assert _normalise_tools_used(['"Read"', "'Write'"]) == {"Read", "Write"}
+    assert _normalise_tools_used("[Read, Write]") == {"Read", "Write"}
+    assert _normalise_tools_used('["Read", "Write"]') == {"Read", "Write"}
+    assert _normalise_tools_used("not a list") == set()
+    assert _normalise_tools_used(42) == set()
+    assert _normalise_tools_used(True) == set()
+    assert _normalise_tools_used({"unexpected": "shape"}) == set()
+
+
+def test_tools_consistency_unit_normalise_tool_counts_keys():
+    from llmwiki.lint.rules import _normalise_tool_counts_keys
+    assert _normalise_tool_counts_keys(None) == set()
+    assert _normalise_tool_counts_keys("") == set()
+    assert _normalise_tool_counts_keys({}) == set()
+    assert _normalise_tool_counts_keys({"Read": 1}) == {"Read"}
+    assert _normalise_tool_counts_keys('{"Read": 1, "Write": 2}') == {"Read", "Write"}
+    assert _normalise_tool_counts_keys(42) == set()


### PR DESCRIPTION
## Summary

Closes #410.

\`ToolsConsistency.run\` did \`re.search(_TOOLS_USED_RE, tools_used_raw)\`. Frontmatter parsed by \`_frontmatter.py\`'s inline-list path returns \`tools_used\` as a real Python list, not a string. \`re.search(regex, list)\` raises \`TypeError\` → the whole rule aborts silently after the first list-typed value (16 → 15 effective rules). One source page is enough to take it out.

## Changes

- New \`_normalise_tools_used(value) -> set[str]\` coerces list / str / None / number / bool / dict to a consistent set.
- New \`_normalise_tool_counts_keys(value) -> set[str]\` does the same for \`tool_counts\` (str-with-quoted-keys vs real dict).
- \`ToolsConsistency.run\` now uses both helpers.

## Test plan

- [x] \`pytest tests/test_lint_rules.py\` — 52 → 59 passing
- [x] \`pytest tests/ -m \"not slow\"\` — 2146 → 2153 passing
- [x] Existing 3 string-input tests still pass
- [x] New 7 list-input tests cover the regression matrix

## Edge case checklist (from #410)

- [x] \`tools_used\` missing entirely → no crash, no spurious flag
- [x] \`tools_used: []\` (empty list) → treated like missing
- [x] \`tools_used: [Read, Write]\` (parsed list of bare tokens)
- [x] \`tools_used: [\"Read\", \"Write\"]\` (parsed list of quoted strings)
- [x] \`tools_used: \"[Read, Write]\"\` (string form, legacy path)
- [x] \`tools_used: 42\` / \`True\` / \`{}\` → silently skipped, no crash
- [x] \`tool_counts\` as real dict → handled
- [x] Direct unit tests for both helpers covering full type matrix

## Release cadence

Patch (\`1.2.7\` → \`1.2.11\`). Pure correctness fix; the rule now actually runs on every page instead of aborting after the first list-typed value.