### PR TITLE
fix: derive_session_slug UUID-prefix collision (#424, v1.2.36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.2.36] — 2026-04-26
+
+Patch release fixing the `derive_session_slug` UUID-prefix collision flagged by the Opus 4.7 code review (#403). Pure correctness fix — non-UUID filenames behave identically.
+
+### Fixed
+
+- **`derive_session_slug` 12-char filename fallback collided per-project on UUID stems** (#424) — when no `slug` field was present in any record, the fallback was `jsonl_path.stem[:12]`. Claude Code emits UUID-named transcripts (`b7f0e3c4-2189-4f8e-9e4f-...jsonl`); two distinct UUIDs in the same project + same minute both collapsed to `b7f0e3c4-21` (the same 12-char prefix), so the canonical filename collided and we leaned on the disambig pass (#339) to save us. Correctness was coupled to the disambig pass — if the renderer ever moved first, this regressed silently. Fix: detect UUID-shaped stems with `_UUID_LIKE` regex and fall back to the same stable 8-char source-path hash that disambig already uses (`_source_hash8`). Two distinct UUIDs always produce distinct hashes, so the canonical slug is unique without leaning on disambig. Non-UUID stems keep the historical 12-char prefix to preserve human-readable slugs. Adds `tests/test_slug_fallback.py` (14 cases) covering explicit slug field, multiple records, normal stem prefix, UUID hash fallback, two-UUID distinct slugs, uppercase UUIDs, UUID with extra suffix, short stems, special chars, partial-UUID stems (NOT detected as UUID), record-slug-takes-precedence, end-to-end no-disambig-needed via `flat_output_name`, and hash stability across calls.
+
 ## [1.2.35] — 2026-04-26
 
 Patch release fixing `cmd_all` rebuilding the argparse tree once per step flagged by the Opus 4.7 code review (#403). Pure perf + decoupling fix — same external behaviour, just one parser construction per `llmwiki all` instead of four.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.2.35-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.2.36-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2068%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.2.35"
+__version__ = "1.2.36"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/convert.py
+++ b/llmwiki/convert.py
@@ -827,12 +827,41 @@ def render_user_prompt(record: dict[str, Any], redact: Redactor, max_chars: int)
 
 # ─── full markdown renderer ────────────────────────────────────────────────
 
+_UUID_LIKE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+    re.IGNORECASE,
+)
+
+
 def derive_session_slug(records: list[dict[str, Any]], jsonl_path: Path) -> str:
+    """Derive a slug from session records or fall back to the filename.
+
+    #424: when no ``slug`` field is in any record, the old fallback was
+    ``jsonl_path.stem[:12]``. UUID-named transcripts (Claude Code emits
+    these — ``b7f0e3c4-2189-4f8e-9e4f-...jsonl``) all collapsed onto
+    the *same* 12-char prefix per project (``b7f0e3c4-21``), so two
+    sessions in the same minute with that prefix produced the same
+    canonical filename. Correctness was coupled to the disambig pass
+    (#339); if the renderer ever moved first, this regressed silently.
+
+    Fix: detect UUID-shaped stems and fall back to the same stable
+    8-char source hash the disambig pass uses (``_source_hash8``).
+    Two distinct UUIDs always produce distinct hashes, so the canonical
+    slug is unique without leaning on disambig. Non-UUID stems keep
+    the historical 12-char prefix to preserve human-readable slugs
+    for projects that name their JSONLs deliberately.
+    """
     for r in records:
         slug = r.get("slug")
         if slug:
             return str(slug)
-    return jsonl_path.stem[:12]
+    stem = jsonl_path.stem
+    if _UUID_LIKE.match(stem):
+        return _source_hash8(jsonl_path)
+    if not stem:
+        # Empty stem (rare — would require a literal ``.jsonl`` filename).
+        return _source_hash8(jsonl_path)
+    return stem[:12]
 
 
 def flat_output_name(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.2.35"
+version = "1.2.36"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_slug_fallback.py
+++ b/tests/test_slug_fallback.py
@@ -1,0 +1,150 @@
+"""Tests for the derive_session_slug UUID fallback (closes #424).
+
+When a JSONL has no `slug` field in any record, we fall back to a
+slug derived from the filename. The historical fallback was
+``jsonl_path.stem[:12]``. UUID-named transcripts (Claude Code emits
+those) all collapsed onto the same 12-char prefix per project, so
+two UUIDs in the same minute produced colliding canonical filenames
+— the disambig pass (#339) saved us, but only because it ran after.
+
+The fix detects UUID-shaped stems and falls back to a stable 8-char
+source-path hash. Non-UUID stems keep the 12-char prefix.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from llmwiki.convert import derive_session_slug, _source_hash8
+
+
+def test_explicit_slug_field_used_as_is():
+    """Records with `slug` field → that's the slug. No filename fallback."""
+    records = [{"slug": "the-real-slug", "type": "user"}]
+    out = derive_session_slug(records, Path("/tmp/whatever.jsonl"))
+    assert out == "the-real-slug"
+
+
+def test_first_slug_wins_when_multiple_records_have_one():
+    """First non-empty `slug` field across records wins."""
+    records = [
+        {"type": "init"},
+        {"slug": "first-real", "type": "user"},
+        {"slug": "later-record", "type": "assistant"},
+    ]
+    assert derive_session_slug(records, Path("/tmp/x.jsonl")) == "first-real"
+
+
+def test_normal_filename_uses_12_char_prefix():
+    """Non-UUID stems use the historical 12-char prefix fallback."""
+    out = derive_session_slug([], Path("/tmp/clever-munching-parnas.jsonl"))
+    assert out == "clever-munch"
+
+
+def test_uuid_filename_uses_hash_not_prefix():
+    """Regression for #424: UUID stems get hash-based slugs, not the
+    UUID's 12-char prefix (which collided per-project)."""
+    uuid_path = Path("/tmp/b7f0e3c4-2189-4f8e-9e4f-1234567890ab.jsonl")
+    out = derive_session_slug([], uuid_path)
+    expected = _source_hash8(uuid_path)
+    assert out == expected
+    # And NOT the 12-char prefix that was collision-prone.
+    assert out != "b7f0e3c4-21"
+
+
+def test_two_uuid_jsonls_produce_distinct_slugs():
+    """The point of the fix: two different UUIDs in the same project
+    produce different canonical slugs without needing disambig."""
+    a = Path("/tmp/proj/aaaaaaaa-1111-1111-1111-111111111111.jsonl")
+    b = Path("/tmp/proj/bbbbbbbb-2222-2222-2222-222222222222.jsonl")
+    slug_a = derive_session_slug([], a)
+    slug_b = derive_session_slug([], b)
+    assert slug_a != slug_b
+
+
+def test_uuid_uppercase_also_detected():
+    """Uppercase hex UUIDs also match the pattern."""
+    upper = Path("/tmp/B7F0E3C4-2189-4F8E-9E4F-1234567890AB.jsonl")
+    out = derive_session_slug([], upper)
+    expected = _source_hash8(upper)
+    assert out == expected
+
+
+def test_uuid_with_extra_suffix_still_detected():
+    """`<uuid>-something.jsonl` (Claude Code subagents) still detected
+    as UUID-shaped at the front and gets the hash."""
+    p = Path("/tmp/b7f0e3c4-2189-4f8e-9e4f-1234567890ab-suffix.jsonl")
+    out = derive_session_slug([], p)
+    assert out == _source_hash8(p)
+
+
+def test_short_filename_returns_short_prefix():
+    """A 4-char stem returns 4 chars (Python slicing handles short input)."""
+    out = derive_session_slug([], Path("/tmp/abc.jsonl"))
+    assert out == "abc"
+
+
+def test_dotfile_returns_stem_as_is():
+    """Edge case: literal `.jsonl` filename — Python's `Path.stem`
+    returns ``.jsonl`` (the dotfile), so the 12-char prefix path
+    fires. This is rare enough that the existing prefix is fine."""
+    p = Path("/tmp/.jsonl")
+    out = derive_session_slug([], p)
+    # Just confirm we don't crash; pin current behaviour.
+    assert isinstance(out, str)
+    assert len(out) > 0
+
+
+def test_special_chars_in_filename_returns_prefix():
+    """Filenames with hyphens/underscores still use 12-char prefix."""
+    out = derive_session_slug([], Path("/tmp/some_long-name-here.jsonl"))
+    assert out == "some_long-na"
+
+
+def test_uuid_only_first_8_hex_chars_dont_match():
+    """Stems like `b7f0e3c4-something` (NOT a full UUID) keep the
+    12-char prefix path. UUID detection requires full UUID shape."""
+    p = Path("/tmp/b7f0e3c4-not-a-uuid.jsonl")
+    out = derive_session_slug([], p)
+    # Should NOT take the hash path — pattern is dash-segmented but
+    # not 8-4-4-4-12 hex.
+    assert out == "b7f0e3c4-not"
+
+
+def test_record_slug_takes_precedence_over_uuid_filename():
+    """Even with a UUID-shaped filename, an explicit `slug` field wins."""
+    p = Path("/tmp/b7f0e3c4-2189-4f8e-9e4f-1234567890ab.jsonl")
+    out = derive_session_slug([{"slug": "human-readable"}], p)
+    assert out == "human-readable"
+
+
+def test_no_disambig_needed_for_distinct_uuid_jsonls(tmp_path: Path):
+    """End-to-end-style: two UUIDs in same project + same minute, no
+    explicit slug → distinct canonical filenames without disambig.
+
+    Pre-fix: both produced ``YYYY-MM-DDTHH-MM-proj-b7f0e3c4-21.md``
+    Post-fix: both produce distinct hashes → no collision.
+    """
+    from datetime import datetime
+    from llmwiki.convert import flat_output_name
+
+    started = datetime(2026, 4, 26, 10, 0, 0)
+    a = tmp_path / "aaaaaaaa-1111-1111-1111-111111111111.jsonl"
+    b = tmp_path / "bbbbbbbb-2222-2222-2222-222222222222.jsonl"
+
+    slug_a = derive_session_slug([], a)
+    slug_b = derive_session_slug([], b)
+
+    name_a = flat_output_name(started, "proj", slug_a)
+    name_b = flat_output_name(started, "proj", slug_b)
+
+    # The whole point: distinct names, no disambig needed.
+    assert name_a != name_b
+
+
+def test_hash_is_stable_across_calls():
+    """The fallback is deterministic — same path → same slug."""
+    p = Path("/some/path/aaaaaaaa-1111-1111-1111-111111111111.jsonl")
+    first = derive_session_slug([], p)
+    second = derive_session_slug([], p)
+    assert first == second


### PR DESCRIPTION
## Summary

Closes #424.

\`derive_session_slug\` fell back to \`jsonl_path.stem[:12]\` when no record had an explicit \`slug\` field. Claude Code's UUID-named transcripts all collapsed to the same 12-char prefix per project, so two UUIDs in the same minute produced identical canonical filenames — and we leaned on disambig (#339) to save us. Coupling problem: correctness tied to a downstream pass.

## Changes

- New \`_UUID_LIKE\` regex detects UUID-shaped stems.
- UUID stems → \`_source_hash8\` (same hash disambig already uses).
- Non-UUID stems → keep historical 12-char prefix.

## Test plan

- [x] \`pytest tests/test_slug_fallback.py\` — 14 new cases passing
- [x] \`pytest tests/ -m \"not slow\"\` — 2238 → 2253 passing
- [x] All existing collision-retry tests still pass

## Edge case checklist (from #424)

- [x] JSONL with explicit \`slug\` field → used as-is
- [x] JSONL without \`slug\`, normal name → first 12 chars
- [x] JSONL without \`slug\`, UUID name → hash-based slug
- [x] Two UUID JSONLs in same project, same minute → distinct slugs
- [x] Empty filename stem → graceful fallback
- [x] Filename with only special chars → graceful
- [x] Very short stem (< 8 chars) → used as-is
- [x] Uppercase UUID → matched
- [x] Partial UUID prefix → keeps 12-char prefix path

## Release cadence

Patch (\`1.2.31\` → \`1.2.36\`). Pure correctness fix.