### PR TITLE
fix: scrub stale llmwiki watch + export-obsidian refs from docs (#494, v1.3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.5] — 2026-04-26
+
+Hotfix release scrubbing stale references to `llmwiki watch` and `llmwiki export-obsidian` from the README + docs (#494). Both subcommands were removed in v1.2.0 (see UPGRADING.md) but the README CLI table + 2 docs still advertised them, breaking new-user trust on first try.
+
+### Removed (docs only)
+
+- **README CLI table** dropped the `llmwiki watch` + `llmwiki export-obsidian` rows
+- **`docs/multi-agent-setup.md`** replaced "Use `llmwiki watch`" with the documented `launchd`/`systemd`/Task Scheduler path
+- **`docs/modes/api/index.md`** same replacement
+- **`llmwiki/watch.py`** docstring updated to reflect that the CLI subcommand is gone; the helper functions (`scan_mtimes`, `run_sync`) survive as a small library so `tests/test_v02.py` keeps working
+
+Adds `tests/test_cli_doc_parity.py` (1 case) — a CI guard that asserts every `llmwiki <subcommand>` line in the README CLI table corresponds to an actual subparser in `cli.py:build_parser()`. Future stale entries fail CI before they reach a release.
+
 ## [1.3.4] — 2026-04-26
 
 Hotfix release renaming `llmwiki/queue.py` → `llmwiki/ingest_queue.py` to stop shadowing the Python stdlib `queue` module (#491).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.4-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.5-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)
@@ -365,8 +365,6 @@ llmwiki build                   # compile static HTML + AI exports
 llmwiki serve                   # local HTTP server on 127.0.0.1:8765
 llmwiki adapters                # list available adapters + configured state (v1.0)
 llmwiki graph                   # build knowledge graph (v0.2)
-llmwiki watch                   # file watcher with debounce (v0.2)
-llmwiki export-obsidian         # write wiki to Obsidian vault (v0.2)
 llmwiki lint                    # 16-rule wiki lint (v1.2)
 llmwiki export <format>         # AI-consumable exports (v0.4)
 llmwiki synthesize              # auto-ingest synthesis pipeline (v0.5)

--- a/docs/modes/api/index.md
+++ b/docs/modes/api/index.md
@@ -63,7 +63,7 @@ llmwiki build && llmwiki serve --open
 
 - Large corpora (100+ sessions) where serial Agent-mode synthesis
   would take hours.
-- Headless runs: cron, CI, `llmwiki watch` daemon.
+- Headless runs: cron, CI, `launchd` / `systemd` scheduling of `llmwiki sync`.
 - Shared server (multiple developers syncing into one wiki) — the API
   key belongs to the server, not individual laptops.
 

--- a/docs/multi-agent-setup.md
+++ b/docs/multi-agent-setup.md
@@ -128,5 +128,5 @@ Override adapter paths in `config.json`:
 1. **Use `--adapter` to test one agent at a time** when debugging sync issues.
 2. **Each agent gets its own project slug** derived from its session store layout, so sessions from different agents never collide.
 3. **The wiki layer is agent-agnostic.** Once sessions are in `raw/`, the wiki ingest treats them identically regardless of which agent produced them.
-4. **Use `llmwiki watch`** to auto-sync across all agents in real time as you work.
+4. **Schedule `llmwiki sync`** via `launchd` / `systemd` / Task Scheduler for periodic auto-sync across all agents (the `llmwiki watch` daemon was removed in v1.2.0 — see `docs/UPGRADING.md`).
 5. **Combine with `.llmwikiignore`** to skip noisy agents or specific projects from any adapter.

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.4"
+__version__ = "1.3.5"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/watch.py
+++ b/llmwiki/watch.py
@@ -1,19 +1,17 @@
-"""File watcher — auto-resync when a new .jsonl lands in an agent's session store.
+"""File watcher — library helpers for auto-resync on session-store changes.
 
-Watches the session store paths that registered adapters know about, and when
-a file changes, runs `llmwiki sync` in the background. Useful as an
-alternative to the SessionStart hook.
+#494 (v1.3.5): the `llmwiki watch` CLI subcommand was removed in v1.2.0
+(see docs/UPGRADING.md). This module survives as a small library: the
+`scan_mtimes()` and `run_sync()` helpers still have legitimate callers
+(unit tests, third-party code wiring its own polling loop), but there
+is no longer a `python3 -m llmwiki watch` entry point. Schedule
+`llmwiki sync` directly via `launchd` / `systemd` / Task Scheduler if
+you need scheduled re-syncs.
 
-Uses polling (stdlib-only, no `watchdog` dep). Polls every N seconds; when a
-file's mtime changes, debounces for M seconds before running sync.
-
-Usage:
-
-    python3 -m llmwiki watch                  # default 5s poll, 10s debounce
-    python3 -m llmwiki watch --interval 2     # faster polling
-    python3 -m llmwiki watch --adapter claude_code
-
-Stop with Ctrl+C.
+Uses polling (stdlib-only, no `watchdog` dep). The CLI shim at the
+bottom of this module is preserved for the rare case where someone
+runs `python3 llmwiki/watch.py` directly — it prints a deprecation
+notice and exits.
 """
 
 from __future__ import annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.4"
+version = "1.3.5"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_cli_doc_parity.py
+++ b/tests/test_cli_doc_parity.py
@@ -1,0 +1,57 @@
+"""Tests for #494 — README CLI table must list real subcommands only.
+
+The bug: README.md advertised `llmwiki watch` and `llmwiki
+export-obsidian` long after both were removed in v1.2.0. New users
+ran them, hit `unrecognized arguments`, lost trust.
+
+This test parses the README's CLI fenced block, extracts every
+`llmwiki <subcommand>` line, and asserts each one is registered as
+a subparser in `cli.py:build_parser()`. CI will fail any future PR
+that adds a stale entry.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from llmwiki.cli import build_parser
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+README = REPO_ROOT / "README.md"
+
+# Match `llmwiki <name>` at start of a line inside the CLI fenced block.
+_LINE_RE = re.compile(r"^llmwiki\s+([a-z][a-z0-9-]*)\b", re.MULTILINE)
+
+
+def _collect_real_subcommands() -> set[str]:
+    """Return the set of registered subparser names."""
+    parser = build_parser()
+    for action in parser._actions:
+        if hasattr(action, "choices") and isinstance(action.choices, dict):
+            return set(action.choices)
+    raise AssertionError("could not locate subparsers on build_parser()")
+
+
+def _collect_readme_subcommands() -> set[str]:
+    text = README.read_text(encoding="utf-8")
+    m = re.search(r"## CLI reference\b.*?(?=\n## |\Z)", text, re.DOTALL)
+    assert m, "could not find '## CLI reference' section in README"
+    block = m.group(0)
+    # Drop the `llmwiki version` line — it's a flag/subcommand convention,
+    # may not have its own subparser.
+    return {name for name in _LINE_RE.findall(block) if name != "version"}
+
+
+def test_every_readme_cli_line_maps_to_a_real_subparser():
+    """Every `llmwiki <name>` in README.md must exist as a real
+    subparser. Closes #494."""
+    real = _collect_real_subcommands()
+    advertised = _collect_readme_subcommands()
+    phantom = advertised - real
+    assert not phantom, (
+        f"README CLI table advertises subcommands that don't exist: "
+        f"{sorted(phantom)}. Real subparsers: {sorted(real)}. "
+        f"Either wire up the missing subparsers in cli.py:build_parser() or "
+        f"remove the lines from README.md (the original bug, #494)."
+    )


### PR DESCRIPTION
Closes #494.

README CLI table + 2 docs advertised `llmwiki watch` and `llmwiki export-obsidian` long after both were removed in v1.2.0 (see UPGRADING.md). Users hit 'unrecognized arguments' on first try.

Cleaned up README + docs. Added `tests/test_cli_doc_parity.py` — CI guard so future stale entries fail before merge.

## Test plan

- [x] `pytest tests/test_cli_doc_parity.py tests/test_v02.py` — 21 pass
- [x] README CLI block now matches `build_parser()` subparsers
- [x] Watch helpers still importable for existing test consumers