### PR TITLE
fix: extend username redaction to D:/E:/cygwin/WSL paths (#485, v1.3.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.16] — 2026-04-26
+
+Hotfix release extending username redaction to cover Windows non-C drives, Cygwin, WSL UNC, and Windows extended-length paths (#485).
+
+### Fixed
+
+- **Username redaction missed D:/, E:/, Cygwin, WSL UNC, and `\\\\?\\` extended-length prefixes** (#485) — `_redact_username` previously covered `/Users/`, `/home/`, `C:\\Users\\`, `C:/Users/`, `/mnt/<letter>/Users/`. Windows users with their profile on a non-C drive (corporate split-disk policy is common: OS on C:, profiles on D:) had their actual username leak verbatim into every `cwd:` frontmatter field and every Bash tool preview. Same for Cygwin (`/cygdrive/c/Users/<u>`), Windows extended-length paths (`\\\\?\\C:\\Users\\<u>` from APIs bypassing MAX_PATH), and WSL UNC paths (`\\\\wsl.localhost\\Ubuntu\\home\\<u>`, `\\\\wsl$\\Ubuntu\\home\\<u>`). Fix: extended the prefix alternation in the redactor regex to include all 5 new shapes. Adds `tests/test_username_redact_paths.py` (10 cases) covering each new prefix variant + a regression test for the existing macOS/Linux/Windows-C/WSL-mnt paths.
+
 ## [1.3.15] — 2026-04-26
 
 Hotfix release extending default redaction to cover the keys that get pasted into LLM sessions most often (#484).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.15-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.16-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.15"
+__version__ = "1.3.16"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/convert.py
+++ b/llmwiki/convert.py
@@ -557,6 +557,16 @@ class Redactor:
         #416: covers macOS (`/Users/<u>`), Linux (`/home/<u>`), Windows
         (`C:\\Users\\<u>` plus mixed-separator variants users hit when
         copy-pasting between shells), and WSL (`/mnt/c/Users/<u>`).
+
+        #485: extended to cover Windows non-C drives (`D:\\Users\\`,
+        `E:\\Users\\`, every drive letter), Cygwin
+        (`/cygdrive/<letter>/Users/<u>`), Windows extended-length
+        prefix (`\\\\?\\C:\\Users\\<u>`), and WSL UNC
+        (`\\\\wsl.localhost\\<distro>\\home\\<u>`,
+        `\\\\wsl$\\<distro>\\home\\<u>`). All variants users hit in
+        the wild on a multi-drive Windows box or a Cygwin/WSL
+        environment.
+
         Username can contain hyphens, underscores, and unicode.
         """
         u = re.escape(self.real_user)
@@ -566,11 +576,27 @@ class Redactor:
         # the real user. The username group is itself the only thing
         # we substitute — separators and prefix are preserved.
         prefixes = (
+            # Original (#416): macOS / Linux / Windows C: / WSL /mnt
             r"/Users/",
             r"/home/",
             r"C:\\Users\\",
             r"C:/Users/",
             r"/mnt/[a-z]/Users/",
+            # #485: Windows non-C drives (D, E, F, ...) — both backslash
+            # and forward-slash forms (Powershell prints either depending
+            # on origin).
+            r"[A-Za-z]:\\Users\\",
+            r"[A-Za-z]:/Users/",
+            # #485: Cygwin home format
+            r"/cygdrive/[a-z]/Users/",
+            # #485: Windows extended-length path prefix `\\?\C:\Users\`
+            # (used by APIs that bypass MAX_PATH; appears in some tool
+            # output).
+            r"\\\\\?\\[A-Za-z]:\\Users\\",
+            # #485: WSL UNC prefixes — both modern (`wsl.localhost`) and
+            # legacy (`wsl$`). Distro name allows letters/digits/hyphens.
+            r"\\\\wsl\.localhost\\[A-Za-z0-9_-]+\\home\\",
+            r"\\\\wsl\$\\[A-Za-z0-9_-]+\\home\\",
         )
         pattern = re.compile(
             r"(?P<prefix>" + "|".join(prefixes) + r")"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.15"
+version = "1.3.16"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_username_redact_paths.py
+++ b/tests/test_username_redact_paths.py
@@ -1,0 +1,105 @@
+"""Tests for #485 — username redaction across Windows D:/E:/cygwin/WSL.
+
+Bug: `_redact_username` covered only `/Users/`, `/home/`, `C:\\Users\\`,
+`C:/Users/`, `/mnt/<letter>/Users/`. Missed Windows non-C drives,
+Cygwin (`/cygdrive/c/Users/`), Windows extended-length prefix
+(`\\\\?\\C:\\Users\\`), WSL UNC (`\\\\wsl.localhost\\<distro>\\home\\`,
+`\\\\wsl$\\<distro>\\home\\`).
+
+Fix: extended the prefix alternation to cover all 5 new shapes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llmwiki.convert import Redactor
+
+
+@pytest.fixture
+def redactor():
+    cfg = {
+        "redaction": {
+            "real_username": "alice",
+            "replacement_username": "USER",
+            "extra_patterns": [],
+        },
+    }
+    return Redactor(cfg)
+
+
+@pytest.mark.parametrize("path", [
+    "/Users/alice/code",
+    "/home/alice/code",
+    r"C:\Users\alice\code",
+    "C:/Users/alice/code",
+    "/mnt/c/Users/alice/code",
+])
+def test_existing_prefixes_still_redact(redactor, path: str):
+    out = redactor(path)
+    assert "alice" not in out
+    assert "USER" in out
+
+
+@pytest.mark.parametrize("path", [
+    r"D:\Users\alice\code",
+    r"E:\Users\alice\code",
+    r"F:\Users\alice\code",
+    "D:/Users/alice/code",
+    "E:/Users/alice/code",
+])
+def test_windows_non_c_drives_redacted(redactor, path: str):
+    out = redactor(path)
+    assert "alice" not in out, f"failed to redact {path!r}"
+    assert "USER" in out
+
+
+def test_cygwin_path_redacted(redactor):
+    path = "/cygdrive/c/Users/alice/code"
+    out = redactor(path)
+    assert "alice" not in out
+    assert "USER" in out
+
+
+def test_cygwin_path_other_drive_redacted(redactor):
+    path = "/cygdrive/d/Users/alice/code"
+    out = redactor(path)
+    assert "alice" not in out
+
+
+def test_windows_extended_length_prefix_redacted(redactor):
+    path = r"\\?\C:\Users\alice\code"
+    out = redactor(path)
+    assert "alice" not in out
+
+
+def test_wsl_localhost_unc_redacted(redactor):
+    path = r"\\wsl.localhost\Ubuntu\home\alice\code"
+    out = redactor(path)
+    assert "alice" not in out
+
+
+def test_wsl_legacy_unc_redacted(redactor):
+    path = r"\\wsl$\Ubuntu\home\alice\code"
+    out = redactor(path)
+    assert "alice" not in out
+
+
+def test_wsl_unc_distro_with_hyphen_redacted(redactor):
+    """Distro names like `Debian-12`, hyphens allowed."""
+    path = r"\\wsl.localhost\Debian-12\home\alice\code"
+    out = redactor(path)
+    assert "alice" not in out
+
+
+def test_unrelated_alice_substring_not_redacted(redactor):
+    """`alice` outside a recognised prefix must NOT be touched."""
+    out = redactor("Function aliceWrapper handles auth.")
+    assert "aliceWrapper" in out
+
+
+def test_alice_in_url_not_redacted(redactor):
+    """`/users/alice/` (lowercase 'users' in a URL path) must not match
+    the `/Users/` prefix."""
+    out = redactor("https://example.com/users/alice/profile")
+    assert "alice" in out


### PR DESCRIPTION
Closes #485.

Username redaction now covers Windows non-C drives, Cygwin, Windows extended-length `\\?\` prefix, and WSL UNC paths (modern + legacy). Previously usernames leaked verbatim on these path shapes.

## Test plan

- [x] `pytest tests/test_username_redact_paths.py` — 18/18
- [x] All 5 existing prefixes still redact (regression guard)
- [x] All 5 new prefix variants redact (D:/E:/cygwin/extended/WSL UNC)
- [x] Substring 'alice' in prose / lowercase 'users' in URL not over-matched