### PR TITLE
fix: graph viewer theme key mismatch (#477, v1.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.1] — 2026-04-26
+
+Hotfix release fixing the localStorage theme key mismatch between site and graph (#477). One-line correctness fix; graph page now correctly inherits the user's site theme on every visit.
+
+### Fixed
+
+- **Graph page used `localStorage["theme"]`, rest of site used `localStorage["llmwiki-theme"]`** (#477) — the graph viewer never inherited the user's site theme. Toggling theme on the graph also had no effect anywhere else. Compounded by `<html data-theme="dark">` hardcoded in the graph template, so light-mode users always saw a dark graph regardless of preference. Fix: standardise on `llmwiki-theme` in graph.py (read + write); drop the hardcoded `data-theme` attribute and replace with a pre-paint inline script that reads localStorage (then `prefers-color-scheme` fallback, then dark) before first paint to avoid a flash of wrong theme. Adds `tests/test_graph_theme_sync.py` (4 cases) covering both keys removed/standardised, pre-paint script present, and template structure.
+
 ## [1.3.0] — 2026-04-26
 
 Consolidated minor release rolling up every patch since v1.2.0 — 38 in-tree version bumps across the Opus 4.7 deep code-review backlog (#403), perf budgets, observability, and a handful of new features. No breaking API changes; all of v1.2.x is byte-identical with v1.3.0 at the code level. Per-fix detail is preserved under the [1.2.x] entries below for grep-ability.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.0-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.1-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)
@@ -106,6 +106,36 @@ Site-level AI-agent entry points:
 | `/manifest.json` | Build manifest with SHA-256 hashes + perf budget |
 
 Every page also includes an `<!-- llmwiki:metadata -->` HTML comment that AI agents can parse without fetching the separate `.json` sibling.
+
+#### Recipe — query `graph.jsonld` from your terminal
+
+The JSON-LD graph isn't just for crawlers — you can ask quick questions about your wiki without leaving the shell. Example: print every session as a tree, grouped by project:
+
+```bash
+python3 examples/scripts/tree_from_graph.py
+```
+
+Output:
+
+```
+📚 8 sessions across 3 projects
+   (site/graph.jsonld v1.3.0)
+
+llmwiki/
+├── demo-blog-engine/  (4 sessions)
+│   ├── 2026-03-12  scaffolding-the-rust-blog-engine
+│   ├── 2026-03-18  adding-syntax-highlighting
+│   ├── 2026-03-25  rss-feed-and-sitemap
+│   └── 2026-04-01  dark-mode-toggle
+├── demo-ml-pipeline/  (2 sessions)
+│   ├── 2026-01-20  training-data-pipeline
+│   └── 2026-02-02  model-training-loop
+└── demo-todo-api/  (2 sessions)
+    ├── 2026-02-08  fastapi-project-bootstrap
+    └── 2026-02-15  adding-oauth-login
+```
+
+The full script is **stdlib-only** at [`examples/scripts/tree_from_graph.py`](examples/scripts/tree_from_graph.py). Same recipe pattern works for any aggregation question — count sessions per model, find the largest project by token usage, list every entity that appears in 3+ sessions, etc. The graph is yours to slice.
 
 ### Quality & governance (v1.0)
 - **4-factor confidence scoring** — source count, source quality, recency, cross-references; with Ebbinghaus-inspired decay per content-type

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/graph.py
+++ b/llmwiki/graph.py
@@ -203,8 +203,24 @@ def write_json(graph: dict[str, Any], out_path: Path) -> None:
 
 
 HTML_TEMPLATE = r"""<!DOCTYPE html>
-<html lang="en" data-theme="dark">
+<html lang="en">
 <head>
+<script>
+  // #477: read the same localStorage key the rest of the site uses
+  // ("llmwiki-theme") BEFORE first paint to avoid a flash of the wrong
+  // theme. Falls back to system preference, then dark.
+  (function () {
+    try {
+      var t = localStorage.getItem('llmwiki-theme');
+      if (!t) {
+        t = (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) ? 'light' : 'dark';
+      }
+      document.documentElement.setAttribute('data-theme', t);
+    } catch (e) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    }
+  })();
+</script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>llmwiki — Knowledge Graph</title>
@@ -430,13 +446,13 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
 'use strict';
 const GRAPH = __GRAPH_JSON__;
 
-// ─── Theme sync with the main site (localStorage key "theme") ──────────
+// ─── Theme sync with the main site (localStorage key "llmwiki-theme") ──
+// #477: standardise on "llmwiki-theme" so toggling on the graph viewer
+// persists across to the rest of the site (and vice-versa). The pre-paint
+// inline script in <head> already set data-theme; this block wires the
+// toolbar toggle.
 const root = document.documentElement;
-const savedTheme = (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) || 'dark';
-root.setAttribute('data-theme', savedTheme);
-// Null-guard the chrome controls — when the graph viewer is rendered as a
-// minimal placeholder (e.g. seeded corpus with zero edges) the toolbar may
-// be omitted but this script still runs. Closes #386.
+const savedTheme = root.getAttribute('data-theme') || 'dark';
 const themeLabel = document.getElementById('theme-label');
 if (themeLabel) themeLabel.textContent = savedTheme;
 const themeToggle = document.getElementById('theme-toggle');
@@ -444,7 +460,7 @@ if (themeToggle) themeToggle.addEventListener('click', () => {
   const next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
   root.setAttribute('data-theme', next);
   if (themeLabel) themeLabel.textContent = next;
-  try { localStorage.setItem('theme', next); } catch (_) { /* private mode */ }
+  try { localStorage.setItem('llmwiki-theme', next); } catch (_) { /* private mode */ }
 });
 
 // ─── Check vis-network loaded (local fallback hook) ────────────────────

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.0"
+version = "1.3.1"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_graph_theme_sync.py
+++ b/tests/test_graph_theme_sync.py
@@ -1,0 +1,65 @@
+"""Tests for #477 — graph viewer theme key sync with the rest of the site.
+
+The bug: `llmwiki/graph.py` wrote `localStorage["theme"]` but the rest of
+the site uses `localStorage["llmwiki-theme"]`. Toggling theme on the
+graph never persisted to /, /docs/, /sessions/, etc., and vice-versa.
+The graph template also hardcoded `<html data-theme="dark">` so light-
+mode users always saw a dark graph regardless of OS / site preference.
+
+The fix:
+  1. Standardise on `llmwiki-theme` for both read + write in graph.py.
+  2. Drop the hardcoded `data-theme="dark"` attribute on `<html>`.
+  3. Add a pre-paint inline `<script>` that reads localStorage (with
+     `prefers-color-scheme` fallback) BEFORE first paint to eliminate
+     the flash of wrong theme.
+"""
+
+from __future__ import annotations
+
+from llmwiki.graph import HTML_TEMPLATE
+
+
+def test_graph_template_uses_llmwiki_theme_key():
+    """No remaining `localStorage.getItem('theme')` or `setItem('theme'`."""
+    # The legacy bare 'theme' key must be gone everywhere in the template.
+    assert "localStorage.getItem('theme')" not in HTML_TEMPLATE
+    assert "localStorage.setItem('theme'" not in HTML_TEMPLATE
+    # The site's canonical key is the only one used.
+    assert "localStorage.getItem('llmwiki-theme')" in HTML_TEMPLATE
+    assert "localStorage.setItem('llmwiki-theme'" in HTML_TEMPLATE
+
+
+def test_graph_template_has_no_hardcoded_data_theme_dark():
+    """`<html data-theme="dark">` was the override that broke light mode.
+
+    The pre-paint script sets the attribute from storage; the markup
+    must not race against it.
+    """
+    assert '<html lang="en" data-theme="dark">' not in HTML_TEMPLATE
+    # The only `<html>` tag should be the bare lang-only form.
+    assert '<html lang="en">' in HTML_TEMPLATE
+
+
+def test_graph_template_has_pre_paint_theme_script():
+    """The pre-paint script must run inside <head> before the body
+    renders so users never see a flash of wrong theme."""
+    head_start = HTML_TEMPLATE.find("<head>")
+    head_end = HTML_TEMPLATE.find("</head>")
+    assert head_start > 0 and head_end > head_start
+    head = HTML_TEMPLATE[head_start:head_end]
+    # The pre-paint script must reference the canonical key + the
+    # prefers-color-scheme fallback.
+    assert "llmwiki-theme" in head
+    assert "prefers-color-scheme" in head
+    assert "data-theme" in head
+
+
+def test_graph_template_toggle_writes_canonical_key():
+    """Clicking the toolbar toggle must persist via the canonical key."""
+    # Find the toggle handler block. It writes via setItem.
+    toggle_section = HTML_TEMPLATE[HTML_TEMPLATE.find("themeToggle.addEventListener"):]
+    # Sanity: the handler exists at all.
+    assert "themeToggle.addEventListener" in HTML_TEMPLATE
+    # And it writes to the canonical key only.
+    assert "localStorage.setItem('llmwiki-theme'" in toggle_section
+    assert "localStorage.setItem('theme'" not in toggle_section

--- a/tests/test_graph_viewer.py
+++ b/tests/test_graph_viewer.py
@@ -133,9 +133,12 @@ def test_template_has_cluster_toggle():
 
 def test_template_has_theme_toggle_and_localstorage():
     assert 'id="theme-toggle"' in HTML_TEMPLATE
-    # Must persist the user's choice across reloads
-    assert "localStorage.setItem('theme'" in HTML_TEMPLATE
-    assert "localStorage.getItem('theme'" in HTML_TEMPLATE
+    # Must persist the user's choice across reloads + share the same
+    # localStorage key as the rest of the site so dark/light syncs both
+    # ways (#477). The legacy bare 'theme' key is intentionally absent —
+    # see tests/test_graph_theme_sync.py for the dedicated regression set.
+    assert "localStorage.setItem('llmwiki-theme'" in HTML_TEMPLATE
+    assert "localStorage.getItem('llmwiki-theme'" in HTML_TEMPLATE
 
 
 def test_template_uses_css_vars_for_theme():
@@ -197,10 +200,11 @@ def test_write_html_escapes_closing_script_tag(tmp_path: Path):
     out = tmp_path / "g.html"
     write_html(g, out)
     text = out.read_text(encoding="utf-8")
-    # Two real </script> tags exist in the template (CDN loader +
-    # inline block). A third would mean the </script> inside the
-    # label injected out of the payload — catch that.
-    assert text.count("</script>") == 2
+    # Three real </script> tags exist in the template now (#477 added
+    # a pre-paint inline script in <head> alongside the CDN loader and
+    # the main inline block). A fourth would mean the </script> inside
+    # the label injected out of the payload — catch that.
+    assert text.count("</script>") == 3
     # And the escaped form should be present inside the JSON payload.
     assert "<\\/script>" in text
 


### PR DESCRIPTION
Closes #477.

## Problem

Graph viewer wrote \`localStorage['theme']\`, rest of site uses \`localStorage['llmwiki-theme']\`. Toggling theme on graph never persisted; \`<html data-theme=\"dark\">\` was hardcoded so light-mode users always saw dark graph.

## Fix

- Standardise on \`llmwiki-theme\` for both read + write in graph.py
- Drop hardcoded \`data-theme=\"dark\"\` attribute on \`<html>\`
- Add pre-paint inline \`<script>\` in \`<head>\` that reads localStorage (then prefers-color-scheme, then dark) before first paint — eliminates flash of wrong theme

## Test plan

- [x] \`pytest tests/test_graph_theme_sync.py\` — 4/4 pass
- [x] No remaining \`localStorage.getItem('theme')\` or \`setItem('theme'\` in graph.py
- [x] Pre-paint script present in \`<head>\`, references \`llmwiki-theme\` + \`prefers-color-scheme\`