### PR TITLE
fix: cmd_graph always falls back to builtin on graphify failure (#488, v1.3.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.10] — 2026-04-26
+
+Hotfix release ensuring `cmd_graph` always falls back to the builtin engine when the graphify path fails (#488).
+
+### Fixed
+
+- **`cmd_graph` didn't fall back to builtin on graphify failure** (#488) — `cli.py:cmd_graph` had two missing fallbacks: (a) any uncaught exception from `build_graphify_graph()` (e.g. `nx.NetworkXError`, `ImportError` deep inside graphify) propagated as a stack trace + non-zero exit instead of falling through to the builtin engine; (b) when `result.get("graph") is None` (legitimate early-return for tiny corpora with zero edges), the function returned 1 directly without trying builtin. Fix: wrap `build_graphify_graph()` in `try/except Exception` that logs the failure mode and falls through to builtin; also fall through on the empty-result path. Builtin's exit code is now authoritative. Adds `tests/test_cmd_graph_fallback.py` (4 cases) covering: graphify exception falls through, empty graphify result falls through, graphify success short-circuits, builtin path runs when graphify unavailable.
+
 ## [1.3.9] — 2026-04-26
 
 Hotfix release fixing Windows lint exemptions broken by POSIX-only path splitting (#490).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.9-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.10-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.9"
+__version__ = "1.3.10"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/cli.py
+++ b/llmwiki/cli.py
@@ -407,7 +407,13 @@ def cmd_query(args: argparse.Namespace) -> int:
 
 
 def cmd_graph(args: argparse.Namespace) -> int:
-    """Build the knowledge graph from wiki/ wikilinks."""
+    """Build the knowledge graph from wiki/ wikilinks.
+
+    #488: graphify-engine failures (uninstalled, crashes, empty
+    result) ALL fall back to the builtin engine so the user always
+    gets *some* graph. Only the builtin engine's exit code is
+    authoritative for the CLI return value.
+    """
     engine = getattr(args, "engine", "graphify")
     if engine == "graphify":
         from llmwiki.graphify_bridge import is_available, build_graphify_graph
@@ -416,8 +422,25 @@ def cmd_graph(args: argparse.Namespace) -> int:
             print("  install with: pip install llmwiki[graph]", file=sys.stderr)
             engine = "builtin"
         else:
-            result = build_graphify_graph()
-            return 0 if result.get("graph") is not None else 1
+            try:
+                result = build_graphify_graph()
+            except Exception as e:
+                # #488: uncaught graphify exception used to surface as a
+                # bare stack trace + non-zero exit. Now we log a warning
+                # and fall through to the builtin engine.
+                print(f"  graphify engine crashed ({type(e).__name__}: {e}) — "
+                      f"falling back to builtin", file=sys.stderr)
+                engine = "builtin"
+            else:
+                if result.get("graph") is not None:
+                    return 0
+                # #488: empty-result early-return used to fail with rc=1
+                # without trying builtin. graphify can legitimately
+                # return None for tiny corpora (no edges); the builtin
+                # engine handles the same input gracefully.
+                print("  graphify returned no graph — falling back to builtin",
+                      file=sys.stderr)
+                engine = "builtin"
 
     from llmwiki.graph import build_and_report
     write_json = args.format in ("json", "both")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.9"
+version = "1.3.10"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_cmd_graph_fallback.py
+++ b/tests/test_cmd_graph_fallback.py
@@ -1,0 +1,72 @@
+"""Tests for #488 — cmd_graph must always fall back to the builtin
+engine when the graphify path fails.
+
+Two missing fallbacks in the original code:
+  1. Uncaught exception from build_graphify_graph() propagated as
+     a stack trace + non-zero exit.
+  2. result.get("graph") is None returned 1 directly without trying
+     builtin (legitimate empty-corpus case).
+"""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import patch
+
+import pytest
+
+from llmwiki.cli import cmd_graph
+
+
+def _make_args(engine="graphify", fmt="both"):
+    return argparse.Namespace(engine=engine, format=fmt)
+
+
+def test_graphify_exception_falls_back_to_builtin(monkeypatch, capsys):
+    """graphify crashing must log + fall through, not propagate."""
+    with patch("llmwiki.graphify_bridge.is_available", return_value=True), \
+         patch("llmwiki.graphify_bridge.build_graphify_graph",
+               side_effect=RuntimeError("graphify exploded")), \
+         patch("llmwiki.graph.build_and_report", return_value=0) as builtin:
+        rc = cmd_graph(_make_args())
+    assert rc == 0
+    builtin.assert_called_once()
+    err = capsys.readouterr().err
+    assert "graphify engine crashed" in err
+    assert "falling back to builtin" in err
+
+
+def test_graphify_empty_result_falls_back_to_builtin(monkeypatch, capsys):
+    """When graphify returns {graph: None} (e.g. tiny corpus with no
+    edges), fall through instead of returning 1."""
+    with patch("llmwiki.graphify_bridge.is_available", return_value=True), \
+         patch("llmwiki.graphify_bridge.build_graphify_graph",
+               return_value={"graph": None}), \
+         patch("llmwiki.graph.build_and_report", return_value=0) as builtin:
+        rc = cmd_graph(_make_args())
+    assert rc == 0
+    builtin.assert_called_once()
+    err = capsys.readouterr().err
+    assert "no graph" in err.lower() or "falling back" in err.lower()
+
+
+def test_graphify_success_short_circuits(monkeypatch):
+    """When graphify produces a real graph, builtin is NOT called."""
+    with patch("llmwiki.graphify_bridge.is_available", return_value=True), \
+         patch("llmwiki.graphify_bridge.build_graphify_graph",
+               return_value={"graph": {"nodes": [{"id": "x"}], "edges": []}}), \
+         patch("llmwiki.graph.build_and_report") as builtin:
+        rc = cmd_graph(_make_args())
+    assert rc == 0
+    builtin.assert_not_called()
+
+
+def test_graphify_unavailable_falls_back_to_builtin(monkeypatch, capsys):
+    """When graphify isn't installed, fall through cleanly (no crash)."""
+    with patch("llmwiki.graphify_bridge.is_available", return_value=False), \
+         patch("llmwiki.graph.build_and_report", return_value=0) as builtin:
+        rc = cmd_graph(_make_args())
+    assert rc == 0
+    builtin.assert_called_once()
+    err = capsys.readouterr().err
+    assert "graphify not installed" in err


### PR DESCRIPTION
Closes #488.

Two missing fallbacks: uncaught graphify exception propagated; `result.get('graph') is None` returned 1 directly. Now both paths fall through to the builtin engine.

## Test plan

- [x] `pytest tests/test_cmd_graph_fallback.py` — 4/4 pass
- [x] graphify success still short-circuits (no double-build)
- [x] graphify-unavailable + graphify-crash + graphify-empty all route to builtin