### PR TITLE
fix: build is read-only on wiki/projects/ by default — stub seeding opt-in (#414, v1.2.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.2.13] — 2026-04-26
+
+Patch release fixing the `build` CI-surprise commit issue flagged by the Opus 4.7 code review (#403). `llmwiki build` is now read-only on `wiki/` by default — stub seeding moves to opt-in.
+
+### Fixed
+
+- **`build` mutated `wiki/projects/` (CI surprise)** (#414) — `build_site` is documented as "regenerate the static HTML site" and was supposed to be read-only on `wiki/`. As a side effect of #378, `ensure_project_stubs` was wired into the build path and wrote `wiki/projects/<slug>.md` for any newly-discovered project. Users running `llmwiki build` from CI on a curated checkout discovered surprise files in their working tree (and committed-by-CI changes if the workflow auto-pushed). Fix: `build_site()` now takes `seed_project_stubs: bool = False`; the `build` CLI subcommand exposes `--seed-project-stubs` for explicit opt-in. `cmd_sync` (which the user has already opted into mutation for) passes `seed_project_stubs=True` so routine `sync` keeps seeding. Default `build` is now pure. Adds 4 regression tests covering the read-only default, the explicit flag, hand-authored stub preservation, and the CLI flag round-trip.
+
 ## [1.2.8] — 2026-04-26
 
 Patch release unifying the frontmatter parsers and fixing two correctness bugs surfaced by the Opus 4.7 code review (#403). Windows-authored files (CRLF, BOM-prefixed) now parse identically to LF input. No user-visible behaviour change beyond formerly-dropped frontmatter now landing.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.2.8-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.2.13-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2068%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.2.8"
+__version__ = "1.2.13"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/build.py
+++ b/llmwiki/build.py
@@ -1889,6 +1889,7 @@ def build_site(
     synthesize: bool = False,
     claude_path: str = "/usr/local/bin/claude",
     search_mode: str = "auto",
+    seed_project_stubs: bool = False,
 ) -> int:
     if not RAW_SESSIONS.exists():
         print(
@@ -1906,11 +1907,16 @@ def build_site(
     groups = group_by_project(sources)
     print(f"  grouped into {len(groups)} projects")
 
-    # I-12 (issues-commands.md): auto-seed wiki/projects/<slug>.md stubs
-    # so real projects get the same hero surface area as demo projects.
-    stubs_written = ensure_project_stubs(groups, PROJECTS_META_DIR)
-    if stubs_written:
-        print(f"  seeded {len(stubs_written)} new wiki/projects/ stubs")
+    # #414: stub-seeding used to be unconditional. `build` is documented
+    # as read-only on `wiki/`, but seeding wrote to `wiki/projects/` —
+    # CI users running `llmwiki build` on a curated checkout discovered
+    # surprise commits in their working tree. Now opt-in: callers that
+    # have already accepted mutation (sync, the new `--seed-project-stubs`
+    # flag) request seeding explicitly; the default `build` is pure.
+    if seed_project_stubs:
+        stubs_written = ensure_project_stubs(groups, PROJECTS_META_DIR)
+        if stubs_written:
+            print(f"  seeded {len(stubs_written)} new wiki/projects/ stubs")
 
     # Reset output dir (clear contents only — the HTTP server may be cwd'd here)
     if out_dir.exists():

--- a/llmwiki/cli.py
+++ b/llmwiki/cli.py
@@ -200,7 +200,9 @@ def cmd_sync(args: argparse.Namespace) -> int:
         if args.auto_build and _should_run_after_sync(schedule.get("build", "on-sync")):
             print("  auto-build: regenerating site/...")
             from llmwiki.build import build_site
-            build_site(out_dir=REPO_ROOT / "site")
+            # #414: sync has explicit user opt-in to mutate wiki/, so it's
+            # the right place to seed project stubs.
+            build_site(out_dir=REPO_ROOT / "site", seed_project_stubs=True)
         if args.auto_lint and _should_run_after_sync(schedule.get("lint", "manual")):
             print("  auto-lint: running wiki lint...")
             from llmwiki.lint import load_pages, run_all, summarize
@@ -261,6 +263,7 @@ def cmd_build(args: argparse.Namespace) -> int:
         synthesize=args.synthesize,
         claude_path=args.claude,
         search_mode=args.search_mode,
+        seed_project_stubs=getattr(args, "seed_project_stubs", False),
     )
 
 
@@ -1045,6 +1048,14 @@ def build_parser() -> argparse.ArgumentParser:
         "--vault", type=Path, default=None,
         help="Vault-overlay mode (#54): build from an existing Obsidian / "
              "Logseq vault. Still writes site output to --out.",
+    )
+    build.add_argument(
+        "--seed-project-stubs", action="store_true", dest="seed_project_stubs",
+        help="(#414) Auto-create wiki/projects/<slug>.md stubs for any "
+             "newly-discovered project that doesn't have a metadata file. "
+             "Off by default — `build` is read-only on wiki/. Use `sync` "
+             "(which already mutates wiki/) for routine seeding, or pass "
+             "this flag to opt in from CI/scripts.",
     )
     build.set_defaults(func=cmd_build)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.2.8"
+version = "1.2.13"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_project_stubs.py
+++ b/tests/test_project_stubs.py
@@ -131,3 +131,102 @@ def test_ensure_project_stubs_empty_groups(tmp_path: Path):
 
     meta_dir = tmp_path / "wiki" / "projects"
     assert ensure_project_stubs({}, meta_dir) == []
+
+
+# ─── #414: build_site is read-only on wiki/projects/ by default ─────
+
+
+def _seed_one_session(tmp_path: Path) -> Path:
+    """Seed a minimal raw/sessions/ corpus + REPO_ROOT layout so
+    build_site has something to walk. Returns the new REPO_ROOT."""
+    repo = tmp_path / "repo"
+    raw = repo / "raw" / "sessions" / "newproj"
+    raw.mkdir(parents=True)
+    (raw / "2026-04-26T10-00-newproj-x.md").write_text(
+        '---\ntitle: "S"\ntype: source\nproject: newproj\n---\n# S\n',
+        encoding="utf-8",
+    )
+    return repo
+
+
+def _patch_build_paths(monkeypatch, repo: Path):
+    """Point build's module-level paths at a tmp REPO_ROOT."""
+    from llmwiki import build as build_mod
+    monkeypatch.setattr(build_mod, "REPO_ROOT", repo)
+    monkeypatch.setattr(build_mod, "RAW_DIR", repo / "raw")
+    monkeypatch.setattr(build_mod, "RAW_SESSIONS", repo / "raw" / "sessions")
+    monkeypatch.setattr(
+        build_mod, "PROJECTS_META_DIR", repo / "wiki" / "projects"
+    )
+    monkeypatch.setattr(build_mod, "DEFAULT_OUT_DIR", repo / "site")
+
+
+def test_build_site_default_does_not_seed_stubs(tmp_path: Path, monkeypatch):
+    """Regression for #414: `build_site` used to unconditionally write
+    `wiki/projects/<slug>.md`. CI runs on curated wiki/ checkouts saw
+    surprise commits in their working tree. New default is read-only.
+    """
+    from llmwiki.build import build_site
+
+    repo = _seed_one_session(tmp_path)
+    projects_dir = repo / "wiki" / "projects"
+    _patch_build_paths(monkeypatch, repo)
+
+    rc = build_site(out_dir=repo / "site")
+    assert rc == 0
+
+    # No stub created; wiki/projects/ is either still missing or empty.
+    if projects_dir.exists():
+        stubs = list(projects_dir.glob("*.md"))
+        assert stubs == [], (
+            f"build_site() seeded {[p.name for p in stubs]} on default — "
+            "regression: should be opt-in via --seed-project-stubs."
+        )
+
+
+def test_build_site_with_flag_seeds_stubs(tmp_path: Path, monkeypatch):
+    """Opt-in path: explicit seed_project_stubs=True still seeds."""
+    from llmwiki.build import build_site
+
+    repo = _seed_one_session(tmp_path)
+    projects_dir = repo / "wiki" / "projects"
+    _patch_build_paths(monkeypatch, repo)
+
+    rc = build_site(out_dir=repo / "site", seed_project_stubs=True)
+    assert rc == 0
+    stub = projects_dir / "newproj.md"
+    assert stub.is_file(), (
+        f"explicit seed_project_stubs=True did not seed: {list(projects_dir.iterdir()) if projects_dir.exists() else 'no dir'}"
+    )
+
+
+def test_build_site_default_preserves_existing_stubs(tmp_path: Path, monkeypatch):
+    """Hand-authored stubs are never touched, even when seeding is off."""
+    from llmwiki.build import build_site
+
+    repo = _seed_one_session(tmp_path)
+    projects_dir = repo / "wiki" / "projects"
+    projects_dir.mkdir(parents=True)
+    curated = projects_dir / "newproj.md"
+    curated_text = (
+        "---\ntitle: \"newproj\"\ntype: entity\nentity_type: project\n"
+        "project: newproj\ntopics: [hand-edited]\n"
+        'description: "real"\nhomepage: ""\n---\n\n# newproj\n\nDo not touch.\n'
+    )
+    curated.write_text(curated_text, encoding="utf-8")
+    _patch_build_paths(monkeypatch, repo)
+
+    rc = build_site(out_dir=repo / "site")
+    assert rc == 0
+    assert curated.read_text() == curated_text
+
+
+def test_cli_build_flag_round_trips(tmp_path: Path):
+    """Sanity: the new --seed-project-stubs flag is registered on the
+    build subparser and parses to args.seed_project_stubs=True."""
+    from llmwiki.cli import build_parser
+    parser = build_parser()
+    args = parser.parse_args(["build", "--seed-project-stubs"])
+    assert getattr(args, "seed_project_stubs", False) is True
+    args_default = parser.parse_args(["build"])
+    assert getattr(args_default, "seed_project_stubs", False) is False


### PR DESCRIPTION
## Summary

Closes #414.

\`build_site\` was supposed to be read-only on \`wiki/\` but \`ensure_project_stubs\` (#378) was wired into the build path. Users running \`llmwiki build\` from CI on a curated checkout discovered surprise files in their working tree — and auto-pushed them if the workflow did \`git add -A\`.

Fix: \`build_site()\` takes \`seed_project_stubs: bool = False\`; \`build\` CLI gets \`--seed-project-stubs\` for explicit opt-in; \`cmd_sync\` keeps passing \`seed_project_stubs=True\` since sync already mutates wiki/.

## Changes

- \`llmwiki/build.py\` — new \`seed_project_stubs\` parameter, default False
- \`llmwiki/cli.py\` — \`--seed-project-stubs\` flag on \`build\` subcommand; \`cmd_sync\`'s auto-build path passes True
- 4 regression tests covering read-only default, explicit flag, hand-authored stub preservation, CLI flag round-trip

## Test plan

- [x] \`pytest tests/test_project_stubs.py\` — 6 → 10 passing
- [x] \`pytest tests/ -m \"not slow\"\` — 2160 → 2164 passing
- [x] All existing project_stubs invariants preserved

## Edge case checklist (from #414)

- [x] \`build\` against a wiki/ with all project stubs present → no writes
- [x] \`build\` against a wiki/ missing one stub → no writes (build is read-only)
- [x] \`sync\` discovers a new project → stub seeded post-sync
- [x] \`build --seed-project-stubs\` → stubs seeded explicitly
- [x] Existing hand-authored project page → never overwritten
- [x] \`wiki/projects/\` doesn't exist → not auto-created on default build

## Release cadence

Patch (\`1.2.8\` → \`1.2.13\`). Behaviour-preserving for \`sync\` users; pure for \`build\` users (which is the documented contract). Mid-version bump skips reflect parallel in-flight PRs.