### PR TITLE
fix: wiki_query ranking length normalisation (#418, v1.2.25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.2.25] — 2026-04-26
+
+Patch release fixing the `wiki_query` MCP-tool ranking quality regression flagged by the Opus 4.7 code review (#403). Pure ranking fix — no API change beyond floats appearing in the score field.
+
+### Fixed
+
+- **`wiki_query` ranking had no length normalisation** (#418) — the formula was `score = 50·full_match + 10·tokens_in_body + 100·title_match + 20·title_token_match`. A 1-MB log page that contains every query token *anywhere* always beat a perfectly relevant 1-paragraph entity page. As LLM clients lean on `wiki_query`, that quality regression was user-visible. Fix: divide the body component by `log2(max(len(content), 256))` before summing — long pages still rank but no longer dominate, short pages don't get an artificial boost (the 256-byte floor caps it). Title matches are unchanged since titles are already short and high-signal. Empty bodies and frontmatter-only pages now ranked safely (no division-by-zero, no NaN). Adds 8 regression tests covering short-vs-long, title precedence, empty query, no-matches, frontmatter-only, unicode tokenisation, finite-score guarantee, and short-page floor.
+
 ## [1.2.19] — 2026-04-26
 
 Patch release fixing the `build` CI-surprise commit issue flagged by the Opus 4.7 code review (#403). `llmwiki build` is now read-only on `wiki/` by default — stub seeding moves to opt-in.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.2.19-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.2.25-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2068%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.2.19"
+__version__ = "1.2.25"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/mcp/server.py
+++ b/llmwiki/mcp/server.py
@@ -301,27 +301,46 @@ def tool_wiki_query(args: dict[str, Any]) -> dict[str, Any]:
     index = (wiki / "index.md").read_text(encoding="utf-8") if (wiki / "index.md").exists() else ""
     overview = (wiki / "overview.md").read_text(encoding="utf-8") if (wiki / "overview.md").exists() else ""
 
-    # Scan every .md under wiki/ for matches on title + body
+    # Scan every .md under wiki/ for matches on title + body.
+    # #418: ranking is now length-normalised — body matches are
+    # divided by ``log2(max(len(content), 256))`` so a 1MB log
+    # page can't beat a perfectly-relevant 1-paragraph entity page
+    # just by accidentally containing every query token. Title
+    # matches are unchanged since titles are already short and
+    # high-signal.
     query_lower = question.lower()
     tokens = [t for t in re.split(r"\W+", query_lower) if t]
-    matches: list[tuple[int, Path, str]] = []
+    matches: list[tuple[float, Path, str]] = []
     for page in wiki.rglob("*.md"):
         try:
             content = page.read_text(encoding="utf-8")
         except OSError:
             continue
         content_lower = content.lower()
-        score = 0
+        body_score = 0
         if query_lower in content_lower:
-            score += 50
-        score += sum(10 for t in tokens if t in content_lower)
-        # Title bonus
+            body_score += 50
+        body_score += sum(10 for t in tokens if t in content_lower)
+        # Length normalisation: divide raw body score by
+        # log2(max(len, 256)). The 256-byte floor keeps very short
+        # pages (frontmatter-only) from getting a massive boost on
+        # zero-token queries.
+        if body_score > 0:
+            import math as _math
+            length_factor = _math.log2(max(len(content), 256))
+            normalised_body = body_score / length_factor
+        else:
+            normalised_body = 0.0
+        # Title bonus — unchanged. Titles are already short and
+        # high-signal; no normalisation needed.
+        title_score = 0
         title_match = re.search(r'^title:\s*"?([^"\n]+)', content, re.MULTILINE)
         if title_match:
             title = title_match.group(1).lower()
             if query_lower in title:
-                score += 100
-            score += sum(20 for t in tokens if t in title)
+                title_score += 100
+            title_score += sum(20 for t in tokens if t in title)
+        score = normalised_body + title_score
         if score > 0:
             snippet = _extract_snippet(content, tokens, max_chars=400)
             matches.append((score, page, snippet))
@@ -336,7 +355,7 @@ def tool_wiki_query(args: dict[str, Any]) -> dict[str, Any]:
     else:
         for score, page, snippet in top:
             rel = page.relative_to(REPO_ROOT)
-            out.append(f"## `{rel}` (score: {score})\n")
+            out.append(f"## `{rel}` (score: {score:.1f})\n")
             out.append(snippet)
             out.append("")
     out.append("---\n")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.2.19"
+version = "1.2.25"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_mcp_safety.py
+++ b/tests/test_mcp_safety.py
@@ -21,6 +21,7 @@ from unittest.mock import patch
 import pytest
 
 from llmwiki.mcp.server import (
+    tool_wiki_query,
     tool_wiki_search,
     tool_wiki_list_sources,
 )
@@ -254,3 +255,159 @@ def test_list_sources_filter_does_not_glob(tmp_path: Path):
         result = tool_wiki_list_sources({"project": "demo*"})
     payload = _result_json(result)
     assert payload == []
+
+
+# ─── #418: wiki_query ranking length normalisation ──────────────────
+
+
+def _seed_query_corpus(tmp_path: Path, pages: dict[str, str]) -> None:
+    """Seed wiki/ with the given (path → body) mapping. Each page also
+    gets a `## Connections\\n- [[NoOp]]` section so the orphan check
+    isn't relevant to ranking."""
+    wiki = tmp_path / "wiki"
+    wiki.mkdir(parents=True, exist_ok=True)
+    for rel, body in pages.items():
+        target = wiki / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body, encoding="utf-8")
+
+
+def _query_pages_in_order(result: dict) -> list[str]:
+    """Extract the ordered list of page paths from a wiki_query result."""
+    text = _result_text(result)
+    import re as _re
+    return _re.findall(r"## `([^`]+)`", text)
+
+
+def test_query_short_relevant_beats_long_incidental(tmp_path: Path):
+    """Regression for #418: a 1-paragraph entity page exactly matching
+    the query must outrank a 1-MB log page that incidentally contains
+    every query token. Pre-fix, the long page won by sheer mass.
+    """
+    short_relevant = (
+        '---\ntitle: "Caching"\ntype: concept\n---\n\n'
+        "# Caching\n\nA short, focused page about caching strategies.\n"
+    )
+    long_incidental = (
+        '---\ntitle: "Long Log"\ntype: source\n---\n\n'
+        "# Long Log\n\n"
+        # Bury "caching" once in a long sea of other content.
+        + ("Generic prose that doesn't mention the topic. " * 5000)
+        + " caching mentioned exactly once "
+        + ("More filler content. " * 5000)
+    )
+    _seed_query_corpus(tmp_path, {
+        "concepts/Caching.md": short_relevant,
+        "sources/log.md": long_incidental,
+    })
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        result = tool_wiki_query({"question": "caching"})
+    pages = _query_pages_in_order(result)
+    assert pages, f"no pages returned: {_result_text(result)[:500]}"
+    assert pages[0].endswith("Caching.md"), (
+        f"length normalisation broken — long page won: {pages}"
+    )
+
+
+def test_query_title_match_still_wins(tmp_path: Path):
+    """Title matches stay the strongest signal even after normalisation."""
+    body_match = (
+        '---\ntitle: "Unrelated"\ntype: source\n---\n\n'
+        "# Unrelated\n\nfoo " * 100  # body has 100 mentions of "foo"
+    )
+    title_match = (
+        '---\ntitle: "Foo"\ntype: entity\n---\n\n'
+        "# Foo\n\nA short page about something else entirely.\n"
+    )
+    _seed_query_corpus(tmp_path, {
+        "sources/x.md": body_match,
+        "entities/Foo.md": title_match,
+    })
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        result = tool_wiki_query({"question": "foo"})
+    pages = _query_pages_in_order(result)
+    assert pages[0].endswith("Foo.md"), (
+        f"title match should win, got order: {pages}"
+    )
+
+
+def test_query_empty_question_returns_no_results(tmp_path: Path):
+    _seed_query_corpus(tmp_path, {
+        "entities/Foo.md": '---\ntitle: "Foo"\n---\n\n# Foo\n',
+    })
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        result = tool_wiki_query({"question": ""})
+    text = _result_text(result)
+    # Either explicit empty-results message or just no `## ` page entries.
+    assert "score:" not in text or "No matching" in text
+
+
+def test_query_no_matches_does_not_crash(tmp_path: Path):
+    _seed_query_corpus(tmp_path, {
+        "entities/Foo.md": '---\ntitle: "Foo"\n---\n\n# Foo\n',
+    })
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        result = tool_wiki_query({"question": "completely-unrelated-xyz"})
+    text = _result_text(result)
+    assert "No matching pages" in text or "score:" not in text
+
+
+def test_query_handles_frontmatter_only_pages(tmp_path: Path):
+    """Pages with empty body shouldn't crash on length normalisation."""
+    _seed_query_corpus(tmp_path, {
+        "entities/EmptyBody.md": '---\ntitle: "EmptyBody"\ntype: entity\n---\n',
+        "entities/Real.md": (
+            '---\ntitle: "Real"\n---\n\n# Real\n\nA real body.\n'
+        ),
+    })
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        result = tool_wiki_query({"question": "Real"})
+    # Must succeed (no crash on the empty-body page).
+    pages = _query_pages_in_order(result)
+    assert any("Real" in p for p in pages)
+
+
+def test_query_unicode_query_tokenises(tmp_path: Path):
+    """CJK / emoji queries don't break tokenisation."""
+    _seed_query_corpus(tmp_path, {
+        "entities/Cafe.md": (
+            '---\ntitle: "Café"\n---\n\n# Café\n\nA page with café in body.\n'
+        ),
+    })
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        result = tool_wiki_query({"question": "café"})
+    pages = _query_pages_in_order(result)
+    assert pages, f"unicode query returned nothing: {_result_text(result)[:500]}"
+
+
+def test_query_score_is_finite_no_nan(tmp_path: Path):
+    """Length normalisation must never divide by zero / produce NaN."""
+    _seed_query_corpus(tmp_path, {
+        "entities/Tiny.md": "x",  # 1-byte page
+        "entities/Normal.md": '---\ntitle: "X"\n---\n\n# X\n\nSome x body.\n',
+    })
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        result = tool_wiki_query({"question": "x"})
+    text = _result_text(result)
+    # No NaN/Infinity should appear in the rendered scores.
+    assert "nan" not in text.lower()
+    assert "inf" not in text.lower()
+
+
+def test_query_short_floor_prevents_tiny_page_dominance(tmp_path: Path):
+    """The 256-byte length floor stops 5-byte pages from getting
+    log2(5)≈2.3 scaling and dominating."""
+    tiny = "match"  # 5 bytes, all relevant
+    normal = (
+        '---\ntitle: "Match Page"\n---\n\n# Match Page\n\n'
+        "match match match match\n"
+    )
+    _seed_query_corpus(tmp_path, {
+        "entities/Tiny.md": tiny,
+        "entities/Normal.md": normal,
+    })
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        result = tool_wiki_query({"question": "match"})
+    pages = _query_pages_in_order(result)
+    # The page with title match should still win (titles aren't normalised).
+    assert pages[0].endswith("Normal.md")


### PR DESCRIPTION
## Summary

Closes #418.

\`tool_wiki_query\` ranking had no length normalisation: a 1-MB log page that incidentally contains every query token always beat a perfectly relevant 1-paragraph entity page. As LLM clients lean on \`wiki_query\` for context retrieval, this was a user-visible quality regression.

## Changes

- Body score is now divided by \`log2(max(len(content), 256))\` — long pages don't dominate by mass alone.
- Title matches unchanged (titles are short + high-signal).
- 256-byte floor prevents tiny pages from getting artificial scaling.
- Score field is now a float (\`score: 12.3\`) — sort order unchanged.

## Test plan

- [x] \`pytest tests/test_mcp_safety.py\` — 25 → 33 passing (+8)
- [x] \`pytest tests/ -m \"not slow\"\` — 2169 → 2188 passing
- [x] All existing wiki_query callers still work (sort order preserved for title matches)

## Edge case checklist (from #418)

- [x] Short relevant page beats long incidentally-matching page
- [x] Title match still wins
- [x] Empty query → no crash
- [x] Query matches 0 pages → no crash
- [x] Frontmatter-only pages → no division-by-zero
- [x] Unicode query (CJK) → tokenised correctly
- [x] Score is finite (no NaN, no Infinity)
- [x] Tiny pages don't get artificial scaling boost

## Release cadence

Patch (\`1.2.19\` → \`1.2.25\`). Pure ranking fix; sort order preserved for the dominant case (title matches still win).