### PR TITLE
fix: renderer must read is_subagent frontmatter, not substring rule (#492, v1.3.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.6] — 2026-04-26
+
+Hotfix release closing the renderer-side half of the `is_subagent` regression that #406 fixed at the adapter level (#492). Sub-agent classification was correct in the frontmatter but wrong in the rendered UI for any project with "subagent" in a session filename.
+
+### Fixed
+
+- **Renderer used the broken substring rule across 5 sites** (#492) — PR #406 fixed `is_subagent` at the adapter layer (strict canonical-path check, writes correct `is_subagent: true|false` into frontmatter). But `build.py` never read the frontmatter field; it re-implemented the old `'subagent' in p.name` substring check in 5 separate places (`render_project_page`, `render_projects_index`, `render_index`, project-card stats, JSON schema emit). Result: any session in any project with "subagent" in its filename was demoted from main-session counts in the UI even though the adapter classified it correctly. Fix: new `_is_subagent(meta, path)` helper that prefers the frontmatter field (`true`/`false` bool, plus `"true"/"false"` string coerce for legacy parsers), falls back to the substring check only when the field is missing (pre-#406 raw files). All 5 sites now route through the helper. Adds `tests/test_render_is_subagent.py` (8 cases) covering the frontmatter precedence, all 6 string-bool variants, the substring fallback for missing field, and a regression vs the bug pattern (project named `subagent-runner` whose sessions were misclassified).
+
 ## [1.3.5] — 2026-04-26
 
 Hotfix release scrubbing stale references to `llmwiki watch` and `llmwiki export-obsidian` from the README + docs (#494). Both subcommands were removed in v1.2.0 (see UPGRADING.md) but the README CLI table + 2 docs still advertised them, breaking new-user trust on first try.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.5-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.6-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.5"
+__version__ = "1.3.6"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/build.py
+++ b/llmwiki/build.py
@@ -127,6 +127,36 @@ def _safe_slug(value: str | None, *, fallback: str = "_unknown") -> str:
     return s
 
 
+def _is_subagent(meta: dict[str, Any], path: Path) -> bool:
+    """Return True iff a session is a sub-agent run (#492 / #406).
+
+    Prefers the adapter-written ``is_subagent`` frontmatter field
+    (canonical contract since #406). Falls back to the legacy
+    ``"subagent" in path.name`` substring check ONLY if the field is
+    missing — needed to keep pre-#406 raw files classified correctly
+    until they're re-synced.
+
+    Accepts the field as either a real bool or one of the
+    case-insensitive strings ``"true"`` / ``"false"`` since
+    frontmatter parsers historically coerced inconsistently.
+    """
+    raw = meta.get("is_subagent")
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, str):
+        s = raw.strip().lower()
+        if s in ("true", "yes", "1"):
+            return True
+        if s in ("false", "no", "0"):
+            return False
+    # Field absent or unrecognised — fall back to the legacy heuristic
+    # so pre-#406 raw files (no is_subagent field) still get the right
+    # answer. The renderer renames sub-agent slugs to
+    # `<slug>-subagent-<id>`, so the substring match is correct on
+    # canonically-renamed files even when meta is missing.
+    return "subagent" in path.name
+
+
 def discover_sources(root: Path) -> list[tuple[Path, dict[str, Any], str]]:
     out: list[tuple[Path, dict[str, Any], str]] = []
     if not root.exists():
@@ -1015,7 +1045,7 @@ def render_project_page(
     sessions: list[tuple[Path, dict[str, Any], str]],
     out_dir: Path,
 ) -> Path:
-    main_sessions = [s for s in sessions if "subagent" not in s[0].name]
+    main_sessions = [s for s in sessions if not _is_subagent(s[1], s[0])]
     subagent_sessions = [s for s in sessions if s not in main_sessions]
 
     def card(p: Path, meta: dict[str, Any]) -> str:
@@ -1175,7 +1205,7 @@ def render_projects_index(
 ) -> Path:
     cards = []
     for project, sessions in sorted(groups.items(), key=lambda x: -len(x[1])):
-        main_count = sum(1 for p, _, _ in sessions if "subagent" not in p.name)
+        main_count = sum(1 for p, m, _ in sessions if not _is_subagent(m, p))
         sub_count = len(sessions) - main_count
         # Freshness reflects the newest session in the project.
         newest_meta = max(
@@ -1336,7 +1366,7 @@ def render_index(
     synthesis: Optional[str] = None,
 ) -> Path:
     total = len(all_sources)
-    mains = sum(1 for p, _, _ in all_sources if "subagent" not in p.name)
+    mains = sum(1 for p, m, _ in all_sources if not _is_subagent(m, p))
     subs = total - mains
 
     synth_block = ""
@@ -1389,7 +1419,7 @@ def render_index(
 
     cards = []
     for project, sessions in sorted(groups.items(), key=lambda x: -len(x[1])):
-        main_count = sum(1 for p, _, _ in sessions if "subagent" not in p.name)
+        main_count = sum(1 for p, m, _ in sessions if not _is_subagent(m, p))
         # Project topics — explicit profile in wiki/projects/<slug>.md
         # takes precedence, falls back to aggregated session tags with
         # noise filtered out. Rendered as chips below the card meta.
@@ -2048,7 +2078,7 @@ def synthesize_overview(
     for project, sessions in sorted(groups.items()):
         brief[project] = {
             "session_count": len(sessions),
-            "main_sessions": sum(1 for p, _, _ in sessions if "subagent" not in p.name),
+            "main_sessions": sum(1 for p, m, _ in sessions if not _is_subagent(m, p)),
             "dates": sorted({str(m.get("date", "")) for _, m, _ in sessions if m.get("date")}),
             "models": sorted({str(m.get("model", "")) for _, m, _ in sessions if m.get("model")}),
             "slugs": [str(m.get("slug", p.stem)) for p, m, _ in sessions[:8]],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.5"
+version = "1.3.6"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_render_is_subagent.py
+++ b/tests/test_render_is_subagent.py
@@ -1,0 +1,68 @@
+"""Tests for #492 — renderer must read `is_subagent` frontmatter, not
+re-implement the old broken substring rule.
+
+The bug: PR #406 fixed `is_subagent` at the adapter layer (strict
+canonical-path check, writes correct `is_subagent: true|false` into
+frontmatter). But `build.py` never read the frontmatter field; it
+re-implemented the old `'subagent' in p.name` substring check in 5
+separate places. Any session in any project with "subagent" in its
+filename was misclassified in the rendered UI.
+
+The fix: new `_is_subagent(meta, path)` helper that prefers the
+frontmatter field, falls back to the substring check only when the
+field is missing (back-compat for pre-#406 raw files).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from llmwiki.build import _is_subagent
+
+
+def test_explicit_true_returns_true():
+    assert _is_subagent({"is_subagent": True}, Path("anything.md")) is True
+
+
+def test_explicit_false_returns_false_even_when_path_says_otherwise():
+    """Critical regression: a session in a project named `subagent-runner`
+    whose filename contains 'subagent' must NOT be classified as a
+    sub-agent if the adapter wrote `is_subagent: false` (PR #406)."""
+    assert _is_subagent(
+        {"is_subagent": False},
+        Path("2026-04-25-subagent-runner-rewrite.md"),
+    ) is False
+
+
+def test_string_true_variants_coerce_to_true():
+    for s in ("true", "True", "TRUE", "yes", "1"):
+        assert _is_subagent({"is_subagent": s}, Path("x.md")) is True, s
+
+
+def test_string_false_variants_coerce_to_false():
+    for s in ("false", "False", "FALSE", "no", "0"):
+        assert _is_subagent({"is_subagent": s}, Path("x.md")) is False, s
+
+
+def test_missing_field_falls_back_to_substring():
+    """Pre-#406 raw files won't have the field — keep the substring
+    fallback for back-compat. Re-syncing those files restores the
+    correct classification."""
+    assert _is_subagent({}, Path("session-subagent-abc.md")) is True
+    assert _is_subagent({}, Path("session-foo.md")) is False
+
+
+def test_unrecognised_string_falls_back_to_substring():
+    assert _is_subagent({"is_subagent": "maybe"}, Path("x.md")) is False
+    assert _is_subagent({"is_subagent": "maybe"}, Path("subagent-x.md")) is True
+
+
+def test_none_value_falls_back_to_substring():
+    assert _is_subagent({"is_subagent": None}, Path("subagent-x.md")) is True
+    assert _is_subagent({"is_subagent": None}, Path("foo.md")) is False
+
+
+def test_int_value_falls_back_to_substring():
+    """`is_subagent: 5` is nonsense — falls through to substring rule."""
+    assert _is_subagent({"is_subagent": 5}, Path("foo.md")) is False
+    assert _is_subagent({"is_subagent": 5}, Path("subagent-x.md")) is True

--- a/tests/test_render_split.py
+++ b/tests/test_render_split.py
@@ -106,13 +106,14 @@ def test_build_py_is_smaller():
         compile + #277 palette docs indexing)
       * 2,300 (#417 plain_text cache + content_key helper)
       * 2,400 (#425 stub-defaults pre-population helpers)
+      * 2,500 (#492 _is_subagent helper for renderer-side classification)
     Next refactor target: extract md_to_html + preprocessor to
     llmwiki/render/markdown.py (tracked in the deep-audit epic #286).
     """
     from llmwiki import REPO_ROOT
     build_py = REPO_ROOT / "llmwiki" / "build.py"
     line_count = len(build_py.read_text(encoding="utf-8").splitlines())
-    assert line_count < 2400, f"build.py is {line_count} lines (ceiling 2400)"
+    assert line_count < 2500, f"build.py is {line_count} lines (ceiling 2500)"
 
 
 def test_css_module_under_800_lines():


### PR DESCRIPTION
Closes #492.

Renderer-side half of the #406 `is_subagent` regression. PR #406 fixed it at the adapter layer; build.py never read the frontmatter field and re-implemented the old broken substring rule in 5 places. Any session in any project with 'subagent' in its filename was misclassified.

Fix: new `_is_subagent(meta, path)` helper that prefers the frontmatter field, falls back to substring only when field missing.

## Test plan

- [x] `pytest tests/test_render_is_subagent.py` — 8/8 pass
- [x] All 5 substring sites in build.py replaced with helper
- [x] Regression test: project `subagent-runner` with `is_subagent: false` is now correctly classified as main session