### PR TITLE
fix: Redactor handles Windows + WSL paths + default token redaction (#416, v1.2.18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.2.18] — 2026-04-26
+
+Patch release fixing the `Redactor`'s Windows/WSL blind spot and adding default credential-token redaction flagged by the Opus 4.7 code review (#403). The CLAUDE.md security promise — redaction "before anything hits disk" — now holds across every supported platform.
+
+### Fixed
+
+- **Redactor missed Windows + WSL home-directory paths** (#416) — username substitution was hardcoded to `/Users/{user}` (macOS) and `/home/{user}` (Linux) via plain `str.replace`. Windows (`C:\Users\<u>`), Windows-with-mixed-separators (`C:/Users/<u>` from copy-paste between shells), and WSL (`/mnt/c/Users/<u>`, `/mnt/d/Users/<u>`, etc.) silently skipped redaction — meaning a Windows-authored session transcript shipped real usernames to disk. Fix: single regex with prefix alternation covering all 5 path styles, plus a `(?=$|[/\\])` lookahead so `alice` doesn't match `aliceandbob`. Usernames with hyphens, underscores, and unicode characters all round-trip.
+
+### Added
+
+- **Default credential-token redaction** (#416) — new `_DEFAULT_TOKEN_PATTERNS` runs unconditionally regardless of user `extra_patterns` config, so users who never configured redaction are still protected. Covers GitHub PATs (`ghp_*`, `gho_*`, `ghs_*`, `ghu_*`, `github_pat_*`), AWS access key IDs (`AKIA*`), and Slack tokens (`xoxb-*`, `xoxp-*`, `xoxa-*`, `xoxr-*`, `xoxs-*`). Length thresholds (≥20 chars after the prefix; AKIA-style requires exactly 16 trailing chars) prevent false positives on docs and short example strings. Adds 21 regression tests covering the full path/token matrix.
+
 ## [1.2.12] — 2026-04-26
 
 Patch release fixing the `IndexSync` lint rule's false-positive flood on relative href prefixes flagged by the Opus 4.7 code review (#403). No API change; the rule now correctly resolves `./`, `..`, `#anchor`, and `?query` instead of treating each as a dead link.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.2.12-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.2.18-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2068%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.2.12"
+__version__ = "1.2.18"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/convert.py
+++ b/llmwiki/convert.py
@@ -410,6 +410,29 @@ def most_common_model(records: list[dict[str, Any]]) -> str:
 
 # ─── redaction + truncation ────────────────────────────────────────────────
 
+# #416: default token shapes that should be redacted out of any session
+# transcript regardless of user config. The CLAUDE.md security model
+# promises redaction "before anything hits disk" — these patterns close
+# the gap left by relying on user-provided `extra_patterns`.
+#
+# - GitHub PATs: `ghp_*` (classic), `gho_*` (OAuth), `ghs_*` (server-to-
+#   server), `ghu_*` (user-to-server), `github_pat_*` (fine-grained)
+# - AWS access key IDs: `AKIA*` (20 chars total)
+# - Slack tokens: `xoxb-*`, `xoxp-*`, `xoxa-*`, `xoxr-*`, `xoxs-*`
+#
+# These run AFTER user `extra_patterns` so users can override with a
+# more permissive matcher if they really need to (e.g. test fixtures).
+_DEFAULT_TOKEN_PATTERNS = [
+    re.compile(r"\bghp_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bgho_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bghs_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bghu_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"\bxox[abprs]-[A-Za-z0-9-]{10,}\b"),
+]
+
+
 class Redactor:
     def __init__(self, config: dict[str, Any]):
         red = config.get("redaction", {})
@@ -421,12 +444,43 @@ class Redactor:
         if not text:
             return text
         if self.real_user:
-            text = text.replace(f"/Users/{self.real_user}/", f"/Users/{self.repl_user}/")
-            text = text.replace(f"/Users/{self.real_user}", f"/Users/{self.repl_user}")
-            text = text.replace(f"/home/{self.real_user}/", f"/home/{self.repl_user}/")
+            text = self._redact_username(text)
         for pat in self.patterns:
             text = pat.sub("<REDACTED>", text)
+        # #416: default token redaction runs unconditionally so users
+        # never accidentally publish credentials by forgetting to
+        # configure `extra_patterns`.
+        for pat in _DEFAULT_TOKEN_PATTERNS:
+            text = pat.sub("<REDACTED>", text)
         return text
+
+    def _redact_username(self, text: str) -> str:
+        """Replace the real username in home-directory paths.
+
+        #416: covers macOS (`/Users/<u>`), Linux (`/home/<u>`), Windows
+        (`C:\\Users\\<u>` plus mixed-separator variants users hit when
+        copy-pasting between shells), and WSL (`/mnt/c/Users/<u>`).
+        Username can contain hyphens, underscores, and unicode.
+        """
+        u = re.escape(self.real_user)
+        repl_user = self.repl_user
+        # Single regex with prefix alternation; word-style boundary
+        # (lookahead) prevents matching `aliceandbob` when `alice` is
+        # the real user. The username group is itself the only thing
+        # we substitute — separators and prefix are preserved.
+        prefixes = (
+            r"/Users/",
+            r"/home/",
+            r"C:\\Users\\",
+            r"C:/Users/",
+            r"/mnt/[a-z]/Users/",
+        )
+        pattern = re.compile(
+            r"(?P<prefix>" + "|".join(prefixes) + r")"
+            + r"(?P<user>" + u + r")"
+            + r"(?=$|[/\\])"
+        )
+        return pattern.sub(lambda m: m.group("prefix") + repl_user, text)
 
 
 def _close_open_fence(text: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.2.12"
+version = "1.2.18"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -112,6 +112,207 @@ def test_redactor_email():
     assert "alice@example.com" not in r("email me at alice@example.com please")
 
 
+# ─── #416: Windows / WSL / token redaction ──────────────────────────
+
+
+def _user_redactor(username: str = "alice", replacement: str = "USER") -> Redactor:
+    return Redactor({
+        "redaction": {
+            "real_username": username,
+            "replacement_username": replacement,
+            "extra_patterns": [],
+        }
+    })
+
+
+def test_redactor_windows_path_backslash():
+    """Windows: `C:\\Users\\alice\\Desktop\\...` → redacted (#416)."""
+    r = _user_redactor()
+    out = r(r"C:\Users\alice\Desktop\code\file.py")
+    assert "alice" not in out
+    assert r"C:\Users\USER\Desktop\code\file.py" == out
+
+
+def test_redactor_windows_path_mixed_separators():
+    """Windows: mixed `C:\\Users/alice/...` (copy-paste between shells)."""
+    r = _user_redactor()
+    out = r(r"C:/Users/alice/Documents/x.txt")
+    assert "alice" not in out
+    assert "C:/Users/USER/Documents/x.txt" == out
+
+
+def test_redactor_wsl_path():
+    """WSL: `/mnt/c/Users/alice/...` → redacted."""
+    r = _user_redactor()
+    out = r("/mnt/c/Users/alice/code/repo/file.py")
+    assert "alice" not in out
+    assert "/mnt/c/Users/USER/code/repo/file.py" == out
+
+
+def test_redactor_wsl_path_d_drive():
+    """WSL: `/mnt/d/Users/alice/...` (any drive letter) → redacted."""
+    r = _user_redactor()
+    out = r("/mnt/d/Users/alice/work/file.py")
+    assert "/mnt/d/Users/USER/work/file.py" == out
+
+
+def test_redactor_macos_path_still_works():
+    """Regression: macOS path still redacts after the regex rewrite."""
+    r = _user_redactor()
+    assert r("/Users/alice/Desktop/x") == "/Users/USER/Desktop/x"
+
+
+def test_redactor_linux_path_still_works():
+    """Regression: Linux path still redacts after the regex rewrite."""
+    r = _user_redactor()
+    assert r("/home/alice/code/x") == "/home/USER/code/x"
+
+
+def test_redactor_username_substring_safe():
+    """Username `alice` must NOT match `aliceandbob` (boundary respected)."""
+    r = _user_redactor("alice")
+    text = "/Users/aliceandbob/code"
+    out = r(text)
+    # `aliceandbob` should be left alone since it's not the user.
+    assert out == text
+
+
+def test_redactor_username_with_hyphens():
+    """Usernames with hyphens are valid and must be matched."""
+    r = _user_redactor("alice-smith")
+    out = r("/Users/alice-smith/code")
+    assert out == "/Users/USER/code"
+
+
+def test_redactor_username_with_underscores():
+    r = _user_redactor("alice_smith")
+    out = r("/home/alice_smith/code")
+    assert out == "/home/USER/code"
+
+
+def test_redactor_username_unicode():
+    """Unicode usernames (CJK, emoji-prefix) round-trip."""
+    r = _user_redactor("aliceé")
+    out = r("/Users/aliceé/code")
+    assert "aliceé" not in out
+
+
+def test_redactor_network_drive_no_false_redaction():
+    """`\\\\server\\share\\...` (UNC path) must not be touched."""
+    r = _user_redactor("alice")
+    text = r"\\server\share\public\file.txt"
+    assert r(text) == text  # no `Users\\alice` segment, no change
+
+
+# Token-shape fixtures are built via string concatenation so the
+# literal text never appears in the source — that keeps GitHub's
+# secret-scanner from flagging the test file itself as a leaked secret.
+# These are obvious test patterns (all-A's, sequential digits) chosen
+# to match the regex shape without resembling any real credential.
+
+def _ghp(suffix: str = "A" * 36) -> str:
+    return "g" + "h" + "p_" + suffix
+
+def _gho(suffix: str = "A" * 36) -> str:
+    return "g" + "h" + "o_" + suffix
+
+def _ghs(suffix: str = "A" * 36) -> str:
+    return "g" + "h" + "s_" + suffix
+
+def _ghu(suffix: str = "A" * 36) -> str:
+    return "g" + "h" + "u_" + suffix
+
+def _github_pat(suffix: str = "A" * 36) -> str:
+    return "g" + "ithub_" + "pat_" + suffix
+
+def _akia(suffix: str = "A" * 16) -> str:
+    return "AK" + "IA" + suffix
+
+def _xox(letter: str = "b", suffix: str = "1234567890-abc") -> str:
+    return "x" + "ox" + letter + "-" + suffix
+
+
+def test_redactor_github_pat_classic():
+    """GitHub classic PAT (ghp_*) is redacted by default (#416)."""
+    r = Redactor({})
+    token = _ghp()
+    out = r(f"token={token}")
+    assert token not in out
+    assert "<REDACTED>" in out
+
+
+def test_redactor_github_oauth_token():
+    """GitHub OAuth (gho_*) is redacted."""
+    r = Redactor({})
+    token = _gho()
+    out = r(f"Authorization: token {token}")
+    assert token not in out
+
+
+def test_redactor_github_server_to_server():
+    """ghs_* → redacted."""
+    r = Redactor({})
+    token = _ghs()
+    out = r(f"X-API-Key: {token}")
+    assert token not in out
+
+
+def test_redactor_github_user_to_server():
+    """ghu_* → redacted."""
+    r = Redactor({})
+    token = _ghu()
+    assert token not in r(token)
+
+
+def test_redactor_github_fine_grained_pat():
+    """github_pat_* → redacted."""
+    r = Redactor({})
+    token = _github_pat()
+    out = r(f"export TOKEN={token}")
+    assert token not in out
+
+
+def test_redactor_aws_access_key_id():
+    """AWS access key IDs (AKIA*) → redacted."""
+    r = Redactor({})
+    token = _akia()
+    out = r(f"aws_access_key_id={token}")
+    assert token not in out
+
+
+def test_redactor_slack_bot_token():
+    """Slack bot token (xoxb-*) → redacted."""
+    r = Redactor({})
+    token = _xox("b")
+    out = r(f"Bearer {token}")
+    assert token not in out
+
+
+def test_redactor_slack_user_token():
+    """Slack user token (xoxp-*) → redacted."""
+    r = Redactor({})
+    token = _xox("p")
+    assert token not in r(token)
+
+
+def test_redactor_does_not_mistake_short_tokens():
+    """Short prefixes that don't meet the length threshold are preserved.
+    Avoids false positives on docs / examples."""
+    r = Redactor({})
+    short = "g" + "h" + "p_short"
+    out = r(short)
+    assert short in out
+
+
+def test_redactor_no_extra_patterns_still_redacts_tokens():
+    """Token defaults run regardless of user `extra_patterns` config (#416).
+    Closes the gap where users without security tooling had no protection."""
+    r = Redactor({"redaction": {"real_username": "", "extra_patterns": []}})
+    token = _ghp()
+    out = r(token)
+    assert "<REDACTED>" in out
+
+
 def test_filter_records_drops_noise():
     records = [
         {"type": "user", "message": {"role": "user", "content": "hi"}},


### PR DESCRIPTION
## Summary

Closes #416.

CLAUDE.md promises redaction "before anything hits disk". That promise broke on Windows because:
1. Username substitution was hardcoded to \`/Users/\` (macOS) and \`/home/\` (Linux). Windows (\`C:\Users\\\`), mixed-separator paths, and WSL (\`/mnt/c/Users/\`) silently skipped redaction.
2. Default \`extra_patterns\` is empty — users with no security tooling had ZERO token protection.

## Changes

- **Username substitution** is now a single regex with prefix alternation (\`/Users/\`, \`/home/\`, \`C:\Users\\\`, \`C:/Users/\`, \`/mnt/[a-z]/Users/\`). \`(?=$|[/\\\\])\` lookahead prevents matching \`alice\` inside \`aliceandbob\`.
- **Default token redaction** runs unconditionally: GitHub PATs (\`ghp_*\`, \`gho_*\`, \`ghs_*\`, \`ghu_*\`, \`github_pat_*\`), AWS access key IDs (\`AKIA*\`), Slack tokens (\`xoxb-*\`, \`xoxp-*\`, etc.). Length thresholds prevent false positives on docs.
- **Test fixtures** are built via string concatenation so GitHub's secret-scanner doesn't flag this PR.

## Test plan

- [x] \`pytest tests/test_convert.py\` — 20 → 41 passing
- [x] \`pytest tests/ -m \"not slow\"\` — 2169 → 2190 passing
- [x] All 3 existing Redactor tests still pass

## Edge case checklist (from #416)

- [x] macOS path \`/Users/alice/...\` → redacted
- [x] Linux path \`/home/alice/...\` → redacted
- [x] Windows path \`C:\Users\alice\...\` → redacted
- [x] Mixed separators \`C:/Users/alice/...\` → redacted
- [x] WSL path \`/mnt/c/Users/alice/...\` → redacted
- [x] WSL path with non-c drive \`/mnt/d/Users/alice/...\` → redacted
- [x] Network drive \`\\server\share\...\` → no false redaction
- [x] Username with hyphens \`alice-smith\` → matched
- [x] Username with underscores → matched
- [x] Username with unicode (\`aliceé\`) → matched
- [x] Substring guard: \`alice\` does NOT match in \`aliceandbob\`
- [x] GitHub classic PAT \`ghp_*\` → redacted
- [x] GitHub OAuth \`gho_*\` → redacted
- [x] GitHub server-to-server \`ghs_*\` → redacted
- [x] GitHub user-to-server \`ghu_*\` → redacted
- [x] GitHub fine-grained \`github_pat_*\` → redacted
- [x] AWS \`AKIA*\` → redacted
- [x] Slack bot \`xoxb-*\` → redacted
- [x] Slack user \`xoxp-*\` → redacted
- [x] Short tokens (\`ghp_short\`) NOT mistakenly redacted
- [x] Default config (empty extra_patterns) still redacts tokens

## Release cadence

Patch (\`1.2.12\` → \`1.2.18\`). Closes a real security gap (Windows users); no API change. Mid-version skips reflect parallel in-flight PRs.