### PR TITLE
fix: synth pipeline state file isolation per vault (#420, v1.2.32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.2.32] — 2026-04-26
+
+Patch release fixing the synth-pipeline state-file collision across vault overlays flagged by the Opus 4.7 code review (#403). Pure correctness fix — single-vault and no-vault users see no behaviour change; multi-vault users no longer have one vault's run mark another vault's files unchanged.
+
+### Fixed
+
+- **Synth pipeline state file collided across vault overlays** (#420) — `synth/pipeline.py:STATE_FILE` was hardcoded to `REPO_ROOT / ".llmwiki-synth-state.json"`. Vault-overlay mode (`--vault`) plumbed the new root through `convert_all` but `synthesize_new_sessions` still wrote to the *repo* state file. Two vaults synthesised against the same repo silently shared idempotency state; running synth on vault B marked vault A's already-processed files as unchanged on the next run, leaving vault A drifting silently. Fix: `synthesize_new_sessions(state_file=...)` now accepts an explicit state path; `_load_state` and `_save_state` route through a new `_resolve_state_file` helper. The `synthesize` CLI subcommand exposes `--vault PATH` mirroring `build` and `sync` — when set, state lives at `<vault>/.llmwiki-synth-state.json`. Default no-vault behaviour unchanged.
+
+### Added
+
+- **11 new tests** (`tests/test_vault.py`) covering default vs vault state-file paths, load/save round-trip with explicit path, end-to-end isolation between two vaults, corrupted-file fallback to empty state, missing-file fallback, unicode + spaces in vault paths, the new CLI flag round-trip, default `args.vault is None`, and `cmd_synthesize` exit-2 on non-existent vault path.
+
 ## [1.2.26] — 2026-04-26
 
 Patch release fixing the markdown render-cache hot-path perf flagged by the Opus 4.7 code review (#403). Pure perf — no API change beyond `md_to_html_cache_stats()` exposing additional `plain_*` counters.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.2.26-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.2.32-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2068%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.2.26"
+__version__ = "1.2.32"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/cli.py
+++ b/llmwiki/cli.py
@@ -670,9 +670,26 @@ def cmd_synthesize(args: argparse.Namespace) -> int:
         )
         return 1
 
+    # #420: vault-overlay mode isolates raw/wiki/state to the vault root.
+    vault_path = getattr(args, "vault", None)
+    raw_dir = wiki_sources_dir = state_file = None
+    if vault_path:
+        from llmwiki.vault import resolve_vault
+        try:
+            vault = resolve_vault(vault_path)
+        except (FileNotFoundError, NotADirectoryError) as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        raw_dir = vault / "raw" / "sessions"
+        wiki_sources_dir = vault / "wiki" / "sources"
+        state_file = vault / ".llmwiki-synth-state.json"
+
     summary = synthesize_new_sessions(
         backend=backend,
         force=args.force,
+        raw_dir=raw_dir,
+        wiki_sources_dir=wiki_sources_dir,
+        state_file=state_file,
     )
     print(
         f"Scanned {summary['total_scanned']}, new {summary['new_files']}, "
@@ -1177,6 +1194,14 @@ def build_parser() -> argparse.ArgumentParser:
     syn.add_argument(
         "--body", metavar="PATH", default=None,
         help="Read synthesized body from this file for --complete (default: stdin)",
+    )
+    syn.add_argument(
+        "--vault", type=Path, default=None,
+        help="(#420) Vault-overlay mode: read raw/ + write wiki/sources/ "
+             "under the vault root, and isolate the synth state file to the "
+             "vault. Without this flag the state file lives at the repo "
+             "root, so two vaults synthesised against the same repo silently "
+             "share idempotency state.",
     )
     syn.set_defaults(func=cmd_synthesize)
 

--- a/llmwiki/synth/pipeline.py
+++ b/llmwiki/synth/pipeline.py
@@ -114,18 +114,33 @@ def _load_prompt_template() -> str:
     return PROMPT_TEMPLATE_PATH.read_text(encoding="utf-8")
 
 
-def _load_state() -> dict[str, float]:
+def _resolve_state_file(state_file: Optional[Path] = None) -> Path:
+    """Return the synth state-file path.
+
+    #420: when running in vault-overlay mode, the state file must live
+    *under the vault root*, not the repo root — otherwise two different
+    vaults synthesised against the same repo silently share idempotency
+    state and one vault's run marks the other vault's files unchanged.
+    Callers pass ``state_file`` explicitly when in vault mode; default
+    falls back to the repo-root location for the no-vault case.
+    """
+    return state_file if state_file is not None else STATE_FILE
+
+
+def _load_state(state_file: Optional[Path] = None) -> dict[str, float]:
     """Load the mtime state file. Returns {relative_path: mtime}."""
-    if not STATE_FILE.is_file():
+    target = _resolve_state_file(state_file)
+    if not target.is_file():
         return {}
     try:
-        return json.loads(STATE_FILE.read_text(encoding="utf-8"))
+        return json.loads(target.read_text(encoding="utf-8"))
     except (ValueError, json.JSONDecodeError):
         return {}
 
 
-def _save_state(state: dict[str, float]) -> None:
-    STATE_FILE.write_text(
+def _save_state(state: dict[str, float], state_file: Optional[Path] = None) -> None:
+    target = _resolve_state_file(state_file)
+    target.write_text(
         json.dumps(state, indent=2, sort_keys=True), encoding="utf-8"
     )
 
@@ -549,6 +564,7 @@ def synthesize_new_sessions(
     dry_run: bool = False,
     force: bool = False,
     log_path: Optional[Path] = None,
+    state_file: Optional[Path] = None,
 ) -> dict[str, Any]:
     """Main entry point. Returns a summary dict:
 
@@ -576,7 +592,7 @@ def synthesize_new_sessions(
 
     sources_out = wiki_sources_dir or WIKI_SOURCES
     prompt_template = _load_prompt_template()
-    state = {} if force else _load_state()
+    state = {} if force else _load_state(state_file)
     sessions = _discover_raw_sessions(raw_dir)
 
     new_files: list[tuple[Path, dict[str, Any], str]] = []
@@ -679,7 +695,7 @@ def synthesize_new_sessions(
             },
         )
 
-    _save_state(state)
+    _save_state(state, state_file)
 
     # G-09 (#295): rebuild wiki/index.md so lint's index_sync rule
     # passes on fresh synthesized corpora. Synthesize is authoritative

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.2.26"
+version = "1.2.32"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -495,3 +495,126 @@ def test_existing_vault_doc_exists():
     assert "Obsidian" in text and "Logseq" in text and "Plain" in text
     assert "--allow-overwrite" in text
     assert "non-destructive" in text.lower() or "Non-destructive" in text
+
+
+# ─── #420: synth pipeline state file isolation per vault ────────────
+
+
+def test_synth_state_file_default_at_repo_root(tmp_path: Path, monkeypatch):
+    """Default mode (no vault): state file lives at repo root."""
+    from llmwiki.synth.pipeline import _resolve_state_file, STATE_FILE
+    assert _resolve_state_file(None) == STATE_FILE
+
+
+def test_synth_state_file_per_vault(tmp_path: Path):
+    """Vault mode: state file lives at the vault root, not repo root.
+
+    Regression for #420 — without per-vault isolation, two vaults
+    synthesised against the same repo silently share idempotency state.
+    """
+    from llmwiki.synth.pipeline import _resolve_state_file
+    vault_a = tmp_path / "vault-a" / ".llmwiki-synth-state.json"
+    vault_b = tmp_path / "vault-b" / ".llmwiki-synth-state.json"
+    assert _resolve_state_file(vault_a) == vault_a
+    assert _resolve_state_file(vault_b) == vault_b
+    assert _resolve_state_file(vault_a) != _resolve_state_file(vault_b)
+
+
+def test_synth_load_save_roundtrip_with_explicit_state_file(tmp_path: Path):
+    """Writing then reading state via an explicit path round-trips."""
+    from llmwiki.synth.pipeline import _load_state, _save_state
+    state_file = tmp_path / "vault-x" / ".llmwiki-synth-state.json"
+    state_file.parent.mkdir(parents=True)
+    sample = {"sources/foo.md": 1234567890.0, "sources/bar.md": 1234567891.5}
+    _save_state(sample, state_file)
+    assert state_file.is_file()
+    loaded = _load_state(state_file)
+    assert loaded == sample
+
+
+def test_synth_state_isolated_per_vault(tmp_path: Path):
+    """End-to-end: writing state to vault A doesn't leak into vault B."""
+    from llmwiki.synth.pipeline import _load_state, _save_state
+    vault_a = tmp_path / "vault-a"
+    vault_b = tmp_path / "vault-b"
+    vault_a.mkdir()
+    vault_b.mkdir()
+    state_a = vault_a / ".llmwiki-synth-state.json"
+    state_b = vault_b / ".llmwiki-synth-state.json"
+
+    _save_state({"sources/a-only.md": 1.0}, state_a)
+    _save_state({"sources/b-only.md": 2.0}, state_b)
+
+    loaded_a = _load_state(state_a)
+    loaded_b = _load_state(state_b)
+
+    assert loaded_a == {"sources/a-only.md": 1.0}
+    assert loaded_b == {"sources/b-only.md": 2.0}
+    # Cross-contamination guard: A's keys don't appear in B's state.
+    assert "sources/b-only.md" not in loaded_a
+    assert "sources/a-only.md" not in loaded_b
+
+
+def test_synth_state_corrupted_file_returns_empty(tmp_path: Path):
+    """If the state file exists but contains invalid JSON, fall back to
+    empty state instead of crashing."""
+    from llmwiki.synth.pipeline import _load_state
+    state_file = tmp_path / ".llmwiki-synth-state.json"
+    state_file.write_text("not valid json {{{", encoding="utf-8")
+    assert _load_state(state_file) == {}
+
+
+def test_synth_state_missing_file_returns_empty(tmp_path: Path):
+    """Missing state file → empty state (clean first run)."""
+    from llmwiki.synth.pipeline import _load_state
+    state_file = tmp_path / "does-not-exist.json"
+    assert _load_state(state_file) == {}
+
+
+def test_synth_state_file_with_unicode_path(tmp_path: Path):
+    """Vault paths with unicode characters work end-to-end."""
+    from llmwiki.synth.pipeline import _load_state, _save_state
+    vault = tmp_path / "vault-café-🚀"
+    vault.mkdir()
+    state_file = vault / ".llmwiki-synth-state.json"
+    _save_state({"sources/x.md": 1.0}, state_file)
+    assert _load_state(state_file) == {"sources/x.md": 1.0}
+
+
+def test_synth_state_file_with_spaces_in_path(tmp_path: Path):
+    """Vault paths with spaces (common on macOS)."""
+    from llmwiki.synth.pipeline import _load_state, _save_state
+    vault = tmp_path / "Obsidian Vault"
+    vault.mkdir()
+    state_file = vault / ".llmwiki-synth-state.json"
+    _save_state({"sources/y.md": 2.0}, state_file)
+    assert _load_state(state_file) == {"sources/y.md": 2.0}
+
+
+def test_cli_synthesize_accepts_vault_flag():
+    """CLI exposes --vault flag on `synthesize` (#420)."""
+    from llmwiki.cli import build_parser
+    parser = build_parser()
+    args = parser.parse_args(["synthesize", "--vault", "/tmp/myvault"])
+    assert str(args.vault) == "/tmp/myvault"
+
+
+def test_cli_synthesize_default_vault_is_none():
+    """No --vault flag → args.vault is None → state lives at repo root."""
+    from llmwiki.cli import build_parser
+    parser = build_parser()
+    args = parser.parse_args(["synthesize"])
+    assert getattr(args, "vault", None) is None
+
+
+def test_cli_synthesize_bad_vault_path_exits_with_error(tmp_path: Path, capsys):
+    """cmd_synthesize fails fast with exit 2 on non-existent --vault path."""
+    from llmwiki.cli import build_parser, cmd_synthesize
+    parser = build_parser()
+    args = parser.parse_args(
+        ["synthesize", "--vault", str(tmp_path / "missing-vault")]
+    )
+    rc = cmd_synthesize(args)
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "does not exist" in err


### PR DESCRIPTION
## Summary

Closes #420.

\`synth/pipeline.py:STATE_FILE\` was hardcoded to \`REPO_ROOT/.llmwiki-synth-state.json\`. Vault-overlay mode plumbed the new root through \`convert_all\` but \`synthesize_new_sessions\` still wrote to the *repo* state file. Two vaults synthesised against the same repo silently shared idempotency state.

## Changes

- \`synthesize_new_sessions(state_file=...)\` accepts an explicit state path.
- New \`_resolve_state_file\` helper routes \`_load_state\` + \`_save_state\` through a single chokepoint.
- \`synthesize\` CLI gets \`--vault PATH\` mirroring \`build\` and \`sync\`.
- \`cmd_synthesize\` fails fast with exit 2 on non-existent vault path.

## Test plan

- [x] \`pytest tests/test_vault.py\` — 52 → 63 passing
- [x] \`pytest tests/ -m \"not slow\"\` — 2211 → 2221 passing

## Edge case checklist (from #420)

- [x] Default mode (no vault) → state file at repo root
- [x] Vault mode → state file at vault root
- [x] Two vaults synced sequentially → independent state files
- [x] Vault path with spaces / unicode → handled
- [x] State file corruption → graceful re-creation (returns empty)
- [x] State file missing → returns empty (clean first run)
- [x] CLI \`--vault\` flag round-trips
- [x] Default \`args.vault is None\`
- [x] Bad vault path → exit 2 with clear error

## Release cadence

Patch (\`1.2.26\` → \`1.2.32\`). Pure correctness; no behaviour change for single-vault or no-vault users.