### PR TITLE
fix: add viewport-fit=cover so iOS exposes safe-area inset (#481, v1.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.2] — 2026-04-26
+
+Hotfix release adding `viewport-fit=cover` so iOS Safari exposes safe-area insets, fixing the mobile bottom nav overlap with the iPhone home indicator (#481).
+
+### Fixed
+
+- **Mobile bottom nav `env(safe-area-inset-bottom)` returned 0 on iOS** (#481) — `render/css.py:673` mobile bottom nav padded with `calc(6px + env(safe-area-inset-bottom, 0px))` to clear the iPhone home indicator. But the `<meta name="viewport">` in `build.py:622, 659` was missing `viewport-fit=cover`, so Safari iOS reported the inset as 0. The bottom nav rendered flush against the home indicator, and the system swipe-up gesture intercepted taps on the rightmost Theme + Search buttons. Fix: add `viewport-fit=cover` to both `page_head` and `page_head_article` viewport meta tags. Adds `tests/test_viewport_meta.py` (3 cases) asserting both meta tags carry the directive.
+
 ## [1.3.1] — 2026-04-26
 
 Hotfix release fixing the localStorage theme key mismatch between site and graph (#477). One-line correctness fix; graph page now correctly inherits the user's site theme on every visit.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.1-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.2-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/build.py
+++ b/llmwiki/build.py
@@ -619,7 +619,7 @@ def page_head(title: str, description: str, css_prefix: str = "") -> str:
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>{html.escape(title)}</title>
   <meta name="description" content="{html.escape(description)}">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -656,7 +656,7 @@ def page_head_article(
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>{html.escape(title)}</title>
   <meta name="description" content="{html.escape(description)}">
 {canonical_tag}{og_tags}  <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.1"
+version = "1.3.2"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_viewport_meta.py
+++ b/tests/test_viewport_meta.py
@@ -1,0 +1,50 @@
+"""Tests for #481 — viewport meta tag must include `viewport-fit=cover`.
+
+Without `viewport-fit=cover`, iOS Safari does NOT expose safe-area inset
+values to CSS (`env(safe-area-inset-bottom)` returns 0). The mobile
+bottom nav at `render/css.py:673` relies on that inset to clear the
+iPhone home indicator. Missing it = bottom nav buttons sit under the
+swipe-up gesture region and become un-tappable.
+
+Both viewport meta tags emitted by `build.py` (the regular page head
+and the article-style page head) must carry the directive.
+"""
+
+from __future__ import annotations
+
+import re
+
+from llmwiki.build import page_head, page_head_article
+
+
+_VIEWPORT_RE = re.compile(r'<meta name="viewport" content="([^"]+)">')
+
+
+def test_page_head_viewport_meta_has_viewport_fit_cover():
+    head = page_head("Test", "")
+    m = _VIEWPORT_RE.search(head)
+    assert m, f"no viewport meta tag in page_head output:\n{head[:500]}"
+    content = m.group(1)
+    assert "viewport-fit=cover" in content, (
+        f"page_head viewport missing viewport-fit=cover: {content!r}"
+    )
+
+
+def test_page_head_article_viewport_meta_has_viewport_fit_cover():
+    head = page_head_article("Test", description="x")
+    m = _VIEWPORT_RE.search(head)
+    assert m, f"no viewport meta tag in page_head_article output:\n{head[:500]}"
+    content = m.group(1)
+    assert "viewport-fit=cover" in content, (
+        f"page_head_article viewport missing viewport-fit=cover: {content!r}"
+    )
+
+
+def test_viewport_meta_keeps_legacy_directives():
+    """Don't regress the existing width + initial-scale parts."""
+    for head in (page_head("T", ""), page_head_article("T", description="x")):
+        m = _VIEWPORT_RE.search(head)
+        assert m
+        content = m.group(1)
+        assert "width=device-width" in content
+        assert "initial-scale=1" in content


### PR DESCRIPTION
Closes #481.

## Problem

Mobile bottom nav padding uses `env(safe-area-inset-bottom)` to clear the iPhone home indicator. The viewport meta tag was missing `viewport-fit=cover` → iOS Safari returned 0 for the inset → bottom nav buttons sat under the swipe-up gesture region.

## Fix

Add `viewport-fit=cover` to both viewport meta tags (`page_head` + `page_head_article` in build.py).

## Test plan

- [x] `pytest tests/test_viewport_meta.py` — 3/3 pass
- [x] Both meta tags carry the directive
- [x] Existing width + initial-scale parts preserved (regression guard)