### PR TITLE
fix: rename queue.py → ingest_queue.py to unshadow stdlib (#491, v1.3.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.4] — 2026-04-26
+
+Hotfix release renaming `llmwiki/queue.py` → `llmwiki/ingest_queue.py` to stop shadowing the Python stdlib `queue` module (#491).
+
+### Changed
+
+- **Renamed `llmwiki.queue` → `llmwiki.ingest_queue`** (#491) — naming a module `queue.py` shadows Python's stdlib `queue`, breaking any future code inside `llmwiki/` that wants `queue.Queue` for thread-safe primitives. Pylint/ruff also flag this anti-pattern. Renamed the module to `ingest_queue` (matches the actual purpose — pending-source ingest queue, not a generic queue). Old `llmwiki/queue.py` becomes a back-compat shim that re-exports the public API and emits a `DeprecationWarning` so any third-party code keeps working through one minor cycle. Will be removed in v1.5. Adds `tests/test_ingest_queue_shim.py` (3 cases) covering the rename, the shim's deprecation warning, and the stdlib `queue` import inside `llmwiki/` working correctly.
+
 ## [1.3.3] — 2026-04-26
 
 Hotfix release fixing yellow chip contrast failure flagged by the Opus UI/UX audit (#480).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.3-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.4-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.3"
+__version__ = "1.3.4"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/ingest_queue.py
+++ b/llmwiki/ingest_queue.py
@@ -1,0 +1,101 @@
+"""Pending ingest queue (v1.0 · #148).
+
+Tracks files that have been converted to raw/ but not yet ingested
+into wiki/. The SessionStart hook adds files here after conversion;
+``/wiki-sync`` processes and clears the queue.
+
+State is stored in ``.llmwiki-queue.json`` — a simple JSON array of
+file paths relative to the repo root.
+
+Usage::
+
+    from llmwiki.ingest_queue import enqueue, dequeue, peek, clear, queue_path
+
+    # Hook adds after conversion
+    enqueue(["raw/sessions/2026-04-16T10-30-proj-slug.md"])
+
+    # /wiki-sync reads and processes
+    pending = dequeue()   # returns list and clears queue
+    for path in pending:
+        ingest(path)
+
+    # Or peek without consuming
+    pending = peek()
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from llmwiki import REPO_ROOT
+
+DEFAULT_QUEUE_FILE = REPO_ROOT / ".llmwiki-queue.json"
+
+
+def _load(queue_file: Optional[Path] = None) -> list[str]:
+    """Load the queue file. Returns list of relative paths."""
+    qf = queue_file or DEFAULT_QUEUE_FILE
+    if not qf.is_file():
+        return []
+    try:
+        data = json.loads(qf.read_text(encoding="utf-8"))
+        if isinstance(data, list):
+            return [str(p) for p in data if isinstance(p, str)]
+    except (json.JSONDecodeError, OSError):
+        pass
+    return []
+
+
+def _save(items: list[str], queue_file: Optional[Path] = None) -> None:
+    """Save the queue file."""
+    qf = queue_file or DEFAULT_QUEUE_FILE
+    qf.write_text(
+        json.dumps(sorted(set(items)), indent=2), encoding="utf-8"
+    )
+
+
+def enqueue(
+    paths: list[str],
+    *,
+    queue_file: Optional[Path] = None,
+) -> int:
+    """Add paths to the pending ingest queue.
+
+    Deduplicates automatically. Returns the new queue length.
+    """
+    current = _load(queue_file)
+    combined = list(set(current) | set(paths))
+    _save(combined, queue_file)
+    return len(combined)
+
+
+def dequeue(*, queue_file: Optional[Path] = None) -> list[str]:
+    """Return all pending paths and clear the queue.
+
+    This is the consume operation — after calling this, the queue
+    is empty. Process the returned paths, then they're done.
+    """
+    items = _load(queue_file)
+    qf = queue_file or DEFAULT_QUEUE_FILE
+    if qf.is_file():
+        qf.write_text("[]", encoding="utf-8")
+    return items
+
+
+def peek(*, queue_file: Optional[Path] = None) -> list[str]:
+    """Return pending paths without consuming them."""
+    return _load(queue_file)
+
+
+def clear(*, queue_file: Optional[Path] = None) -> None:
+    """Clear the queue without reading."""
+    qf = queue_file or DEFAULT_QUEUE_FILE
+    if qf.is_file():
+        qf.write_text("[]", encoding="utf-8")
+
+
+def queue_size(*, queue_file: Optional[Path] = None) -> int:
+    """Return the number of pending items."""
+    return len(_load(queue_file))

--- a/llmwiki/queue.py
+++ b/llmwiki/queue.py
@@ -1,101 +1,29 @@
-"""Pending ingest queue (v1.0 · #148).
+"""Back-compat shim — the queue module was renamed to ``ingest_queue``.
 
-Tracks files that have been converted to raw/ but not yet ingested
-into wiki/. The SessionStart hook adds files here after conversion;
-``/wiki-sync`` processes and clears the queue.
+#491: shadowing the stdlib ``queue`` module is an anti-pattern that
+breaks any code inside ``llmwiki/`` wanting ``queue.Queue`` for
+thread-safe primitives. The real implementation now lives at
+``llmwiki/ingest_queue.py``. This shim re-exports the public API so
+existing third-party imports keep working through one minor cycle.
 
-State is stored in ``.llmwiki-queue.json`` — a simple JSON array of
-file paths relative to the repo root.
-
-Usage::
-
-    from llmwiki.queue import enqueue, dequeue, peek, clear, queue_path
-
-    # Hook adds after conversion
-    enqueue(["raw/sessions/2026-04-16T10-30-proj-slug.md"])
-
-    # /wiki-sync reads and processes
-    pending = dequeue()   # returns list and clears queue
-    for path in pending:
-        ingest(path)
-
-    # Or peek without consuming
-    pending = peek()
+Deprecated as of v1.3.4. Remove in v1.5.
 """
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
-from typing import Optional
+import warnings
 
-from llmwiki import REPO_ROOT
+from llmwiki.ingest_queue import (  # noqa: F401
+    enqueue,
+    dequeue,
+    peek,
+    clear,
+    queue_size,
+)
 
-DEFAULT_QUEUE_FILE = REPO_ROOT / ".llmwiki-queue.json"
-
-
-def _load(queue_file: Optional[Path] = None) -> list[str]:
-    """Load the queue file. Returns list of relative paths."""
-    qf = queue_file or DEFAULT_QUEUE_FILE
-    if not qf.is_file():
-        return []
-    try:
-        data = json.loads(qf.read_text(encoding="utf-8"))
-        if isinstance(data, list):
-            return [str(p) for p in data if isinstance(p, str)]
-    except (json.JSONDecodeError, OSError):
-        pass
-    return []
-
-
-def _save(items: list[str], queue_file: Optional[Path] = None) -> None:
-    """Save the queue file."""
-    qf = queue_file or DEFAULT_QUEUE_FILE
-    qf.write_text(
-        json.dumps(sorted(set(items)), indent=2), encoding="utf-8"
-    )
-
-
-def enqueue(
-    paths: list[str],
-    *,
-    queue_file: Optional[Path] = None,
-) -> int:
-    """Add paths to the pending ingest queue.
-
-    Deduplicates automatically. Returns the new queue length.
-    """
-    current = _load(queue_file)
-    combined = list(set(current) | set(paths))
-    _save(combined, queue_file)
-    return len(combined)
-
-
-def dequeue(*, queue_file: Optional[Path] = None) -> list[str]:
-    """Return all pending paths and clear the queue.
-
-    This is the consume operation — after calling this, the queue
-    is empty. Process the returned paths, then they're done.
-    """
-    items = _load(queue_file)
-    qf = queue_file or DEFAULT_QUEUE_FILE
-    if qf.is_file():
-        qf.write_text("[]", encoding="utf-8")
-    return items
-
-
-def peek(*, queue_file: Optional[Path] = None) -> list[str]:
-    """Return pending paths without consuming them."""
-    return _load(queue_file)
-
-
-def clear(*, queue_file: Optional[Path] = None) -> None:
-    """Clear the queue without reading."""
-    qf = queue_file or DEFAULT_QUEUE_FILE
-    if qf.is_file():
-        qf.write_text("[]", encoding="utf-8")
-
-
-def queue_size(*, queue_file: Optional[Path] = None) -> int:
-    """Return the number of pending items."""
-    return len(_load(queue_file))
+warnings.warn(
+    "llmwiki.queue is deprecated and will be removed in v1.5. "
+    "Use llmwiki.ingest_queue instead (#491).",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.3"
+version = "1.3.4"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_ingest_queue_shim.py
+++ b/tests/test_ingest_queue_shim.py
@@ -1,0 +1,56 @@
+"""Tests for #491 — `llmwiki/queue.py` rename to `llmwiki/ingest_queue.py`.
+
+The original `llmwiki/queue.py` shadowed the Python stdlib `queue`
+module, breaking any code inside `llmwiki/` that wanted to import
+`queue.Queue` for thread-safe primitives. Renamed to
+`llmwiki.ingest_queue` (matches the actual purpose — pending-source
+ingest queue, not a generic queue). Old name kept as a deprecation
+shim through one minor cycle.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+
+def test_canonical_module_imports_cleanly():
+    """The new home is `llmwiki.ingest_queue`."""
+    from llmwiki import ingest_queue
+    assert hasattr(ingest_queue, "enqueue")
+    assert hasattr(ingest_queue, "dequeue")
+    assert hasattr(ingest_queue, "queue_size")
+
+
+def test_legacy_shim_re_exports_with_deprecation_warning():
+    """`llmwiki.queue` still imports — but warns."""
+    # Drop any prior cached import so the shim's warnings.warn fires.
+    import importlib
+    import sys
+
+    sys.modules.pop("llmwiki.queue", None)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        from llmwiki import queue as legacy_queue  # noqa: F401
+        importlib.reload(legacy_queue)
+    msgs = [str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert any("llmwiki.queue" in m for m in msgs), (
+        f"expected DeprecationWarning mentioning llmwiki.queue, got {msgs}"
+    )
+    # Public API still works through the shim
+    assert hasattr(legacy_queue, "enqueue")
+    assert hasattr(legacy_queue, "queue_size")
+
+
+def test_stdlib_queue_import_unshadowed():
+    """A bare `import queue` from inside `llmwiki/` resolves to stdlib.
+
+    This is the reason for the rename — before #491, this test would
+    have surfaced the shim instead of the stdlib's thread-safe Queue.
+    """
+    import queue as stdlib_queue
+    # The stdlib `queue` module has `Queue`, `LifoQueue`, `PriorityQueue` —
+    # none of which the llmwiki shim exposes.
+    assert hasattr(stdlib_queue, "Queue")
+    assert hasattr(stdlib_queue, "LifoQueue")
+    assert hasattr(stdlib_queue, "PriorityQueue")

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from llmwiki.queue import enqueue, dequeue, peek, clear, queue_size
+from llmwiki.ingest_queue import enqueue, dequeue, peek, clear, queue_size
 
 
 # ─── Basic operations ──────────────────────────────────────────────────


### PR DESCRIPTION
Closes #491.

`llmwiki/queue.py` shadowed the Python stdlib `queue` module — anti-pattern flagged by Pylint/ruff. Renamed to `llmwiki/ingest_queue.py` (matches purpose). Old name kept as back-compat deprecation shim through v1.4; removed in v1.5.

## Test plan

- [x] `pytest tests/test_ingest_queue_shim.py tests/test_queue.py` — 17 pass
- [x] Bare `import queue` from inside llmwiki/ now resolves to stdlib (regression test)
- [x] Legacy `from llmwiki.queue import …` still works + emits DeprecationWarning