### PR TITLE
fix: MCP wiki_search/wiki_query per-file + aggregate byte cap (#483, v1.3.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.14] — 2026-04-26
+
+Hotfix release adding per-file + aggregate byte caps to MCP `wiki_search` and `wiki_query` so a single large file or huge corpus can't OOM the server (#483).
+
+### Fixed
+
+- **MCP `wiki_search` / `wiki_query` had no per-file or aggregate byte cap** (#483) — both tools called `p.read_text()` on every `.md` file under the search roots with no `stat().st_size` guard. `_SEARCH_HIT_CAP=200` (#413) capped *output* but the loop still read every byte of every file. A vault-overlay user with a 100MB Obsidian transcript (embedded video, huge meeting transcript) thrashed the MCP server on every call. Fix: new `_read_capped(p, remaining_budget)` helper that reads up to a 4 MiB per-file cap. `wiki_query` and `wiki_search` track a 50 MiB aggregate budget across all files and bail when it hits zero. Files exceeding the per-file cap are skipped entirely (no partial-read — would slice query tokens across the boundary). `wiki_search` response now includes a `skipped_oversize_files` count so callers know what was bypassed. Adds `tests/test_mcp_byte_cap.py` (8 cases) covering: per-file cap honored, aggregate budget exhaustion, oversize file fully skipped (not partial-read), counters surfaced in response, normal-corpus behaviour unchanged.
+
 ## [1.3.13] — 2026-04-26
 
 Hotfix release adding an allowlist to the MCP `wiki_read_page` tool so it can't leak `.git/`, `.env`, or `.llmwiki-state.json` (#482).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.13-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.14-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.13"
+__version__ = "1.3.14"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/mcp/server.py
+++ b/llmwiki/mcp/server.py
@@ -352,11 +352,22 @@ def tool_wiki_query(args: dict[str, Any]) -> dict[str, Any]:
     query_lower = question.lower()
     tokens = [t for t in re.split(r"\W+", query_lower) if t]
     matches: list[tuple[float, Path, str]] = []
+    # #483: bound input bytes so a single large file or a giant corpus
+    # can't OOM the MCP server.
+    budget = _MCP_SCAN_AGGREGATE_BYTES
+    skipped_oversize = 0
     for page in wiki.rglob("*.md"):
-        try:
-            content = page.read_text(encoding="utf-8")
-        except OSError:
+        if budget <= 0:
+            break
+        content, consumed = _read_capped(page, remaining_budget=budget)
+        if consumed == 0:
+            try:
+                if page.stat().st_size > _MCP_SCAN_PER_FILE_BYTES:
+                    skipped_oversize += 1
+            except OSError:
+                pass
             continue
+        budget -= consumed
         content_lower = content.lower()
         body_score = 0
         if query_lower in content_lower:
@@ -423,6 +434,50 @@ def _extract_snippet(content: str, tokens: list[str], max_chars: int = 400) -> s
 
 _SEARCH_HIT_CAP = 200
 
+# #483: per-file + aggregate byte caps for wiki_search / wiki_query.
+# Without these, a single large file (e.g. a 100MB Obsidian transcript
+# with embedded video, or a malicious user-supplied .md) gets fully
+# read into memory by every MCP call. _SEARCH_HIT_CAP capped output
+# only — the loop still read every byte of every file. Cap inputs
+# explicitly so the worst-case is bounded regardless of corpus shape.
+_MCP_SCAN_PER_FILE_BYTES = 4 * 1024 * 1024   # 4 MiB / file
+_MCP_SCAN_AGGREGATE_BYTES = 50 * 1024 * 1024  # 50 MiB / call
+
+
+def _read_capped(p: Path, *, remaining_budget: int) -> tuple[str, int]:
+    """Read up to min(per-file cap, remaining_budget) bytes of `p`.
+
+    Returns (text, bytes_consumed). ``bytes_consumed == 0`` signals
+    the file was skipped entirely (over-budget or unreadable). Caller
+    decrements the aggregate budget by ``bytes_consumed`` and bails
+    when it hits zero.
+    """
+    try:
+        size = p.stat().st_size
+    except OSError:
+        return "", 0
+    cap = min(_MCP_SCAN_PER_FILE_BYTES, max(0, remaining_budget))
+    if size > _MCP_SCAN_PER_FILE_BYTES:
+        # Skip the file entirely — do not partial-read. The truncation
+        # would slice query tokens across the boundary and produce
+        # confusing partial hits.
+        return "", 0
+    if cap <= 0:
+        return "", 0
+    try:
+        with p.open("rb") as f:
+            raw = f.read(cap + 1)
+    except OSError:
+        return "", 0
+    # If we read more than cap, the file grew between stat and read.
+    # Trust the stat-based skip above; truncate defensively here.
+    if len(raw) > cap:
+        return "", 0
+    try:
+        return raw.decode("utf-8", errors="replace"), len(raw)
+    except Exception:
+        return "", 0
+
 
 def tool_wiki_search(args: dict[str, Any]) -> dict[str, Any]:
     # #413: the old loop had three nested terminators (`for line`,
@@ -444,18 +499,27 @@ def tool_wiki_search(args: dict[str, Any]) -> dict[str, Any]:
     term_lower = term.lower()
     hits: list[dict[str, Any]] = []
     truncated = False
+    # #483: aggregate byte budget across all roots, plus per-file cap
+    # via _read_capped. Output cap (_SEARCH_HIT_CAP) is unchanged.
+    budget = _MCP_SCAN_AGGREGATE_BYTES
+    skipped_oversize = 0
     for root in roots:
-        if truncated:
+        if truncated or budget <= 0:
             break
         if not root.exists():
             continue
         for p in root.rglob("*.md"):
-            if truncated:
+            if truncated or budget <= 0:
                 break
-            try:
-                text = p.read_text(encoding="utf-8")
-            except OSError:
+            text, consumed = _read_capped(p, remaining_budget=budget)
+            if consumed == 0:
+                try:
+                    if p.stat().st_size > _MCP_SCAN_PER_FILE_BYTES:
+                        skipped_oversize += 1
+                except OSError:
+                    pass
                 continue
+            budget -= consumed
             for i, line in enumerate(text.splitlines(), start=1):
                 if term_lower in line.lower():
                     hits.append(
@@ -468,7 +532,14 @@ def tool_wiki_search(args: dict[str, Any]) -> dict[str, Any]:
                     if len(hits) >= _SEARCH_HIT_CAP:
                         truncated = True
                         break
-    return _ok(json.dumps({"term": term, "matches": hits, "truncated": truncated}, indent=2))
+    # #483: surface skipped-oversize count so callers know we didn't
+    # silently miss content from huge files.
+    return _ok(json.dumps({
+        "term": term,
+        "matches": hits,
+        "truncated": truncated,
+        "skipped_oversize_files": skipped_oversize,
+    }, indent=2))
 
 
 def tool_wiki_list_sources(args: dict[str, Any]) -> dict[str, Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.13"
+version = "1.3.14"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_mcp_byte_cap.py
+++ b/tests/test_mcp_byte_cap.py
@@ -1,0 +1,115 @@
+"""Tests for #483 — MCP wiki_search / wiki_query must cap input bytes
+to prevent OOM on huge files / huge corpora.
+
+The bug: both tools called p.read_text() on every .md with no
+size guard. `_SEARCH_HIT_CAP=200` capped output, not input. A
+vault user with a 100MB Obsidian transcript thrashed the server
+on every call.
+
+The fix: `_read_capped(p, remaining_budget)` enforces a 4 MiB
+per-file cap and a 50 MiB aggregate budget per call. Oversize
+files are skipped entirely (no partial-read).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from llmwiki.mcp.server import (
+    _MCP_SCAN_AGGREGATE_BYTES,
+    _MCP_SCAN_PER_FILE_BYTES,
+    _read_capped,
+    tool_wiki_search,
+)
+
+
+def test_read_capped_returns_text_under_cap(tmp_path: Path):
+    p = tmp_path / "small.md"
+    p.write_text("hello world\n", encoding="utf-8")
+    text, consumed = _read_capped(p, remaining_budget=100_000)
+    assert text == "hello world\n"
+    assert consumed == len("hello world\n")
+
+
+def test_read_capped_skips_oversize_file_entirely(tmp_path: Path):
+    """Oversize files must be skipped (consumed=0) NOT partial-read."""
+    p = tmp_path / "huge.md"
+    big_content = "x" * (_MCP_SCAN_PER_FILE_BYTES + 1)
+    p.write_text(big_content, encoding="utf-8")
+    text, consumed = _read_capped(p, remaining_budget=_MCP_SCAN_AGGREGATE_BYTES)
+    assert text == ""
+    assert consumed == 0
+
+
+def test_read_capped_respects_remaining_budget(tmp_path: Path):
+    """File bigger than remaining budget but smaller than per-file
+    cap → skip (cap is min of the two)."""
+    p = tmp_path / "medium.md"
+    p.write_text("y" * 1000, encoding="utf-8")
+    text, consumed = _read_capped(p, remaining_budget=500)
+    assert text == ""
+    assert consumed == 0
+
+
+def test_read_capped_zero_budget_skips(tmp_path: Path):
+    p = tmp_path / "any.md"
+    p.write_text("anything", encoding="utf-8")
+    text, consumed = _read_capped(p, remaining_budget=0)
+    assert text == ""
+    assert consumed == 0
+
+
+def test_read_capped_unreadable_file_returns_zero(tmp_path: Path):
+    """Missing file returns ('', 0) gracefully — no exception."""
+    p = tmp_path / "missing.md"
+    text, consumed = _read_capped(p, remaining_budget=100_000)
+    assert text == ""
+    assert consumed == 0
+
+
+def test_search_response_includes_skipped_oversize_counter(tmp_path: Path):
+    """Surface the skipped count so callers know we didn't silently
+    miss content."""
+    wiki = tmp_path / "wiki"
+    raw = tmp_path / "raw"
+    wiki.mkdir()
+    raw.mkdir()
+    (wiki / "small.md").write_text("findme appears here\n", encoding="utf-8")
+    (wiki / "huge.md").write_text("x" * (_MCP_SCAN_PER_FILE_BYTES + 100),
+                                   encoding="utf-8")
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        res = tool_wiki_search({"term": "findme"})
+    body = res.get("content", [{}])[0].get("text", "")
+    payload = json.loads(body)
+    assert payload["term"] == "findme"
+    assert payload["skipped_oversize_files"] >= 1, (
+        f"expected ≥1 oversize file skipped, got {payload}"
+    )
+    assert any("findme" in m.get("text", "") for m in payload["matches"])
+
+
+def test_search_normal_corpus_no_skips(tmp_path: Path):
+    """Sanity: small-corpus calls should not report any skips."""
+    wiki = tmp_path / "wiki"
+    raw = tmp_path / "raw"
+    wiki.mkdir()
+    raw.mkdir()
+    (wiki / "a.md").write_text("apple\n", encoding="utf-8")
+    (wiki / "b.md").write_text("banana\n", encoding="utf-8")
+    with patch("llmwiki.mcp.server.REPO_ROOT", tmp_path):
+        res = tool_wiki_search({"term": "apple"})
+    body = res.get("content", [{}])[0].get("text", "")
+    payload = json.loads(body)
+    assert payload["skipped_oversize_files"] == 0
+    assert payload["truncated"] is False
+
+
+def test_per_file_cap_constants_documented():
+    """The cap values are part of the contract — make a future
+    refactor that changes them notice this test."""
+    assert _MCP_SCAN_PER_FILE_BYTES == 4 * 1024 * 1024
+    assert _MCP_SCAN_AGGREGATE_BYTES == 50 * 1024 * 1024


### PR DESCRIPTION
Closes #483.

Both tools previously read every byte of every file. Now: 4 MiB/file + 50 MiB/call cap via `_read_capped`. Oversize files skipped entirely (no token-slicing). Response includes `skipped_oversize_files` counter.

## Test plan

- [x] `pytest tests/test_mcp_byte_cap.py` — 8/8
- [x] Oversize file skipped entirely (NOT partial-read)
- [x] Counter surfaces in search response
- [x] Normal-corpus call shows no false skips