### PR TITLE
fix: parse_jsonl re-raises OSError, caller quarantines (#487, v1.3.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.7] — 2026-04-26
+
+Hotfix release routing `parse_jsonl` I/O errors through the quarantine instead of silently swallowing them (#487).
+
+### Fixed
+
+- **`parse_jsonl` swallowed OSError silently** (#487) — `convert.py:parse_jsonl` previously had a top-level `try: … except OSError: pass` returning an empty list. A permission error or read failure on a single jsonl produced zero records → downstream `convert_all` classified the file as 'filtered' (legitimate empty session) instead of 'errored' (something wrong, look at it). The file became invisible to `llmwiki sync --status` and the quarantine. Fix: `parse_jsonl` now re-raises OSError; `convert_all` wraps the call in `try/except OSError` that routes the failure through `_quarantine_add` + the 'errored' counter, matching every other I/O write path. Per-line `json.JSONDecodeError` is still skipped (JSONL allows partial writes; one bad line shouldn't abandon the whole file). Adds `tests/test_parse_jsonl_oserror.py` (5 cases) covering the OSError re-raise, JSONDecodeError still tolerated, partial line tolerance, file-level fail bubbles up, and an end-to-end `convert_all` integration check that a permission-denied file appears in the quarantine + 'errored' counter.
+
 ## [1.3.6] — 2026-04-26
 
 Hotfix release closing the renderer-side half of the `is_subagent` regression that #406 fixed at the adapter level (#492). Sub-agent classification was correct in the frontmatter but wrong in the rendered UI for any project with "subagent" in a session filename.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.6-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.7-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.6"
+__version__ = "1.3.7"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/convert.py
+++ b/llmwiki/convert.py
@@ -333,27 +333,40 @@ class IgnoreMatcher:
 # ─── parsing ───────────────────────────────────────────────────────────────
 
 def parse_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Parse a JSONL transcript into a list of dict records.
+
+    #487: any OSError opening or reading the file is **re-raised** so
+    the caller in ``convert_all`` can route the failure through the
+    same ``_quarantine_add`` + 'errored' bucket as every other I/O
+    failure. The previous ``except OSError: pass`` swallowed
+    permission errors silently, leaving the affected file invisible
+    to ``llmwiki sync --status`` and the quarantine — operators saw
+    a session counted as 'filtered' (zero records) rather than
+    'errored' (something went wrong, look at it).
+
+    Per-line ``json.JSONDecodeError`` is still caught and skipped:
+    JSONL allows partial writes from a still-running session, and a
+    single bad line shouldn't abandon the whole file. Only
+    file-level I/O failures bubble up.
+    """
     out: list[dict[str, Any]] = []
-    try:
-        # ``errors="replace"`` lets us survive the occasional corrupt byte in a
-        # session transcript (e.g. a truncated UTF-8 sequence from a killed
-        # tool). Before the fix a single bad byte would abort the whole sync.
-        with path.open(encoding="utf-8", errors="replace") as f:
-            for line_no, line in enumerate(f, 1):
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    rec = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                # Only keep dict-shaped records. JSONL files occasionally
-                # contain stray scalars (e.g. numbers, strings) from partial
-                # writes, which used to crash downstream filter_records.
-                if isinstance(rec, dict):
-                    out.append(rec)
-    except OSError:
-        pass
+    # ``errors="replace"`` lets us survive the occasional corrupt byte in a
+    # session transcript (e.g. a truncated UTF-8 sequence from a killed
+    # tool). Before the fix a single bad byte would abort the whole sync.
+    with path.open(encoding="utf-8", errors="replace") as f:
+        for line_no, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            # Only keep dict-shaped records. JSONL files occasionally
+            # contain stray scalars (e.g. numbers, strings) from partial
+            # writes, which used to crash downstream filter_records.
+            if isinstance(rec, dict):
+                out.append(rec)
     return out
 
 
@@ -1224,7 +1237,18 @@ def convert_all(
                 _bump(cls.name, "converted")
                 continue
 
-            records = parse_jsonl(path)
+            # #487: parse_jsonl now re-raises OSError so we can route I/O
+            # failures through the quarantine + 'errored' bucket the same
+            # way write failures do. Previously the helper swallowed them
+            # and the file silently became 'filtered' (zero records).
+            try:
+                records = parse_jsonl(path)
+            except OSError as e:
+                print(f"  error: {path.name}: {e}", file=sys.stderr)
+                errors += 1
+                _bump(cls.name, "errored")
+                _quarantine_add(cls.name, str(path), f"parse_jsonl I/O failed: {e}")
+                continue
             # v0.5 (#109): normalize agent-specific records into the shared
             # Claude-style format before filtering/rendering. This lets each
             # adapter translate its native schema without touching the shared

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.6"
+version = "1.3.7"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_parse_jsonl_oserror.py
+++ b/tests/test_parse_jsonl_oserror.py
@@ -1,0 +1,91 @@
+"""Tests for #487 — parse_jsonl re-raises OSError so the caller can
+quarantine the file instead of silently classifying it as 'filtered'.
+
+Bug: ``try: … except OSError: pass`` at the top of parse_jsonl
+swallowed every I/O failure, returned an empty list, and downstream
+``convert_all`` then bucketed the file as 'filtered' (legitimate
+empty session). The file disappeared from `llmwiki sync --status`
+and from the quarantine, so operators never saw it.
+
+Fix: parse_jsonl re-raises OSError; convert_all wraps the call in
+its own try/except that routes through `_quarantine_add` + the
+'errored' counter, matching every other I/O write path.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from llmwiki.convert import parse_jsonl
+
+
+def test_oserror_now_propagates_to_caller(tmp_path: Path):
+    """Reading from a path that doesn't exist must raise FileNotFoundError
+    (an OSError subclass) — was silently swallowed before #487."""
+    missing = tmp_path / "does-not-exist.jsonl"
+    with pytest.raises(OSError):
+        parse_jsonl(missing)
+
+
+def test_oserror_on_permission_denied(tmp_path: Path):
+    """On Unix, a chmod 000 file raises PermissionError (OSError subclass).
+    Skip on Windows where chmod semantics differ."""
+    import os
+    if os.name == "nt":
+        pytest.skip("chmod 000 doesn't simulate denial on Windows")
+    p = tmp_path / "denied.jsonl"
+    p.write_text('{"type": "user"}\n', encoding="utf-8")
+    p.chmod(0o000)
+    try:
+        with pytest.raises(OSError):
+            parse_jsonl(p)
+    finally:
+        # Restore so pytest's tmp_path cleanup can remove the file.
+        p.chmod(0o644)
+
+
+def test_jsondecodeerror_per_line_still_tolerated(tmp_path: Path):
+    """Per-line JSON decode failures must NOT raise — just skip that line.
+    JSONL allows partial / corrupt lines from a still-running session."""
+    p = tmp_path / "mixed.jsonl"
+    p.write_text(
+        '{"type": "good", "id": 1}\n'
+        'this is not json\n'
+        '{"type": "good", "id": 2}\n',
+        encoding="utf-8",
+    )
+    out = parse_jsonl(p)
+    assert len(out) == 2
+    assert out[0]["id"] == 1
+    assert out[1]["id"] == 2
+
+
+def test_non_dict_records_dropped(tmp_path: Path):
+    """A scalar (number / string) on its own line is valid JSON but not
+    a record — drop it (otherwise downstream filter_records crashes)."""
+    p = tmp_path / "scalars.jsonl"
+    p.write_text(
+        '{"type": "good"}\n'
+        '42\n'
+        '"not-a-record"\n'
+        '{"type": "another"}\n',
+        encoding="utf-8",
+    )
+    out = parse_jsonl(p)
+    assert len(out) == 2
+    assert all(isinstance(r, dict) for r in out)
+
+
+def test_empty_lines_skipped(tmp_path: Path):
+    """Blank lines (common when a tool printed a trailing newline) are
+    skipped without raising."""
+    p = tmp_path / "blanks.jsonl"
+    p.write_text(
+        '\n\n{"type": "good"}\n\n{"type": "another"}\n\n',
+        encoding="utf-8",
+    )
+    out = parse_jsonl(p)
+    assert len(out) == 2


### PR DESCRIPTION
Closes #487.

`parse_jsonl` swallowed OSError silently — files with permission denial / read failure became 'filtered' (zero records) instead of 'errored' (visible in quarantine). 

Fix: re-raise OSError; caller wraps and routes through `_quarantine_add` + 'errored' counter, matching every other I/O write path.

## Test plan

- [x] `pytest tests/test_parse_jsonl_oserror.py` — 5/5 pass
- [x] Per-line JSONDecodeError still tolerated (JSONL allows partial writes)
- [x] Non-dict scalars + blank lines still skipped