### PR TITLE
fix: auto-detected real_username over-matched on Windows + containers (#489, v1.3.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.8] — 2026-04-26
+
+Hotfix release fixing the auto-detected `real_username` falsely matching `root` / short paths in containers and Windows (#489).
+
+### Fixed
+
+- **Auto-detected `real_username` over-matched on Windows + stripped containers** (#489) — `convert.py:load_config` previously fell back to `os.environ["USER"] or Path.home().name`. Two failure modes hit users in the wild: (a) **Windows** uses `USERNAME` not `USER` → env lookup empty → fallback to `Path.home().name` returns the actual short name, which the redactor then substring-matched into unrelated path tokens; (b) **stripped Docker / CI images** have `USER` unset and `Path.home()` = `/root` → fallback returns `"root"` → every `/Users/root/`, `/home/root/` path got mass-rewritten to `/Users/USER/` even when the actual transcript author had a totally different username. Fix: prefer `USER` → `USERNAME` → `Path.home().name`, but only trust the home-dir name when it's ≥3 chars AND not in the generic-container set (`root`, `user`, `users`, `home`, `ubuntu`). Otherwise leave the field empty so the redactor stays a no-op until the user opts in via config. Adds `tests/test_username_autodetect.py` (8 cases) covering Unix USER, Windows USERNAME, generic-container blocklist, short-name floor, explicit config wins, all-empty graceful fallback, and a regression vs the bug pattern.
+
 ## [1.3.7] — 2026-04-26
 
 Hotfix release routing `parse_jsonl` I/O errors through the quarantine instead of silently swallowing them (#487).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.7-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.8-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.7"
+__version__ = "1.3.8"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/convert.py
+++ b/llmwiki/convert.py
@@ -67,11 +67,46 @@ def load_config(path: Path) -> dict[str, Any]:
                 cfg[section].update(value)
             else:
                 cfg[section] = value
-    # Auto-detect username if not set
+    # Auto-detect username if not set. #489: be careful here.
+    #
+    # The previous logic was `os.environ["USER"] or Path.home().name`.
+    # Two failure modes that bit users in the wild:
+    #
+    # 1. **Windows.** Windows uses ``USERNAME``, not ``USER``. The env
+    #    var lookup returns empty, the fallback returns
+    #    ``Path.home().name`` — which is the user's actual name, fine
+    #    on a real desktop but the redactor then matches the *short*
+    #    string in path components anywhere in transcripts. On a
+    #    Windows machine where the user's name is short (e.g. "AB")
+    #    this flagged unrelated path tokens.
+    # 2. **Stripped Docker images / CI.** ``USER`` is unset and
+    #    ``Path.home()`` returns ``/`` or ``/root``; ``Path("/").name``
+    #    is empty, but ``Path("/root").name`` is ``"root"`` — every
+    #    ``/Users/root/`` and ``/home/root/`` path got rewritten as
+    #    ``/Users/USER/`` even when the actual transcript author had
+    #    a totally different username.
+    #
+    # Fix: prefer ``USER`` (Unix) → ``USERNAME`` (Windows) →
+    # ``Path.home().name`` *only if it's at least 3 chars long*.
+    # Anything shorter is too risky as a substring rewrite target;
+    # leave the field empty and let the user opt in via config.
     if not cfg["redaction"].get("real_username"):
         try:
             import os
-            cfg["redaction"]["real_username"] = os.environ.get("USER", "") or Path.home().name
+            candidate = (
+                os.environ.get("USER")
+                or os.environ.get("USERNAME")
+                or ""
+            ).strip()
+            if not candidate:
+                home_name = Path.home().name.strip()
+                # Only trust the home-dir name when it's not a generic
+                # container default and is long enough to be specific.
+                if len(home_name) >= 3 and home_name.lower() not in (
+                    "root", "user", "users", "home", "ubuntu",
+                ):
+                    candidate = home_name
+            cfg["redaction"]["real_username"] = candidate
         except Exception:
             pass
     return cfg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.7"
+version = "1.3.8"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_username_autodetect.py
+++ b/tests/test_username_autodetect.py
@@ -1,0 +1,108 @@
+"""Tests for #489 — auto-detected `real_username` must not over-match
+on Windows or stripped containers.
+
+The bug: `load_config` fell back to `os.environ["USER"] or
+Path.home().name`. Two failure modes hit users in the wild:
+
+1. **Windows** uses `USERNAME` not `USER` → env lookup empty →
+   fallback to `Path.home().name` returns the actual short name,
+   which the redactor then substring-matched into unrelated path
+   tokens.
+2. **Stripped Docker / CI images** have `USER` unset and
+   `Path.home()` = `/root` → fallback returns `"root"` → every
+   `/Users/root/`, `/home/root/` path got mass-rewritten to
+   `/Users/USER/`.
+
+Fix: prefer `USER` → `USERNAME` → `Path.home().name` only when
+it's ≥3 chars AND not in the generic-container set.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from llmwiki.convert import load_config
+
+
+def _config_path(tmp_path: Path) -> Path:
+    """A non-existent path so load_config skips file-merge and only
+    runs the auto-detect branch we want to test."""
+    return tmp_path / "no-such-config.json"
+
+
+def test_unix_user_env_var_wins(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("USER", "alice")
+    monkeypatch.delenv("USERNAME", raising=False)
+    cfg = load_config(_config_path(tmp_path))
+    assert cfg["redaction"]["real_username"] == "alice"
+
+
+def test_windows_username_env_var_used_when_USER_missing(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("USER", raising=False)
+    monkeypatch.setenv("USERNAME", "alice-win")
+    cfg = load_config(_config_path(tmp_path))
+    assert cfg["redaction"]["real_username"] == "alice-win"
+
+
+def test_USER_takes_precedence_over_USERNAME(tmp_path: Path, monkeypatch):
+    """Unix-style env wins over Windows-style if both happen to be set
+    (e.g. on Cygwin or WSL)."""
+    monkeypatch.setenv("USER", "unix-user")
+    monkeypatch.setenv("USERNAME", "win-user")
+    cfg = load_config(_config_path(tmp_path))
+    assert cfg["redaction"]["real_username"] == "unix-user"
+
+
+def test_root_homedir_does_not_leak_as_username(tmp_path: Path, monkeypatch):
+    """The original bug: stripped container with USER unset →
+    Path.home().name was 'root' → every /home/root/ path got
+    rewritten. Must now leave field empty so the redactor stays a
+    no-op until user opts in."""
+    monkeypatch.delenv("USER", raising=False)
+    monkeypatch.delenv("USERNAME", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: Path("/root")))
+    cfg = load_config(_config_path(tmp_path))
+    assert cfg["redaction"]["real_username"] == ""
+
+
+def test_generic_user_homedir_does_not_leak(tmp_path: Path, monkeypatch):
+    """Same protection for `user`, `ubuntu`, `home` etc."""
+    for generic in ("user", "User", "USER", "ubuntu", "home", "users"):
+        monkeypatch.delenv("USER", raising=False)
+        monkeypatch.delenv("USERNAME", raising=False)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls, g=generic: Path(f"/home/{g}")))
+        cfg = load_config(_config_path(tmp_path))
+        assert cfg["redaction"]["real_username"] == "", generic
+
+
+def test_short_homedir_name_skipped(tmp_path: Path, monkeypatch):
+    """Names <3 chars are too risky as substring rewrite targets."""
+    monkeypatch.delenv("USER", raising=False)
+    monkeypatch.delenv("USERNAME", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: Path("/home/ab")))
+    cfg = load_config(_config_path(tmp_path))
+    assert cfg["redaction"]["real_username"] == ""
+
+
+def test_long_specific_homedir_used(tmp_path: Path, monkeypatch):
+    """Real user names (≥3 chars, not generic) ARE trusted as fallback."""
+    monkeypatch.delenv("USER", raising=False)
+    monkeypatch.delenv("USERNAME", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: Path("/home/pratiyush")))
+    cfg = load_config(_config_path(tmp_path))
+    assert cfg["redaction"]["real_username"] == "pratiyush"
+
+
+def test_explicit_config_value_overrides_autodetect(tmp_path: Path, monkeypatch):
+    """If the user wrote `real_username` into config, never auto-overwrite."""
+    import json
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(
+        json.dumps({"redaction": {"real_username": "explicitly-mine"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("USER", "should-be-ignored")
+    cfg = load_config(cfg_path)
+    assert cfg["redaction"]["real_username"] == "explicitly-mine"


### PR DESCRIPTION
Closes #489.

`USER` → `USERNAME` → `Path.home().name` (≥3 chars, not generic-container name). Otherwise leave empty so redactor is no-op until user opts in.

## Test plan

- [x] `pytest tests/test_username_autodetect.py` — 8/8 pass
- [x] Windows USERNAME path covered
- [x] Container 'root' / 'user' / 'ubuntu' blocked from leaking