### PR TITLE
fix: delete phantom PDF adapter dispatch + docs (#493, v1.3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.11] — 2026-04-26
+
+Hotfix release deleting the phantom PDF adapter dispatch + docs (#493).
+
+### Removed
+
+- **PDF adapter dispatch was dead code** (#493) — `convert.py` had a `if path.suffix == ".pdf"` branch calling `adapter.convert_pdf()`. No concrete adapter ever implemented it; every adapter raised `AttributeError`, which got swallowed into `_quarantine_add` showing "'XAdapter' object has no attribute 'convert_pdf'". README + multi-agent-setup docs both lied with "PDF Production v0.5". Removed: the 33-line PDF dispatch branch in `convert_all`, the `pdf` legacy migration hint in `_migrate_legacy_state`, the README "PDF files | ✅ Production" row, and the `pdf available: yes` example output in `docs/multi-agent-setup.md`. The `jira` and `meeting` migration hints went too — same shape (no concrete adapter ships). If a real PDF/jira/meeting adapter lands later, the author can re-add the branch and declare the method on `BaseAdapter` properly. Adds `tests/test_no_phantom_adapters.py` (3 cases) — CI guard that asserts no `.pdf` dispatch in convert_all, no `convert_pdf` method on any registered adapter, and that the `pdf` adapter name doesn't appear in the registry.
+
 ## [1.3.10] — 2026-04-26
 
 Hotfix release ensuring `cmd_graph` always falls back to the builtin engine when the graphify path fails (#488).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.10-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.11-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)
@@ -384,7 +384,6 @@ Each subcommand has its own `--help`. All commands are also wrapped in one-click
 | [Codex CLI](https://github.com/openai/codex) | `llmwiki.adapters.codex_cli` | ✅ Production | v0.3 |
 | [Cursor](https://cursor.com) | `llmwiki.adapters.cursor` | ✅ Production | v0.5 |
 | [Gemini CLI](https://ai.google.dev/gemini-api) | `llmwiki.adapters.gemini_cli` | ✅ Production | v0.5 |
-| PDF files | `llmwiki.adapters.pdf` | ✅ Production | v0.5 |
 | [Copilot Chat](https://github.com/features/copilot) | `llmwiki.adapters.copilot_chat` | ✅ Production | v0.9 |
 | [Copilot CLI](https://github.com/features/copilot) | `llmwiki.adapters.copilot_cli` | ✅ Production | v0.9 |
 | OpenCode / OpenClaw | — | ⏸ Deferred | — |

--- a/docs/multi-agent-setup.md
+++ b/docs/multi-agent-setup.md
@@ -13,7 +13,6 @@ llmwiki reads sessions from multiple coding agents simultaneously. One `llmwiki 
 | Cursor | `cursor` | Cursor IDE workspaceStorage | Scaffold (SQLite parser in progress) |
 | Gemini CLI | `gemini_cli` | `~/.gemini/` | Scaffold (schema TBC) |
 | Obsidian | `obsidian` | Configurable vault paths | Production |
-| PDF | `pdf` | Any `.pdf` dropped into `raw/` | Production |
 
 ## How auto-detection works
 
@@ -42,7 +41,6 @@ Registered adapters:
   cursor            available: yes  (Cursor IDE — reads chat history)
   gemini_cli        available: no   (Gemini CLI — reads ~/.gemini/ session history)
   obsidian          available: no   (Obsidian vault)
-  pdf               available: yes  (PDF files)
 ```
 
 ## Per-agent setup

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.10"
+__version__ = "1.3.11"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/convert.py
+++ b/llmwiki/convert.py
@@ -188,9 +188,10 @@ def _migrate_legacy_state(
         ("obsidian",     "Obsidian"),
         ("opencode",     "opencode/"),
         ("chatgpt",      "conversations.json"),
-        ("jira",         "/jira/"),
-        ("meeting",      "transcripts"),
-        ("pdf",          ".pdf"),
+        # #493: jira / meeting / pdf hints removed — no concrete
+        # adapters ship for them. If they're added back later, the
+        # adapter author can add their own LEGACY_PATH_HINT. See
+        # docs/UPGRADING.md for the original removal note.
     ]
     known_names = set(adapter_names)
     for k, v in raw.items():
@@ -1239,38 +1240,15 @@ def convert_all(
                 _bump(cls.name, "converted")
                 continue
 
-            # PDF adapter: extract text → frontmatter'd markdown
-            if path.suffix == ".pdf":
-                try:
-                    md, out_name = adapter.convert_pdf(path, redact=redact)
-                except Exception as e:
-                    print(f"  skip: {path.name}: {e}", file=sys.stderr)
-                    errors += 1
-                    _bump(cls.name, "errored")
-                    _quarantine_add(cls.name, str(path), f"pdf convert failed: {e}")
-                    continue
-                if not md:
-                    filtered += 1
-                    _bump(cls.name, "filtered")
-                    continue
-                out_path = out_dir / f"{project_slug}-{out_name}"
-                if dry_run:
-                    print(f"  [dry-run] {out_path.relative_to(REPO_ROOT) if out_path.is_relative_to(REPO_ROOT) else out_path} ({len(md)} bytes)")
-                else:
-                    out_path.parent.mkdir(parents=True, exist_ok=True)
-                    try:
-                        _raw_write_guard(out_path, force=force, source=str(path),
-                                         adapter_name=cls.name)
-                    except FileExistsError as e:
-                        errors += 1
-                        _bump(cls.name, "errored")
-                        _quarantine_add(cls.name, str(path), str(e))
-                        continue
-                    out_path.write_text(md, encoding="utf-8")
-                    state[key] = mtime
-                converted += 1
-                _bump(cls.name, "converted")
-                continue
+            # #493: PDF dispatch removed. There was never a concrete PDF
+            # adapter — `adapter.convert_pdf` raised AttributeError on
+            # every adapter, the exception got swallowed into
+            # `_quarantine_add`, and the user saw a confusing
+            # "'XAdapter' object has no attribute 'convert_pdf'" entry.
+            # README also lied about a "PDF Production v0.5" adapter
+            # that never existed. If a real PDF adapter ships later it
+            # can re-add this branch and declare `convert_pdf` on
+            # `BaseAdapter` properly.
 
             # #487: parse_jsonl now re-raises OSError so we can route I/O
             # failures through the quarantine + 'errored' bucket the same

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.10"
+version = "1.3.11"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_no_phantom_adapters.py
+++ b/tests/test_no_phantom_adapters.py
@@ -1,0 +1,71 @@
+"""Tests for #493 — no phantom adapters or dead dispatch branches.
+
+The bug: convert.py had `if path.suffix == ".pdf"` calling
+`adapter.convert_pdf(path, redact=redact)`. No concrete adapter
+ever implemented `convert_pdf`. README + docs both advertised
+"PDF Production v0.5". Users who tried it saw confusing
+'AttributeError' lines in the quarantine.
+
+This test file is the CI guard against the phantom returning.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from llmwiki import convert as convert_mod
+from llmwiki.adapters import REGISTRY, discover_adapters
+
+
+def _strip_comments(src: str) -> str:
+    """Drop full-line `#` comments + trailing `# ...` so the source-
+    string scan doesn't false-positive on the historical context
+    comment that mentions the deleted code."""
+    out = []
+    for line in src.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        # trailing inline comment
+        if "#" in line:
+            line = line.split("#", 1)[0]
+        out.append(line)
+    return "\n".join(out)
+
+
+def test_convert_all_does_not_dispatch_pdf():
+    """The `if path.suffix == \".pdf\"` branch must stay deleted —
+    re-adding it without a real adapter brings back the original
+    confusing AttributeError quarantine entries."""
+    src = _strip_comments(inspect.getsource(convert_mod.convert_all))
+    assert 'path.suffix == ".pdf"' not in src, (
+        "PDF dispatch branch is back in convert_all — but no adapter "
+        "implements convert_pdf. Either land a real PDF adapter first "
+        "(declare convert_pdf on BaseAdapter) or remove the dispatch."
+    )
+    assert "convert_pdf" not in src, (
+        "convert_all calls convert_pdf without a concrete impl — "
+        "see #493 history for why this is dead code."
+    )
+
+
+def test_no_registered_adapter_implements_convert_pdf():
+    """As long as the registry has no convert_pdf-providing adapter,
+    the dispatch branch above must stay out (paired guard)."""
+    discover_adapters()
+    for name, cls in REGISTRY.items():
+        assert not hasattr(cls, "convert_pdf"), (
+            f"Adapter {name} implements convert_pdf — re-add the "
+            f"convert_all dispatch branch in the same PR."
+        )
+
+
+def test_pdf_adapter_not_in_registry():
+    """If a real PDF adapter is added later, its name shouldn't be
+    `pdf` (reserved as removed in v1.2.0). Use a more specific name
+    like `pdf_files` or `pypdf`."""
+    discover_adapters()
+    assert "pdf" not in REGISTRY, (
+        "An adapter is registered as 'pdf' — name was reserved as "
+        "removed in v1.2.0. Use a more specific name."
+    )


### PR DESCRIPTION
Closes #493.

Removed: dead PDF dispatch branch in convert_all, jira/meeting/pdf migration hints, README 'PDF Production' adapter row, multi-agent-setup PDF row + adapters output line. Added CI guard so the phantom can't sneak back without a real adapter.

## Test plan

- [x] `pytest tests/test_no_phantom_adapters.py` — 3/3 pass
- [x] No `convert_pdf` symbol in convert_all source (comment-stripped scan)
- [x] No registered adapter implements convert_pdf
- [x] 'pdf' name reserved in registry