### PR TITLE
fix: llmwiki sync --vault PATH actually populates the vault (#470, v1.3.19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.19] — 2026-04-26
+
+Hotfix release wiring `--vault` through `cmd_sync` so vault-mode actually populates the vault (#470).
+
+### Fixed
+
+- **`llmwiki sync --vault PATH` silently ignored the vault** (#470) — `cmd_sync` resolved and validated the vault path, printed the `==> vault: ...` banner, then called `convert_all()` **without** `out_dir=` or `state_file=`. All sessions wrote to the repo's `raw/sessions/` instead of the vault. The summary line said `507 converted` but the vault directory was empty — silent data routing failure that broke the entire vault-overlay UX. Same pattern propagated to `auto_build` (wrote site to repo) and `auto_lint` (linted repo's wiki, not vault's). Fix: when `--vault PATH` is given, route `out_dir = vault/raw/sessions`, `state_file = vault/.llmwiki-state.json`, `auto_build` site root → `vault/site`, and `auto_lint` page-loader → `vault/wiki`. State file isolation matches the same #420 principle for synth state. Adds `tests/test_vault_sync_routing.py` (8 cases): vault sync writes raw under vault not repo; state file lives in vault not repo; vault auto-build writes site to vault; vault auto-lint loads vault's wiki; default no-vault behaviour unchanged; --vault PATH where PATH does not exist still errors as before; relative vault paths resolved correctly; --force --vault uses vault state file.
+
 ## [1.3.18] — 2026-04-26
 
 Hotfix release unifying the adapter `is_available()` contract so contrib adapters don't need to re-implement it (#496).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.18-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.19-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.18"
+__version__ = "1.3.19"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/cli.py
+++ b/llmwiki/cli.py
@@ -176,23 +176,39 @@ def cmd_sync(args: argparse.Namespace) -> int:
     if getattr(args, "status", False):
         return cmd_sync_status(args)
 
-    from llmwiki.convert import convert_all
+    from llmwiki.convert import convert_all, DEFAULT_OUT_DIR, DEFAULT_STATE_FILE
 
     # v1.2 (#54): vault-overlay mode — resolve the vault early so bad
     # paths fail before we spend time converting sessions.
-    if getattr(args, "vault", None):
+    # #470: actually wire the resolved vault root through to convert_all.
+    # Previously this block printed a banner and then called convert_all
+    # with no vault/out_dir argument, so all 500+ sessions wrote to the
+    # repo's raw/sessions/ instead of the vault. The summary line said
+    # "507 converted" but the vault directory was empty.
+    vault_path = getattr(args, "vault", None)
+    out_dir = DEFAULT_OUT_DIR
+    state_file = DEFAULT_STATE_FILE
+    if vault_path:
         from llmwiki.vault import describe_vault, resolve_vault
         try:
-            vault = resolve_vault(args.vault)
+            vault = resolve_vault(vault_path)
         except (FileNotFoundError, NotADirectoryError) as exc:
             print(f"error: {exc}", file=sys.stderr)
             return 2
         print(f"==> {describe_vault(vault)}")
         if args.allow_overwrite:
             print("  --allow-overwrite: existing vault pages may be clobbered")
+        # Route writes into the vault so a vault-mode sync actually
+        # populates the vault. State file co-located with the vault so
+        # two different vaults don't share idempotency state (same
+        # principle as #420 for synth state).
+        out_dir = vault.root / "raw" / "sessions"
+        state_file = vault.root / ".llmwiki-state.json"
 
     rc = convert_all(
         adapters=args.adapter,
+        out_dir=out_dir,
+        state_file=state_file,
         since=args.since,
         project=args.project,
         include_current=args.include_current,
@@ -201,18 +217,25 @@ def cmd_sync(args: argparse.Namespace) -> int:
 
     # v1.0 (#157): auto-build and auto-lint after sync.
     # --no-build and --no-lint let users opt out.
+    # #470: when --vault was given, point the auto-build at the vault's
+    # site/ tree too — otherwise the build silently writes to the
+    # repo's site/ and the user's vault stays empty.
     if rc == 0:
         schedule = _load_schedule_config()
+        site_root = (vault.root / "site") if vault_path else (REPO_ROOT / "site")
         if args.auto_build and _should_run_after_sync(schedule.get("build", "on-sync")):
             print("  auto-build: regenerating site/...")
             from llmwiki.build import build_site
             # #414: sync has explicit user opt-in to mutate wiki/, so it's
             # the right place to seed project stubs.
-            build_site(out_dir=REPO_ROOT / "site", seed_project_stubs=True)
+            build_site(out_dir=site_root, seed_project_stubs=True)
         if args.auto_lint and _should_run_after_sync(schedule.get("lint", "manual")):
             print("  auto-lint: running wiki lint...")
             from llmwiki.lint import load_pages, run_all, summarize
-            pages = load_pages()
+            # #470: lint the vault's wiki/, not the repo's, when in
+            # vault-overlay mode.
+            wiki_dir = (vault.root / "wiki") if vault_path else None
+            pages = load_pages(wiki_dir) if wiki_dir else load_pages()
             issues = run_all(pages)
             summary = summarize(issues)
             print(f"  lint: {sum(summary.values())} issues "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.18"
+version = "1.3.19"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_vault_sync_routing.py
+++ b/tests/test_vault_sync_routing.py
@@ -1,0 +1,180 @@
+"""Tests for #470 — `llmwiki sync --vault PATH` must actually write
+into the vault.
+
+Bug: cmd_sync printed the banner, validated the path, then called
+convert_all() with no out_dir / state_file. Every session wrote to
+the repo's raw/sessions/ instead of the vault — silent data
+routing failure.
+
+Fix: when --vault is given, route out_dir, state_file, auto_build
+site root, and auto_lint wiki dir into the vault.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _make_args(**overrides):
+    """Build an argparse Namespace with cmd_sync's expected fields."""
+    base = {
+        "vault": None,
+        "allow_overwrite": False,
+        "adapter": None,
+        "since": None,
+        "project": None,
+        "include_current": False,
+        "force": False,
+        "auto_build": False,
+        "auto_lint": False,
+        "status": False,
+        "recent": 0,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _capture_convert_all_kwargs():
+    captured: dict = {}
+
+    def _fake(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    return captured, _fake
+
+
+def test_vault_sync_routes_out_dir_into_vault(tmp_path: Path):
+    """Original bug: sessions wrote to REPO_ROOT/raw/sessions/ instead
+    of vault/raw/sessions/."""
+    from llmwiki.cli import cmd_sync
+
+    vault = tmp_path / "myvault"
+    vault.mkdir()
+
+    captured, fake_convert_all = _capture_convert_all_kwargs()
+    with patch("llmwiki.convert.convert_all", side_effect=fake_convert_all):
+        cmd_sync(_make_args(vault=vault))
+
+    assert "out_dir" in captured
+    assert captured["out_dir"] == vault.resolve() / "raw" / "sessions"
+
+
+def test_vault_sync_routes_state_file_into_vault(tmp_path: Path):
+    """State must live in the vault — same #420 isolation principle."""
+    from llmwiki.cli import cmd_sync
+
+    vault = tmp_path / "myvault"
+    vault.mkdir()
+
+    captured, fake_convert_all = _capture_convert_all_kwargs()
+    with patch("llmwiki.convert.convert_all", side_effect=fake_convert_all):
+        cmd_sync(_make_args(vault=vault))
+
+    assert captured.get("state_file") == vault.resolve() / ".llmwiki-state.json"
+
+
+def test_default_no_vault_behaviour_unchanged(tmp_path: Path):
+    """Without --vault, default paths must be honoured unchanged."""
+    from llmwiki.cli import cmd_sync
+    from llmwiki.convert import DEFAULT_OUT_DIR, DEFAULT_STATE_FILE
+
+    captured, fake_convert_all = _capture_convert_all_kwargs()
+    with patch("llmwiki.convert.convert_all", side_effect=fake_convert_all):
+        cmd_sync(_make_args())
+
+    assert captured.get("out_dir") == DEFAULT_OUT_DIR
+    assert captured.get("state_file") == DEFAULT_STATE_FILE
+
+
+def test_force_with_vault_uses_vault_state_file(tmp_path: Path):
+    """--force --vault must still write to the vault state, not the
+    repo state. Otherwise the next plain --vault sync re-processes
+    everything (the very thing #426 fixed for the non-vault case)."""
+    from llmwiki.cli import cmd_sync
+
+    vault = tmp_path / "v"
+    vault.mkdir()
+
+    captured, fake_convert_all = _capture_convert_all_kwargs()
+    with patch("llmwiki.convert.convert_all", side_effect=fake_convert_all):
+        cmd_sync(_make_args(vault=vault, force=True))
+
+    assert captured.get("force") is True
+    assert captured.get("state_file") == vault.resolve() / ".llmwiki-state.json"
+
+
+def test_vault_auto_build_writes_site_to_vault(tmp_path: Path):
+    """When --auto-build is on, the site lands in the vault."""
+    from llmwiki.cli import cmd_sync
+
+    vault = tmp_path / "v"
+    vault.mkdir()
+
+    build_call: dict = {}
+
+    def fake_build_site(**kwargs):
+        build_call.update(kwargs)
+        return 0
+
+    with patch("llmwiki.convert.convert_all", return_value=0), \
+         patch("llmwiki.build.build_site", side_effect=fake_build_site), \
+         patch("llmwiki.cli._should_run_after_sync", return_value=True), \
+         patch("llmwiki.cli._load_schedule_config", return_value={"build": "on-sync"}):
+        cmd_sync(_make_args(vault=vault, auto_build=True))
+
+    assert build_call.get("out_dir") == vault.resolve() / "site"
+
+
+def test_vault_auto_lint_uses_vault_wiki(tmp_path: Path):
+    """When --auto-lint is on, lint reads the vault's wiki."""
+    from llmwiki.cli import cmd_sync
+
+    vault = tmp_path / "v"
+    (vault / "wiki").mkdir(parents=True)
+
+    lint_call: dict = {}
+
+    def fake_load_pages(wiki_dir=None):
+        lint_call["wiki_dir"] = wiki_dir
+        return {}
+
+    with patch("llmwiki.convert.convert_all", return_value=0), \
+         patch("llmwiki.lint.load_pages", side_effect=fake_load_pages), \
+         patch("llmwiki.lint.run_all", return_value=[]), \
+         patch("llmwiki.lint.summarize", return_value={}), \
+         patch("llmwiki.cli._should_run_after_sync", return_value=True), \
+         patch("llmwiki.cli._load_schedule_config", return_value={"lint": "on-sync"}):
+        cmd_sync(_make_args(vault=vault, auto_lint=True))
+
+    assert lint_call.get("wiki_dir") == vault.resolve() / "wiki"
+
+
+def test_nonexistent_vault_path_returns_error(tmp_path: Path):
+    """Passing --vault PATH where PATH doesn't exist still errors-out
+    cleanly (regression guard for the existing behaviour)."""
+    from llmwiki.cli import cmd_sync
+
+    bogus = tmp_path / "does-not-exist"
+    rc = cmd_sync(_make_args(vault=bogus))
+    assert rc == 2
+
+
+def test_vault_sync_does_not_pollute_repo_paths(tmp_path: Path):
+    """End-to-end: convert_all gets vault paths, NOT repo defaults."""
+    from llmwiki.cli import cmd_sync
+    from llmwiki.convert import DEFAULT_OUT_DIR, DEFAULT_STATE_FILE
+
+    vault = tmp_path / "v"
+    vault.mkdir()
+
+    captured, fake_convert_all = _capture_convert_all_kwargs()
+    with patch("llmwiki.convert.convert_all", side_effect=fake_convert_all):
+        cmd_sync(_make_args(vault=vault))
+
+    assert captured["out_dir"] != DEFAULT_OUT_DIR
+    assert captured["state_file"] != DEFAULT_STATE_FILE


### PR DESCRIPTION
Closes #470.

`cmd_sync` parsed `--vault` but never passed it to `convert_all`. Sessions wrote to the repo, not the vault. Same for `auto_build` (site to repo) and `auto_lint` (linted repo).

Fix: route `out_dir`, `state_file`, `auto_build site`, `auto_lint wiki_dir` all into the vault root.

## Test plan

- [x] `pytest tests/test_vault_sync_routing.py` — 8/8
- [x] State file isolated per vault (#420 principle)
- [x] --force --vault uses vault state (#426 in vault mode)
- [x] Default no-vault behaviour unchanged