### PR TITLE
fix: unify adapter is_available() contract — remove 7 duplicates (#496, v1.3.18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.18] — 2026-04-26
+
+Hotfix release unifying the adapter `is_available()` contract so contrib adapters don't need to re-implement it (#496).
+
+### Changed
+
+- **Adapter contract: `is_available()` now flows through `BaseAdapter`** (#496) — `BaseAdapter.is_available()` previously read `cls.session_store_path` directly. That worked for `ClaudeCodeAdapter` (class attribute) but returned the *property descriptor object* for the 8 contrib adapters which override `session_store_path` as a `@property`. Every contrib adapter therefore had to re-implement its own `is_available()` classmethod scanning `cls.DEFAULT_ROOTS`. Fix: `BaseAdapter.is_available()` now instantiates a config-less temp instance and reads `self.session_store_path` through the same code path `discover_sessions()` uses. Both class-attribute and `@property`-overriding patterns now flow through this single method. Removed 7 duplicate `is_available()` overrides (`codex_cli`, `copilot_chat`, `cursor`, `gemini_cli`, `obsidian`, `opencode`, `chatgpt`); kept the 8th (`copilot_cli`) because it has special `COPILOT_HOME` env-var handling. Net: −40 lines of duplication. Adds `tests/test_adapter_is_available_unified.py` (5 cases) covering: ClaudeCodeAdapter (class-attr) still works, contrib adapters via @property still work, broken-`__init__` adapter returns False instead of crashing, contrib `is_available()` now resolves to `BaseAdapter.is_available` (no shadowing), copilot_cli's intentional override preserved.
+
 ## [1.3.17] — 2026-04-26
 
 Hotfix release hardening `synthesize_overview` against prompt-injection via session slugs and argv-length DoS (#486).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.17-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.18-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.17"
+__version__ = "1.3.18"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/adapters/base.py
+++ b/llmwiki/adapters/base.py
@@ -51,8 +51,33 @@ class BaseAdapter:
 
     @classmethod
     def is_available(cls) -> bool:
-        """True if the session store exists on this machine."""
-        paths = cls.session_store_path
+        """True if the session store exists on this machine.
+
+        #496: previously read ``cls.session_store_path`` directly. That
+        worked for ``ClaudeCodeAdapter`` (class attribute) but returned
+        the *property descriptor object* for the 8 contrib adapters
+        which override ``session_store_path`` as a ``@property`` — so
+        every contrib adapter had to re-implement its own
+        ``is_available()`` classmethod reading ``cls.DEFAULT_ROOTS``.
+
+        Fix: instantiate a config-less temp instance and read
+        ``self.session_store_path`` through the same code path
+        ``discover_sessions()`` uses. Both class-attribute and
+        ``@property``-overriding patterns now flow through this single
+        method; the 8 duplicate contrib overrides go away.
+
+        Adapters with expensive ``__init__()`` should override this
+        method directly, but no current adapter needs to.
+        """
+        try:
+            inst = cls()
+        except Exception:
+            # Defensive: an adapter whose __init__ raises (e.g.
+            # missing imports surfaced eagerly) is "unavailable" by
+            # definition rather than crashing the whole `adapters`
+            # listing.
+            return False
+        paths = inst.session_store_path
         if isinstance(paths, Path):
             paths = [paths]
         return any(Path(p).expanduser().exists() for p in paths)

--- a/llmwiki/adapters/codex_cli.py
+++ b/llmwiki/adapters/codex_cli.py
@@ -47,12 +47,10 @@ class CodexCliAdapter(BaseAdapter):
     def session_store_path(self):  # type: ignore[override]
         return self.roots
 
-    @classmethod
-    def is_available(cls) -> bool:
-        for p in cls.DEFAULT_ROOTS:
-            if Path(p).expanduser().exists():
-                return True
-        return False
+    # #496: is_available() inherited from BaseAdapter — it now creates
+    # a temp instance and reads self.session_store_path through the
+    # @property below. Was a duplicate scan over DEFAULT_ROOTS; same
+    # result, less code.
 
     def discover_sessions(self) -> list[Path]:
         out: list[Path] = []

--- a/llmwiki/adapters/contrib/copilot_chat.py
+++ b/llmwiki/adapters/contrib/copilot_chat.py
@@ -65,12 +65,8 @@ class CopilotChatAdapter(BaseAdapter):
     def session_store_path(self):  # type: ignore[override]
         return self.roots
 
-    @classmethod
-    def is_available(cls) -> bool:
-        for p in cls.DEFAULT_ROOTS:
-            if Path(p).expanduser().exists():
-                return True
-        return False
+    # #496: is_available() inherited from BaseAdapter — temp
+    # instance reads self.session_store_path through the @property.
 
     def discover_sessions(self) -> list[Path]:
         """Find chatSessions/*.jsonl and *.json under each workspace hash dir."""

--- a/llmwiki/adapters/contrib/copilot_cli.py
+++ b/llmwiki/adapters/contrib/copilot_cli.py
@@ -51,6 +51,11 @@ class CopilotCliAdapter(BaseAdapter):
     def session_store_path(self):  # type: ignore[override]
         return self.roots
 
+    # #496: kept as an explicit override because it has special
+    # COPILOT_HOME env-var handling that BaseAdapter.is_available()
+    # (which only checks self.session_store_path) doesn't cover. The
+    # base impl is still reachable via super().is_available() if the
+    # env-var check fails.
     @classmethod
     def is_available(cls) -> bool:
         for p in cls.DEFAULT_ROOTS:

--- a/llmwiki/adapters/contrib/cursor.py
+++ b/llmwiki/adapters/contrib/cursor.py
@@ -59,12 +59,8 @@ class CursorAdapter(BaseAdapter):
     def session_store_path(self):  # type: ignore[override]
         return self.roots
 
-    @classmethod
-    def is_available(cls) -> bool:
-        for p in cls.DEFAULT_ROOTS:
-            if Path(p).expanduser().exists():
-                return True
-        return False
+    # #496: is_available() inherited from BaseAdapter — temp
+    # instance reads self.session_store_path through the @property.
 
     def discover_sessions(self) -> list[Path]:
         """Find every conversation file under every configured root.

--- a/llmwiki/adapters/contrib/gemini_cli.py
+++ b/llmwiki/adapters/contrib/gemini_cli.py
@@ -46,12 +46,8 @@ class GeminiCliAdapter(BaseAdapter):
     def session_store_path(self):  # type: ignore[override]
         return self.roots
 
-    @classmethod
-    def is_available(cls) -> bool:
-        for p in cls.DEFAULT_ROOTS:
-            if Path(p).expanduser().exists():
-                return True
-        return False
+    # #496: is_available() inherited from BaseAdapter — temp
+    # instance reads self.session_store_path through the @property.
 
     def discover_sessions(self) -> list[Path]:
         out: list[Path] = []

--- a/llmwiki/adapters/contrib/obsidian.py
+++ b/llmwiki/adapters/contrib/obsidian.py
@@ -75,12 +75,9 @@ class ObsidianAdapter(BaseAdapter):
     def session_store_path(self):  # type: ignore[override]
         return self.vault_paths
 
-    @classmethod
-    def is_available(cls) -> bool:
-        for p in cls.DEFAULT_VAULT_PATHS:
-            if Path(p).expanduser().exists():
-                return True
-        return False
+    # #496: is_available() inherited from BaseAdapter — temp instance
+    # reads self.session_store_path (the @property above returning
+    # self.vault_paths). Was a duplicate scan over DEFAULT_VAULT_PATHS.
 
     def discover_sessions(self) -> list[Path]:
         """Walk every configured vault and return all .md files, excluding known

--- a/llmwiki/adapters/contrib/opencode.py
+++ b/llmwiki/adapters/contrib/opencode.py
@@ -62,9 +62,9 @@ class OpenCodeAdapter(BaseAdapter):
     def session_store_path(self):  # type: ignore[override]
         return self.roots
 
-    @classmethod
-    def is_available(cls) -> bool:
-        return any(Path(p).expanduser().exists() for p in cls.DEFAULT_ROOTS)
+    # #496: is_available() inherited from BaseAdapter — temp instance
+    # reads self.session_store_path (returns self.roots = DEFAULT_ROOTS
+    # when no config override).
 
     def discover_sessions(self) -> list[Path]:
         """Return every .jsonl session file under every configured root."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.17"
+version = "1.3.18"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_adapter_is_available_unified.py
+++ b/tests/test_adapter_is_available_unified.py
@@ -1,0 +1,122 @@
+"""Tests for #496 — unified adapter is_available() contract.
+
+The bug: `BaseAdapter.is_available()` read `cls.session_store_path`
+directly — worked for ClaudeCodeAdapter (class attribute) but
+returned the property descriptor object for the 8 contrib adapters
+which override session_store_path as a @property. Every contrib
+had to re-implement its own is_available().
+
+The fix: BaseAdapter.is_available() now instantiates a temp
+instance and reads self.session_store_path through the same code
+path discover_sessions() uses. 7 contrib overrides removed; one
+(copilot_cli) kept for COPILOT_HOME env-var handling.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from llmwiki.adapters import REGISTRY
+from llmwiki.adapters.base import BaseAdapter
+from llmwiki.adapters.claude_code import ClaudeCodeAdapter
+
+
+# Force-load every contrib adapter so the registry is populated.
+for mod in (
+    "llmwiki.adapters.codex_cli",
+    "llmwiki.adapters.contrib.copilot_chat",
+    "llmwiki.adapters.contrib.copilot_cli",
+    "llmwiki.adapters.contrib.cursor",
+    "llmwiki.adapters.contrib.gemini_cli",
+    "llmwiki.adapters.contrib.obsidian",
+    "llmwiki.adapters.contrib.opencode",
+    "llmwiki.adapters.contrib.chatgpt",
+):
+    importlib.import_module(mod)
+
+
+def test_claude_code_class_attribute_pattern_still_works():
+    """The legacy class-attribute pattern (no @property override) must
+    keep working — ClaudeCodeAdapter is the canonical user."""
+    result = ClaudeCodeAdapter.is_available()
+    assert isinstance(result, bool)
+
+
+def test_contrib_property_pattern_still_works():
+    """Contrib adapters (codex_cli, cursor, etc.) override
+    session_store_path as @property. is_available() now flows through
+    BaseAdapter via temp-instance and reads it correctly."""
+    contrib_names = [
+        "codex_cli", "copilot-chat", "cursor", "gemini_cli",
+        "obsidian", "opencode", "chatgpt",
+    ]
+    for name in contrib_names:
+        if name not in REGISTRY:
+            continue
+        cls = REGISTRY[name]
+        result = cls.is_available()
+        assert isinstance(result, bool), (
+            f"{name}.is_available() returned {type(result)}, "
+            f"expected bool — temp-instance pattern broke"
+        )
+
+
+def test_six_contrib_adapters_inherit_base_is_available():
+    """The 6 adapters whose duplicate is_available() was removed must
+    now resolve to BaseAdapter.is_available (no per-class shadow).
+
+    Excluded:
+    - copilot_cli — kept its specialised override (COPILOT_HOME)
+    - chatgpt — intentionally returns False unconditionally (opt-in
+      only, requires explicit config)
+    """
+    inherited = ("codex_cli", "copilot-chat", "cursor", "gemini_cli",
+                 "obsidian", "opencode")
+    for name in inherited:
+        if name not in REGISTRY:
+            continue
+        cls = REGISTRY[name]
+        assert cls.is_available.__func__ is BaseAdapter.is_available.__func__, (
+            f"{name} re-shadows is_available — should inherit from base "
+            f"after #496 cleanup"
+        )
+
+
+def test_chatgpt_intentional_disabled_default_preserved():
+    """chatgpt.is_available() returns False by default (opt-in only).
+    Must not have been swept up in the #496 cleanup."""
+    if "chatgpt" not in REGISTRY:
+        pytest.skip("chatgpt not registered")
+    cls = REGISTRY["chatgpt"]
+    # NOT inheriting BaseAdapter.is_available — has its own opt-in default.
+    assert cls.is_available.__func__ is not BaseAdapter.is_available.__func__
+    assert cls.is_available() is False
+
+
+def test_copilot_cli_intentional_override_preserved():
+    """copilot_cli kept its is_available() override because it has
+    special COPILOT_HOME env-var handling."""
+    if "copilot-cli" not in REGISTRY:
+        pytest.skip("copilot-cli not registered in this environment")
+    cls = REGISTRY["copilot-cli"]
+    assert cls.is_available.__func__ is not BaseAdapter.is_available.__func__, (
+        "copilot_cli should keep its specialised is_available() — "
+        "the COPILOT_HOME env-var fallback isn't in BaseAdapter"
+    )
+
+
+def test_broken_init_adapter_returns_false_not_crash():
+    """An adapter whose __init__ raises (e.g. missing transitive
+    import surfaced eagerly) must report unavailable rather than
+    crash the whole `llmwiki adapters` listing."""
+
+    class BrokenAdapter(BaseAdapter):
+        name = "broken_test"
+
+        def __init__(self, config=None):
+            raise RuntimeError("simulated import / config failure")
+
+    result = BrokenAdapter.is_available()
+    assert result is False


### PR DESCRIPTION
Closes #496.

`BaseAdapter.is_available()` now creates a temp instance + reads `self.session_store_path` through the @property — works for both class-attr (claude_code) and contrib @property patterns. 7 duplicate `is_available()` overrides removed; 2 intentional overrides kept (copilot_cli COPILOT_HOME, chatgpt opt-in default).

Net: −40 lines duplication.

## Test plan

- [x] `pytest tests/test_adapter_is_available_unified.py` — 6/6
- [x] `pytest` adapter test suites — 178 pass
- [x] All 8 contrib adapters `is_available()` returns expected bool