### PR TITLE
fix: lint exemptions broken on Windows backslash paths (#490, v1.3.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.9] — 2026-04-26
+
+Hotfix release fixing Windows lint exemptions broken by POSIX-only path splitting (#490).
+
+### Fixed
+
+- **Lint exemptions broke on Windows backslash paths** (#490) — `lint/rules.py:FrontmatterCompleteness`, `_page_slug`, and `IndexSync` all derived basenames via `rel.rsplit('/', 1)[-1]`. On Windows the page-key paths use native `\\` separators (from `Path.parts`), so the split produced the *whole* string, every navigation file (`wiki\\index.md`, `wiki\\overview.md`, etc.) failed exemption matching, and every Windows install lit up with spurious lint errors. Fix: new `_basename(rel)` helper that normalises both separators before splitting; all 3 sites route through it. Adds `tests/test_lint_windows_paths.py` (5 cases) covering the helper directly + each fixed callsite, with parametrised POSIX vs Windows path inputs.
+
 ## [1.3.8] — 2026-04-26
 
 Hotfix release fixing the auto-detected `real_username` falsely matching `root` / short paths in containers and Windows (#489).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.8-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.9-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.8"
+__version__ = "1.3.9"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/lint/rules.py
+++ b/llmwiki/lint/rules.py
@@ -67,8 +67,11 @@ class FrontmatterCompleteness(LintRule):
     def run(self, pages, *, llm_callback=None):
         issues = []
         for rel, page in pages.items():
-            # Skip system nav files and _context.md stubs
-            basename = rel.rsplit("/", 1)[-1]
+            # Skip system nav files and _context.md stubs.
+            # #490: use the separator-agnostic basename helper so
+            # exemptions still fire on Windows-built page paths
+            # (`wiki\\index.md` etc.).
+            basename = _basename(rel)
             if basename in self.EXEMPT_FILES or basename == "_context.md":
                 continue
             meta = page["meta"]
@@ -147,9 +150,23 @@ class FrontmatterValidity(LintRule):
         return issues
 
 
+def _basename(rel: str) -> str:
+    """Return the last path component, normalising both `/` and `\\\\`.
+
+    #490: lint pages built on Windows have keys like
+    ``wiki\\\\entities\\\\Foo.md`` (native ``Path.parts`` separators),
+    so a ``rel.rsplit('/', 1)[-1]`` returns the *whole* string. This
+    silently broke every exemption + slug-derivation site that
+    assumed POSIX separators — every Windows install showed spurious
+    lint errors against navigation files. Use this helper everywhere.
+    """
+    # Normalise both separators, then split on the canonical one.
+    return rel.replace("\\", "/").rsplit("/", 1)[-1]
+
+
 def _page_slug(rel: str) -> str:
     """Convert path like 'entities/Foo.md' → 'Foo'."""
-    return rel.rsplit("/", 1)[-1].removesuffix(".md")
+    return _basename(rel).removesuffix(".md")
 
 
 @register
@@ -480,7 +497,7 @@ class IndexSync(LintRule):
             if not resolved:
                 continue
             if resolved in pages:
-                listed_slugs.add(resolved.rsplit("/", 1)[-1].removesuffix(".md"))
+                listed_slugs.add(_basename(resolved).removesuffix(".md"))
             else:
                 issues.append({
                     "rule": self.name,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.8"
+version = "1.3.9"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_lint_windows_paths.py
+++ b/tests/test_lint_windows_paths.py
@@ -1,0 +1,72 @@
+"""Tests for #490 — lint helpers must handle both POSIX and Windows
+path separators.
+
+The bug: `rel.rsplit('/', 1)[-1]` returns the WHOLE string when the
+path uses backslashes (i.e. on Windows where `Path.parts` yields
+native separators). Every navigation file fell out of the
+exemption set; every Windows install spammed spurious lint errors.
+
+The fix: a `_basename(rel)` helper that normalises both separators
+before splitting. All callsites route through it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llmwiki.lint.rules import _basename, _page_slug, FrontmatterCompleteness
+
+
+@pytest.mark.parametrize("rel,expected", [
+    ("wiki/index.md", "index.md"),
+    ("wiki\\index.md", "index.md"),
+    ("entities/Foo.md", "Foo.md"),
+    ("entities\\Foo.md", "Foo.md"),
+    ("a/b/c/deep.md", "deep.md"),
+    ("a\\b\\c\\deep.md", "deep.md"),
+    ("a/b\\c/mixed.md", "mixed.md"),
+    ("noslash.md", "noslash.md"),
+])
+def test_basename_handles_both_separators(rel: str, expected: str):
+    assert _basename(rel) == expected
+
+
+@pytest.mark.parametrize("rel,expected_slug", [
+    ("entities/Foo.md", "Foo"),
+    ("entities\\Foo.md", "Foo"),
+    ("Bar.md", "Bar"),
+])
+def test_page_slug_strips_extension_after_basename(rel: str, expected_slug: str):
+    assert _page_slug(rel) == expected_slug
+
+
+def test_frontmatter_completeness_exempts_windows_index_path():
+    """Regression for the original bug: a Windows page key like
+    `wiki\\index.md` must hit the EXEMPT_FILES set instead of being
+    linted as missing-frontmatter."""
+    rule = FrontmatterCompleteness()
+    pages = {
+        "wiki\\index.md": {"meta": {}, "body": "# Index"},
+        "wiki\\overview.md": {"meta": {}, "body": "# Overview"},
+    }
+    issues = rule.run(pages)
+    assert issues == [], (
+        f"Windows nav paths still leaking lint errors: {issues}"
+    )
+
+
+def test_frontmatter_completeness_still_lints_windows_real_pages():
+    """Sanity: the helper doesn't accidentally exempt non-nav pages
+    just because the path uses backslashes."""
+    rule = FrontmatterCompleteness()
+    pages = {
+        "wiki\\entities\\NewEntity.md": {
+            "meta": {},
+            "body": "Some body",
+        },
+    }
+    issues = rule.run(pages)
+    assert any(
+        issue.get("page", "").endswith("NewEntity.md")
+        for issue in issues
+    ), f"expected lint error on NewEntity.md (Windows path), got {issues}"


### PR DESCRIPTION
Closes #490.

`rsplit('/', 1)[-1]` returned the whole string on Windows where path keys use `\\` — every nav file fell out of `EXEMPT_FILES`, every Windows install spammed spurious lint errors. Fix: `_basename(rel)` helper that normalises both separators; all 3 callsites route through it.

## Test plan

- [x] `pytest tests/test_lint_windows_paths.py tests/test_lint_rules.py` — 81 pass
- [x] Helper handles 8 path variants (POSIX/Windows/mixed/no-separator)
- [x] Regression test: `wiki\\index.md` correctly exempted; `wiki\\entities\\NewEntity.md` still linted