### PR TITLE
chore: release v1.3.0 — consolidate v1.2.x patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,48 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.0] — 2026-04-26
+
+Consolidated minor release rolling up every patch since v1.2.0 — 38 in-tree version bumps across the Opus 4.7 deep code-review backlog (#403), perf budgets, observability, and a handful of new features. No breaking API changes; all of v1.2.x is byte-identical with v1.3.0 at the code level. Per-fix detail is preserved under the [1.2.x] entries below for grep-ability.
+
+### Highlights
+
+**Code review (#403, ~26 issues, all closed)** — every finding from the Opus 4.7 deep review of llmwiki/build.py, convert.py, MCP server, lint rules, and adapters got its own one-issue-one-PR fix with edge-case + e2e test checklists. Headliners:
+
+- `is_subagent` heuristic stopped mis-classifying any project whose name contains "subagent" (#406)
+- `derive_session_slug` UUID-prefix collision fixed — two distinct UUIDs in the same project no longer collapse to the same canonical filename (#424)
+- `_close_open_fence` now counts both `\`\`\`` and `~~~` fences independently — Quarto-style transcripts no longer leak past the truncation point (#419)
+- `wiki_query` MCP ranking gained log-length normalisation — 1MB log pages no longer dominate over relevant 1-paragraph entity pages (#418)
+- `wiki_search` MCP cap (`_SEARCH_HIT_CAP`) prevents pathological-query response blow-ups (#413)
+- Synth-pipeline state file now per-vault — multi-vault overlays no longer cross-contaminate idempotency state (#420)
+- `--force` sync now persists `_meta` / `_counters` / per-key state — `sync --status` audit trail no longer silently lost across forced re-syncs (#426)
+- Subprocess `claude_path` resolution moved to `shutil.which("claude")` with shell-metacharacter rejection — works on every platform, not just brew installs (#421)
+
+**Performance**
+
+- `DuplicateDetection` lint rule rewritten with bucket+fingerprint+SequenceMatcher — 500-page corpus now lints in <1s instead of minutes (#412)
+- New perf-budget test suite (`tests/test_lint_perf.py`, opt-in via `-m slow`) pins wall-clock budgets per rule (#429)
+- `md_to_html` cache key + new `md_to_plain_text` cache (#417)
+- `cmd_all` builds the argparse tree once instead of per-step (#422)
+
+**Features**
+
+- `wiki-all` slash command to invoke the full `sync → synth → build → lint` chain
+- Auto-seeded project stubs (`wiki/projects/<slug>.md`) now pre-populated with `topics:` from session tags/tools and `description:` from the latest session — fresh projects light up the moment the first session lands (#387 · #425)
+- 2 new lint rules: `frontmatter_count_consistency` + `tools_consistency` (#378)
+- New `_context.md` folder convention for cheaper deep queries (#60)
+
+**Quality + observability**
+
+- 23 new test files added across the v1.2.x cycle (`test_force_counters.py`, `test_subprocess_paths.py`, `test_slug_fallback.py`, `test_cmd_all_parser.py`, `test_mcp_safety.py`, `test_vault.py`, `test_lint_perf.py`, `test_path_traversal.py`, `test_is_subagent.py`, …)
+- Unified frontmatter parser with BOM strip + CRLF support (#409 · #423)
+- Strict `is_subagent` checks across every adapter (#406)
+- `sync --force` now refuses silent overwrites; failures land in `.llmwiki-quarantine.json` (#326)
+- Demo-data fidelity audit + `wiki-all` command (#378)
+
+### Detailed changelog
+The 1.2.x entries below document each incremental fix in full. Future minor releases will follow the same pattern: ship patches under `1.x.y` as we go, then consolidate under a clean `1.x+1.0` cut.
+
 ## [1.2.38] — 2026-04-26
 
 Patch release fixing the `--force` sync silently discarding observability metadata + per-key state flagged by the Opus 4.7 code review (#403). Pure correctness fix — default behaviour unchanged; users who run `sync --force` no longer lose their `last_sync` audit trail or get every file re-processed on the next plain sync.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.2.38-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.0-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2068%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
 [![Version](https://img.shields.io/badge/version-v1.3.0-10B981.svg)](CHANGELOG.md)
-[![Tests](https://img.shields.io/badge/tests-2068%20passing-10B981.svg)](tests/)
+[![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)
 [![Wiki checks](https://github.com/Pratiyush/llm-wiki/actions/workflows/wiki-checks.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/wiki-checks.yml)
@@ -33,7 +33,7 @@ Every Claude Code, Codex CLI, Copilot, Cursor, and Gemini CLI session writes a f
 ./build.sh && ./serve.sh           # build + serve at http://127.0.0.1:8765
 ```
 
-<!-- TODO: re-record demo GIF for v1.2 (#248). Removed broken ref to docs/demo.gif. -->
+<!-- TODO: re-record demo GIF for v1.3 (#248). Removed broken ref to docs/demo.gif. -->
 
 
 **Contributing in one line:** read [`CONTRIBUTING.md`](CONTRIBUTING.md), keep PRs focused (one concern each), use `feat:` / `fix:` / `docs:` / `chore:` / `test:` commit prefixes, never commit real session data (`raw/` is gitignored), no new runtime deps. CI must be green to merge.

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -15,6 +15,55 @@ The canonical per-release detail is
 [CHANGELOG.md](https://github.com/Pratiyush/llm-wiki/blob/master/CHANGELOG.md)
 — this guide focuses on "what might break".
 
+## v1.3.0 — consolidated 1.2.x patch roll-up
+
+**Released: 2026-04-26.**
+
+### Summary
+
+Drop-in upgrade from any 1.2.x. v1.3.0 consolidates 38 in-tree
+patch versions (1.2.1 → 1.2.38) under one minor release tag — no
+breaking API changes, no schema migrations, no config changes.
+
+```bash
+pip install -U llm-notebook   # → 1.3.0
+llmwiki --version             # → 1.3.0
+```
+
+### What's in it
+
+The full per-fix detail is preserved under the [1.2.x] entries in
+`CHANGELOG.md`. Two themes:
+
+1. **Opus 4.7 deep code-review backlog (#403, ~26 issues)** — every
+   correctness, perf, and observability finding got a one-issue-one-PR
+   fix. Headliners: `is_subagent` strict path check (#406),
+   `derive_session_slug` UUID-prefix collision (#424), tilde-fence
+   counting in `_close_open_fence` (#419), `wiki_query` ranking
+   length normalisation (#418), `wiki_search` cap (#413), per-vault
+   synth state (#420), `--force` sync persisting `_meta`/`_counters`
+   (#426), subprocess `claude_path` resolved via `shutil.which`
+   (#421).
+
+2. **Performance + features** — `DuplicateDetection` lint rule
+   rewritten with bucket+fingerprint+SequenceMatcher (1s vs minutes
+   on 500 pages, #412), perf-budget test suite (`-m slow`, #429),
+   `md_to_plain_text` cache (#417), auto-seeded project stubs
+   pre-populated from session metadata (#425), 2 new lint rules
+   (`frontmatter_count_consistency`, `tools_consistency`, #378),
+   `wiki-all` slash command, `_context.md` folder convention (#60).
+
+### Breaking — none
+
+Same CLI surface, same config schema, same on-disk state format.
+The only thing that changed is that the next plain `sync` after a
+forced re-sync will now correctly identify already-processed files
+as unchanged (was: re-processed every time, #426).
+
+### Schema migrations — none
+
+State files written by 1.2.x are read verbatim by 1.3.0.
+
 ## v1.2.0 — first stable on the 1.x line
 
 **Released: 2026-04-25.**

--- a/docs/tutorials/00-quickstart-walkthrough.md
+++ b/docs/tutorials/00-quickstart-walkthrough.md
@@ -29,7 +29,7 @@ Verify:
 
 ```
 llmwiki --version
-# -> llmwiki 1.2.0
+# -> llmwiki 1.3.0
 ```
 
 ---

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.2.38"
+__version__ = "1.3.0"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.2.38"
+version = "1.3.0"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Consolidated minor bump rolling up every 1.2.x patch since v1.2.0 — 38 in-tree version bumps across:

- **Opus 4.7 code review (#403)** — full backlog of ~26 issues closed via one-issue-one-PR fixes
- **Performance** — DuplicateDetection rewrite, plain-text cache, perf-budget tests
- **Features** — wiki-all command, auto-seeded project stubs with pre-populated topics/description, 2 new lint rules, _context.md folder convention
- **Quality** — 23 new test files, unified frontmatter parser, strict is_subagent

No breaking API changes. v1.2.x is byte-identical with v1.3.0 at the code level. Per-fix detail preserved under [1.2.x] entries in CHANGELOG.

## After merge

Tag v1.3.0 from master → triggers `release.yml`:
- builds sdist + wheel
- signs with Sigstore
- publishes to PyPI as `llm-notebook` (trusted publisher already configured)
- creates GitHub release with artifacts

## Test plan

- [x] All 38 incremental patches landed via individual PRs each with green CI
- [x] Master health check on v1.2.38: full unit suite green
- [ ] Docs review pass before tag (tutorial, README, deploy docs) — in flight