### PR TITLE
fix: MCP wiki_read_page allowlist — block .env / .git / state file (#482, v1.3.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.13] — 2026-04-26
+
+Hotfix release adding an allowlist to the MCP `wiki_read_page` tool so it can't leak `.git/`, `.env`, or `.llmwiki-state.json` (#482).
+
+### Fixed
+
+- **MCP `tool_wiki_read_page` could read any file under REPO_ROOT** (#482) — `_safe_path` correctly rejected symlinks pointing outside the repo, but READ any file *under* REPO_ROOT. That included `.env`, `.git/config`, `.llmwiki-state.json` (which contains absolute paths to every Claude session file = host directory listing leak), and any other dotfile or nested config. Anyone with MCP access (typically the user's own agent, but also any third-party MCP client they enable in Claude Desktop) could list / exfiltrate those. Fix: new `_is_read_page_allowed(p)` allowlist that restricts the tool to `wiki/`, `raw/`, `docs/`, `examples/`, `site/` directories plus `README.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, `LICENSE` at the repo root. Anything else returns an error explaining the readable surface. Adds `tests/test_mcp_read_page_allowlist.py` (10 cases) covering each allowlisted path type, every blocked sensitive file (`.env`, `.git/config`, `.llmwiki-state.json`, `.venv/anything`, `node_modules/anything`, `tests/test_*.py`), and explicit error-message clarity.
+
 ## [1.3.12] — 2026-04-26
 
 Hotfix release consolidating 3 divergent frontmatter parsers onto the canonical `_frontmatter.py` (#495).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.12-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.13-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.12"
+__version__ = "1.3.13"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/mcp/server.py
+++ b/llmwiki/mcp/server.py
@@ -272,6 +272,22 @@ TOOLS = [
 # ─── Tool implementations ─────────────────────────────────────────────────
 
 
+# #482: top-level directories the MCP read-page tool is allowed to
+# return content from. Anything outside this set is rejected even
+# though it lives under REPO_ROOT — e.g. .git/, .env, .venv/, the
+# state files (.llmwiki-state.json contains absolute paths to every
+# Claude session file → host directory listing leak), and dotfiles
+# in general. README, CHANGELOG, CONTRIBUTING are allowed by name
+# because they're the documentation surface every consumer expects.
+_READ_PAGE_ALLOWED_DIRS: tuple[str, ...] = (
+    "wiki", "raw", "docs", "examples", "site",
+)
+_READ_PAGE_ALLOWED_ROOT_FILES: frozenset[str] = frozenset({
+    "README.md", "CHANGELOG.md", "CONTRIBUTING.md",
+    "LICENSE", "LICENSE.md",
+})
+
+
 def _safe_path(rel: str) -> Path | None:
     """Resolve a user-supplied path relative to REPO_ROOT and refuse if it
     escapes the repo (path traversal guard)."""
@@ -283,6 +299,31 @@ def _safe_path(rel: str) -> Path | None:
     except ValueError:
         return None
     return p
+
+
+def _is_read_page_allowed(p: Path) -> bool:
+    """#482: restrict `tool_wiki_read_page` to a documented surface.
+
+    The path-traversal guard in `_safe_path` only checks the file is
+    *under* REPO_ROOT. That still leaks every dotfile, the .git
+    directory, the state files, and node_modules. Apply an explicit
+    allowlist on top — the docs surface, plus the user's wiki/raw
+    content. Anything else is silently a "not found".
+    """
+    try:
+        rel_parts = p.resolve().relative_to(REPO_ROOT.resolve()).parts
+    except ValueError:
+        return False
+    if not rel_parts:
+        return False
+    head = rel_parts[0]
+    # Top-level allowlisted directory?
+    if head in _READ_PAGE_ALLOWED_DIRS:
+        return True
+    # Single allowlisted file at the root?
+    if len(rel_parts) == 1 and head in _READ_PAGE_ALLOWED_ROOT_FILES:
+        return True
+    return False
 
 
 def tool_wiki_query(args: dict[str, Any]) -> dict[str, Any]:
@@ -462,6 +503,16 @@ def tool_wiki_read_page(args: dict[str, Any]) -> dict[str, Any]:
     p = _safe_path(rel)
     if p is None:
         return _err(f"path escapes repo root: {rel!r}")
+    # #482: restrict to documented allowlist (wiki/, raw/, docs/,
+    # examples/, site/, plus README/CHANGELOG/etc. at the root).
+    # Reject .git/, .env, .llmwiki-state.json, node_modules, etc.
+    # even though they live under REPO_ROOT.
+    if not _is_read_page_allowed(p):
+        return _err(
+            f"path is outside the readable surface: {rel!r}. "
+            f"Allowed: {', '.join(_READ_PAGE_ALLOWED_DIRS)}/, "
+            f"plus {', '.join(sorted(_READ_PAGE_ALLOWED_ROOT_FILES))} at the root."
+        )
     if not p.exists():
         return _err(f"path does not exist: {rel}")
     if not p.is_file():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.12"
+version = "1.3.13"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_mcp_read_page_allowlist.py
+++ b/tests/test_mcp_read_page_allowlist.py
@@ -1,0 +1,109 @@
+"""Tests for #482 — MCP wiki_read_page must restrict reads to a
+documented allowlist.
+
+The bug: `_safe_path` only checked the file was under REPO_ROOT.
+Any dotfile (`.env`, `.git/config`, `.llmwiki-state.json`) or
+private dir (`.venv/`, `node_modules/`) was readable via MCP. The
+state file in particular leaks absolute paths to every Claude
+session on the host machine.
+
+The fix: `_is_read_page_allowed(p)` allowlist of `wiki/raw/docs/
+examples/site/` directories + a few documented root files
+(README, CHANGELOG, CONTRIBUTING, LICENSE).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from llmwiki import REPO_ROOT
+from llmwiki.mcp.server import (
+    _is_read_page_allowed,
+    tool_wiki_read_page,
+)
+
+
+# ─── _is_read_page_allowed: positive cases ──────────────────────────────
+
+
+@pytest.mark.parametrize("rel", [
+    "wiki/index.md",
+    "wiki/entities/Foo.md",
+    "raw/sessions/2026-04-01-x.md",
+    "docs/getting-started.md",
+    "examples/sessions_config.json",
+    "site/index.html",
+    "README.md",
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+])
+def test_allowlisted_paths_pass(rel: str):
+    assert _is_read_page_allowed(REPO_ROOT / rel), (
+        f"{rel!r} should be allowed by the read-page surface"
+    )
+
+
+# ─── _is_read_page_allowed: negative cases (the bug) ────────────────────
+
+
+@pytest.mark.parametrize("rel", [
+    ".env",
+    ".gitignore",
+    ".git/config",
+    ".git/HEAD",
+    ".llmwiki-state.json",
+    ".llmwiki-quarantine.json",
+    ".venv/lib/python3.12/something.py",
+    "node_modules/some-pkg/index.js",
+    "tests/test_secret_helper.py",   # tests/ deliberately not allowlisted
+    "llmwiki/cli.py",                 # source code not allowlisted
+    "pyproject.toml",                 # root config not allowlisted
+])
+def test_blocked_paths_rejected(rel: str):
+    assert not _is_read_page_allowed(REPO_ROOT / rel), (
+        f"{rel!r} should NOT be readable via MCP — it leaks "
+        f"sensitive host info or source code"
+    )
+
+
+# ─── tool_wiki_read_page integration ───────────────────────────────────
+
+
+def test_tool_rejects_state_file_with_helpful_error():
+    """The original bug pattern: state file contains absolute paths
+    to every Claude session on the host."""
+    res = tool_wiki_read_page({"path": ".llmwiki-state.json"})
+    assert res.get("isError") is True or "outside the readable surface" in str(res), res
+    # Error message should name the allowed dirs so the caller knows
+    # what to ask for instead.
+    body = str(res)
+    assert "wiki" in body and "raw" in body, (
+        f"error message should list allowed dirs: {body}"
+    )
+
+
+def test_tool_accepts_changelog():
+    res = tool_wiki_read_page({"path": "CHANGELOG.md"})
+    # Should NOT be a permission-style error — file exists, content returned.
+    assert res.get("isError") is not True or "outside the readable surface" not in str(res)
+
+
+def test_tool_rejects_dot_env_even_if_present(tmp_path: Path, monkeypatch):
+    """Belt-and-braces: even if a user puts `.env` in REPO_ROOT
+    (gitignored, but happens), it must not be readable via MCP."""
+    # Create a fake .env at REPO_ROOT (cleanup needed)
+    env_path = REPO_ROOT / ".env"
+    created = False
+    if not env_path.exists():
+        env_path.write_text("API_KEY=secret\n", encoding="utf-8")
+        created = True
+    try:
+        res = tool_wiki_read_page({"path": ".env"})
+        assert "outside the readable surface" in str(res) or res.get("isError"), res
+        # Critical: secret content must NOT appear in the response.
+        assert "API_KEY=secret" not in str(res)
+    finally:
+        if created:
+            env_path.unlink()


### PR DESCRIPTION
Closes #482.

`tool_wiki_read_page` was readable for any file under REPO_ROOT — including `.env`, `.git/config`, `.llmwiki-state.json` (host directory listing leak). Now restricted to `wiki/raw/docs/examples/site/` + 4 root files.

## Test plan

- [x] `pytest tests/test_mcp_read_page_allowlist.py` — 23/23
- [x] 9 allowlisted paths pass
- [x] 11 blocked sensitive paths rejected (.env, .git/, state, .venv, node_modules, tests, source, root configs)
- [x] Belt-and-braces: even a real `.env` placed at REPO_ROOT cannot leak content via MCP