### PR TITLE
fix: extend default redaction to Anthropic/OpenAI/Google/Stripe/JWT/PEM (#484, v1.3.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.15] — 2026-04-26
+
+Hotfix release extending default redaction to cover the keys that get pasted into LLM sessions most often (#484).
+
+### Fixed
+
+- **Default redaction missed Anthropic / OpenAI / Google / Stripe / JWT / private keys** (#484) — `_DEFAULT_TOKEN_PATTERNS` previously covered GitHub PATs, AWS access key IDs, and Slack tokens only (#416 contract). Developers commonly paste env blocks into Claude sessions ("here's my .env, why is auth failing?") — those got committed to `raw/` and served at the public GitHub Pages URL. Extended defaults to also catch: `sk-ant-api03-...` (Anthropic), `sk-proj-...` / `sk-svcacct-...` / generic `sk-...` (OpenAI), `AIza[35-char]` (Google), `sk_live_...` / `pk_live_...` / `rk_live_...` (Stripe live + restricted; test keys intentionally NOT redacted), `npm_[36-char]` (npm registry), JWT 3-segment structure starting `eyJ.eyJ.sig`, and full PEM `-----BEGIN/END PRIVATE KEY-----` envelopes (multi-line via DOTALL). All run unconditionally per the #416 contract — no config opt-in needed. Adds `tests/test_default_redaction.py` (16 cases) covering positive matches for each new pattern + negative cases (Stripe test keys preserved, lowercase `aiza` not matched, generic dotted strings not JWT-classified).
+
 ## [1.3.14] — 2026-04-26
 
 Hotfix release adding per-file + aggregate byte caps to MCP `wiki_search` and `wiki_query` so a single large file or huge corpus can't OOM the server (#483).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.14-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.15-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.14"
+__version__ = "1.3.15"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/convert.py
+++ b/llmwiki/convert.py
@@ -459,26 +459,74 @@ def most_common_model(records: list[dict[str, Any]]) -> str:
 
 # ─── redaction + truncation ────────────────────────────────────────────────
 
-# #416: default token shapes that should be redacted out of any session
-# transcript regardless of user config. The CLAUDE.md security model
-# promises redaction "before anything hits disk" — these patterns close
-# the gap left by relying on user-provided `extra_patterns`.
+# #416 + #484: default token shapes redacted out of every session
+# transcript regardless of user config. CLAUDE.md security model
+# promises redaction "before anything hits disk" — these patterns
+# close the gap left by relying on user-provided `extra_patterns`.
 #
-# - GitHub PATs: `ghp_*` (classic), `gho_*` (OAuth), `ghs_*` (server-to-
-#   server), `ghu_*` (user-to-server), `github_pat_*` (fine-grained)
+# Original (#416):
+# - GitHub PATs: `ghp_*` (classic), `gho_*` (OAuth), `ghs_*`
+#   (server-to-server), `ghu_*` (user-to-server), `github_pat_*`
+#   (fine-grained)
 # - AWS access key IDs: `AKIA*` (20 chars total)
 # - Slack tokens: `xoxb-*`, `xoxp-*`, `xoxa-*`, `xoxr-*`, `xoxs-*`
 #
-# These run AFTER user `extra_patterns` so users can override with a
-# more permissive matcher if they really need to (e.g. test fixtures).
+# Extended (#484) — added the patterns Pratiyush's developers most
+# commonly paste into Claude sessions ("here's my .env, why isn't
+# auth working?"). Anything below this comment is one PEM-encoded
+# / one prefix-shaped paste away from being committed to raw/ and
+# served at the public GitHub Pages URL by the pages.yml workflow:
+#
+# - Anthropic API keys: `sk-ant-api03-*` (and any future variant)
+# - OpenAI keys: classic `sk-*`, project keys `sk-proj-*`,
+#   service-account keys `sk-svcacct-*`
+# - Google API keys: `AIza[A-Za-z0-9_-]{35}`
+# - Stripe live keys: `sk_live_*`, `pk_live_*` (publishable too —
+#   leak associates the project with you even if revoked)
+# - npm tokens: `npm_[A-Za-z0-9]{36}`
+# - JWT structure: `eyJ...eyJ...sig` (loose 3-segment shape)
+# - PEM private keys: full BEGIN/END envelope
+#
+# These run AFTER user `extra_patterns` so users can override.
 _DEFAULT_TOKEN_PATTERNS = [
+    # GitHub
     re.compile(r"\bghp_[A-Za-z0-9_]{20,}\b"),
     re.compile(r"\bgho_[A-Za-z0-9_]{20,}\b"),
     re.compile(r"\bghs_[A-Za-z0-9_]{20,}\b"),
     re.compile(r"\bghu_[A-Za-z0-9_]{20,}\b"),
     re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"),
+    # AWS
     re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    # Slack
     re.compile(r"\bxox[abprs]-[A-Za-z0-9-]{10,}\b"),
+    # #484: Anthropic API keys
+    re.compile(r"\bsk-ant-api[0-9]{2}-[A-Za-z0-9_-]{20,}\b"),
+    # #484: OpenAI keys (project + service-account variants must come
+    # BEFORE the generic `sk-` rule below so they match more specifically).
+    re.compile(r"\bsk-proj-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\bsk-svcacct-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b"),
+    # #484: Google API keys (39 chars total: AIza + 35)
+    re.compile(r"\bAIza[A-Za-z0-9_-]{35}\b"),
+    # #484: Stripe live + restricted keys (test keys `sk_test_*` are
+    # intentionally not redacted — they're meant to ship in code).
+    re.compile(r"\bsk_live_[0-9a-zA-Z]{24,}\b"),
+    re.compile(r"\bpk_live_[0-9a-zA-Z]{24,}\b"),
+    re.compile(r"\brk_live_[0-9a-zA-Z]{24,}\b"),
+    # #484: npm registry tokens
+    re.compile(r"\bnpm_[A-Za-z0-9]{36}\b"),
+    # #484: JWT shape — 3 base64url segments separated by `.`. Loose
+    # enough to catch most JWTs without false-positiving on every dotted
+    # token. Header MUST start `eyJ` (`{"`) which is the canonical JWT
+    # opening; payload likewise.
+    re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b"),
+    # #484: PEM-encoded private keys. Multi-line via `re.DOTALL`.
+    re.compile(
+        r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |ENCRYPTED |PGP )?PRIVATE KEY-----"
+        r".*?"
+        r"-----END (?:RSA |EC |DSA |OPENSSH |ENCRYPTED |PGP )?PRIVATE KEY-----",
+        re.DOTALL,
+    ),
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.14"
+version = "1.3.15"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_default_redaction.py
+++ b/tests/test_default_redaction.py
@@ -1,0 +1,171 @@
+"""Tests for #484 — default redaction covers Anthropic/OpenAI/Google/
+Stripe/JWT/PEM keys.
+
+The original #416 contract: GitHub PATs + AWS keys + Slack tokens
+unconditionally redacted. Extended in #484 to cover the keys
+developers most commonly paste into Claude sessions:
+
+- Anthropic: sk-ant-api03-...
+- OpenAI: sk-..., sk-proj-..., sk-svcacct-...
+- Google: AIza[35-char]
+- Stripe: sk_live_..., pk_live_..., rk_live_...
+- npm: npm_[36-char]
+- JWT: eyJ.eyJ.sig 3-segment shape
+- PEM: full BEGIN/END PRIVATE KEY envelope
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llmwiki.convert import Redactor, DEFAULT_CONFIG
+
+
+@pytest.fixture
+def redactor():
+    """Default redactor with no extra patterns — exercises only the
+    built-in _DEFAULT_TOKEN_PATTERNS."""
+    cfg = {"redaction": {"real_username": "", "extra_patterns": []}}
+    return Redactor(cfg)
+
+
+# ─── positive matches: each new pattern catches its target ──────────────
+
+
+def test_anthropic_key_redacted(redactor):
+    text = "ANTHROPIC_API_KEY=sk-ant-api03-abcdefghij1234567890XXX-_"
+    out = redactor(text)
+    assert "sk-ant-api03" not in out
+    assert "abcdefghij1234567890" not in out
+
+
+def test_openai_classic_key_redacted(redactor):
+    text = "OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwx"
+    out = redactor(text)
+    assert "abcdefghij" not in out
+
+
+def test_openai_project_key_redacted(redactor):
+    text = "OPENAI_PROJECT=sk-proj-abc123def456ghi789jkl012mno345"
+    out = redactor(text)
+    assert "abc123" not in out
+
+
+def test_openai_service_account_key_redacted(redactor):
+    text = "OPENAI_SVCACCT=sk-svcacct-XYZ123def456ghi789jkl012mno345"
+    out = redactor(text)
+    assert "XYZ123" not in out
+
+
+def test_google_api_key_redacted(redactor):
+    # AIza + exactly 35 chars. Built via concatenation so GitHub's
+    # secret-scanner doesn't flag this test file as containing a
+    # real Google API key.
+    fake_key = "AI" + "za" + "SyD-9tSrke72PouQMnMX-a7eZSW0jkFMBWY"
+    text = f"GOOGLE_API_KEY={fake_key}"
+    out = redactor(text)
+    assert fake_key[:8] not in out
+
+
+def test_stripe_live_secret_key_redacted(redactor):
+    # Concatenated so GitHub's secret-scanner doesn't flag the
+    # contiguous `sk_live_*` literal in this test file.
+    fake_key = "sk" + "_live_" + "51HabcDEFghiJKLmnoPQRstuVWXyz"
+    text = f"STRIPE={fake_key}"
+    out = redactor(text)
+    assert "_live_" not in out  # the prefix part of the fake key gone
+
+
+def test_stripe_publishable_live_key_redacted(redactor):
+    fake_key = "pk" + "_live_" + "51HabcDEFghiJKLmnoPQRstuVWXyz"
+    text = f"STRIPE_PUB={fake_key}"
+    out = redactor(text)
+    assert "_live_" not in out
+
+
+def test_stripe_restricted_live_key_redacted(redactor):
+    fake_key = "rk" + "_live_" + "51HabcDEFghiJKLmnoPQRstuVWXyz"
+    text = f"STRIPE_RK={fake_key}"
+    out = redactor(text)
+    assert "_live_" not in out
+
+
+def test_npm_token_redacted(redactor):
+    text = "NPM_TOKEN=npm_abcdefghijklmnopqrstuvwxyz0123456789"
+    out = redactor(text)
+    assert "npm_abc" not in out
+
+
+def test_jwt_redacted(redactor):
+    # eyJ header + eyJ payload + signature, all base64url-shaped
+    text = (
+        "Authorization: Bearer "
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+        "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4ifQ."
+        "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+    )
+    out = redactor(text)
+    assert "eyJhbGciOi" not in out
+
+
+def _pem(kind: str = "", body: str = "MIIE-fake-body") -> str:
+    """Build a PEM envelope at runtime so gitleaks doesn't flag the
+    test file itself as containing a private key. The literal string
+    `-----BEGIN ... PRIVATE KEY-----` never appears in source."""
+    label = (kind + " ").lstrip()
+    dashes = "-" * 5
+    return (
+        f"{dashes}BEGIN {label}PRIVATE KEY{dashes}\n"
+        f"{body}\n"
+        f"{dashes}END {label}PRIVATE KEY{dashes}"
+    )
+
+
+def test_pem_private_key_redacted(redactor):
+    text = _pem(body="MIIEvQ-secret-content-line-1\nsecret-content-line-2")
+    out = redactor(text)
+    assert "secret-content-line" not in out
+    assert "MIIEvQ" not in out
+
+
+def test_pem_rsa_private_key_redacted(redactor):
+    """Variants like RSA, EC, OPENSSH, etc. should also be caught."""
+    for kind in ("RSA", "EC", "DSA", "OPENSSH", "ENCRYPTED"):
+        text = _pem(kind=kind, body=f"VERY-SECRET-{kind}-MATERIAL")
+        out = redactor(text)
+        assert f"VERY-SECRET-{kind}" not in out, f"failed on {kind}"
+
+
+# ─── negative cases: don't over-match ───────────────────────────────────
+
+
+def test_stripe_test_key_NOT_redacted(redactor):
+    """Test keys are meant to ship in code — leaving them visible is
+    a feature. Built via concat so GitHub doesn't flag `sk_test_`."""
+    fake_test = "sk" + "_test_" + "51HabcDEFghiJKLmnoPQRstuVWX"
+    text = f"STRIPE_TEST={fake_test}"
+    out = redactor(text)
+    assert "_test_" in out
+
+
+def test_lowercase_aiza_not_matched(redactor):
+    """Google keys are case-sensitive — `aiza...` is not a key."""
+    text = "var name = aizabcdefghijklmnopqrstuvwxyz0123456789"
+    out = redactor(text)
+    assert "aizabcdefghijk" in out
+
+
+def test_dotted_string_not_classified_as_jwt(redactor):
+    """A generic three-segment dotted string (not starting with eyJ)
+    must not be JWT-classified."""
+    text = "module.submodule.function"
+    out = redactor(text)
+    assert "module.submodule.function" in out
+
+
+def test_short_sk_substring_not_redacted(redactor):
+    """`sk-` followed by <20 chars is too short to be an API key."""
+    text = "git checkout sk-feature-branch"
+    out = redactor(text)
+    # `sk-feature-branch` is 17 chars after `sk-`, below the 20-char threshold
+    assert "sk-feature-branch" in out


### PR DESCRIPTION
Closes #484.

Extended `_DEFAULT_TOKEN_PATTERNS` from 3 token families to 11. Devs commonly paste env blocks into Claude sessions; those shouldn't ship to GitHub Pages.

## Test plan

- [x] `pytest tests/test_default_redaction.py` — 16/16
- [x] All 8 new patterns redact realistic samples
- [x] Stripe test keys preserved (intentional)
- [x] Lowercase `aiza`, dotted module paths, short `sk-` substrings untouched
- [x] Test fixtures built via string concat so GitHub secret-scanner doesn't false-positive on the test file