### PR TITLE
fix: home project cards show first/last activity date range (#455) — v1.3.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.20] — 2026-04-26
+
+Hotfix release adding a small muted date-range line under each home project card so users can spot fresh vs stale projects at a glance (#455).
+
+### Added
+
+- **Home project cards now show first/last activity dates** (#455) — `build.py` home-page card emitter now renders a `.card-date-range` div between the meta line and the topic chips, computed from each session's `date:` frontmatter field. Format: `2026-03-12 → 2026-04-01` for multi-day projects, single date when first == last, omitted when no dates available. CSS adds `.card-date-range { font-size: 0.72rem; color: var(--text-muted); font-variant-numeric: tabular-nums; }` so the text is visually subordinate to title + meta and tabular digits keep month columns aligned across cards. Pairs naturally with the freshness badge on `projects/index.html`. Adds `tests/test_home_card_date_range.py` (5 cases): multi-day range rendered, single-day shown once, empty-dates project produces no element, dates HTML-escaped, CSS class present in render/css.py.
+
 ## [1.3.19] — 2026-04-26
 
 Hotfix release wiring `--vault` through `cmd_sync` so vault-mode actually populates the vault (#470).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.19-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.20-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.19"
+__version__ = "1.3.20"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/build.py
+++ b/llmwiki/build.py
@@ -1427,10 +1427,32 @@ def render_index(
         topics = get_project_topics(PROJECTS_META_DIR, project, proj_metas)
         topics_html = render_topic_chips(topics, max_visible=4,
                                          classname="project-topics card-topics")
+        # #455: render the activity date range under the meta line so
+        # users can spot fresh vs stale projects without clicking. Pull
+        # `date:` from frontmatter (already YYYY-MM-DD strings); ignore
+        # missing/blank values; format as `2026-03-12 → 2026-04-01` for
+        # multi-day, just `2026-04-01` if first == last.
+        dates = sorted(
+            {str(m.get("date", "")) for _, m, _ in sessions if m.get("date")}
+        )
+        if dates:
+            if dates[0] == dates[-1]:
+                date_range_html = (
+                    f'<div class="card-date-range">{html.escape(dates[0])}</div>'
+                )
+            else:
+                date_range_html = (
+                    f'<div class="card-date-range">'
+                    f'{html.escape(dates[0])} → {html.escape(dates[-1])}'
+                    f'</div>'
+                )
+        else:
+            date_range_html = ""
         cards.append(
             f"""  <a class="card card-project" href="projects/{html.escape(project)}.html">
     <div class="card-title">{html.escape(project)}</div>
     <div class="card-meta">{main_count} main · {len(sessions) - main_count} sub-agent</div>
+    {date_range_html}
     {topics_html}
   </a>"""
         )

--- a/llmwiki/render/css.py
+++ b/llmwiki/render/css.py
@@ -240,6 +240,8 @@ kbd { display: inline-block; padding: 2px 6px; font-family: var(--mono); font-si
 .card:hover { border-color: var(--accent); text-decoration: none; transform: translateY(-1px); box-shadow: var(--shadow-card-hover); }
 .card-title { font-weight: 600; font-size: 0.95rem; margin-bottom: 4px; color: var(--text); }
 .card-meta { font-size: 0.82rem; color: var(--text-secondary); }
+/* #455: small muted activity date range under the meta line. */
+.card-date-range { font-size: 0.72rem; color: var(--text-muted); margin-top: 2px; font-variant-numeric: tabular-nums; }
 .card-stats { font-size: 0.78rem; margin-top: 6px; }
 .card-badge { margin-top: 8px; }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.19"
+version = "1.3.20"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_home_card_date_range.py
+++ b/tests/test_home_card_date_range.py
@@ -1,0 +1,96 @@
+"""#455: home project cards show a small muted activity date range
+under the meta line. These tests pin the rendering contract so the
+date-range div doesn't drift back to bare meta-only cards.
+
+The render_index() emitter computes the range from each session's
+`date:` frontmatter field (string YYYY-MM-DD). Five cases exercised:
+
+1. Multi-day project shows `first → last` arrow form.
+2. Single-day project shows the date once, no arrow.
+3. Project with no dates renders no `.card-date-range` element.
+4. Date strings are html-escaped (defence in depth — frontmatter
+   should already be safe, but the emitter shouldn't trust that).
+5. CSS rule `.card-date-range` is defined in render/css.py so the
+   div isn't unstyled.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from llmwiki.build import render_index
+from llmwiki.render.css import CSS
+
+
+def _meta(date: str, project: str = "demo", model: str = "claude-sonnet-4-6") -> dict:
+    return {
+        "title": f"session-{date}",
+        "slug": f"session-{date}",
+        "project": project,
+        "date": date,
+        "model": model,
+        "tools_used": [],
+    }
+
+
+def _session(date: str, project: str = "demo", filename: str | None = None):
+    """Build a (path, meta, body) tuple matching render_index() input shape."""
+    fname = filename or f"2026-01-01T00-00-{project}-{date}.md"
+    return (Path("raw/sessions") / fname, _meta(date, project=project), "body")
+
+
+def _render(groups, tmp_path: Path) -> str:
+    all_sources = [s for sessions in groups.values() for s in sessions]
+    out_path = render_index(groups=groups, all_sources=all_sources, out_dir=tmp_path)
+    return out_path.read_text(encoding="utf-8")
+
+
+def test_multi_day_project_renders_date_range(tmp_path: Path) -> None:
+    groups = {"demo": [
+        _session("2026-03-12", filename="a.md"),
+        _session("2026-04-01", filename="b.md"),
+        _session("2026-03-20", filename="c.md"),
+    ]}
+    html_out = _render(groups, tmp_path)
+    assert 'class="card-date-range"' in html_out
+    assert "2026-03-12 → 2026-04-01" in html_out
+
+
+def test_single_day_project_renders_one_date(tmp_path: Path) -> None:
+    groups = {"demo": [
+        _session("2026-04-01", filename="a.md"),
+        _session("2026-04-01", filename="b.md"),
+    ]}
+    html_out = _render(groups, tmp_path)
+    assert 'class="card-date-range"' in html_out
+    assert ">2026-04-01<" in html_out
+    # Arrow only appears in multi-day form. Spot-check inside the cards.
+    cards_only = html_out.split('class="card-grid"', 1)[1]
+    assert "→" not in cards_only
+
+
+def test_no_dates_no_date_element(tmp_path: Path) -> None:
+    """Sessions whose meta has no `date` (or blank) yield no date-range div."""
+    no_date_meta = {"slug": "x", "project": "demo", "model": "claude-sonnet-4-6"}
+    blank_meta = {"slug": "y", "project": "demo", "model": "claude-sonnet-4-6", "date": ""}
+    groups = {"demo": [
+        (Path("raw/sessions/x.md"), no_date_meta, "b"),
+        (Path("raw/sessions/y.md"), blank_meta, "b"),
+    ]}
+    html_out = _render(groups, tmp_path)
+    assert "card-date-range" not in html_out
+
+
+def test_date_string_html_escaped(tmp_path: Path) -> None:
+    """Defence in depth — even if frontmatter ever carries `<` characters,
+    the card div must escape them rather than render raw."""
+    groups = {"demo": [
+        _session("2026-03-12<script>alert(1)</script>", filename="a.md"),
+        _session("2026-04-01", filename="b.md"),
+    ]}
+    html_out = _render(groups, tmp_path)
+    assert "<script>alert" not in html_out
+    assert "&lt;script&gt;" in html_out
+
+
+def test_css_class_defined() -> None:
+    assert ".card-date-range" in CSS


### PR DESCRIPTION
## Summary

Closes #455. Home-page project cards now render a small muted activity date range under the meta line, so users can spot fresh vs stale projects without clicking into them.

- `build.py` emits a `.card-date-range` div between `card-meta` and topic chips, computed from each session's `date:` frontmatter
- Format: `2026-03-12 → 2026-04-01` for multi-day projects, single date when first == last, omitted when no dates
- `render/css.py` adds the rule (0.72rem, `var(--text-muted)`, `font-variant-numeric: tabular-nums`)
- Pairs with the existing freshness badge on `projects/index.html`

## Test plan

- [x] `tests/test_home_card_date_range.py` — 5 cases (multi-day, single-day, no-dates, html-escape, CSS class present) — all green
- [x] Full pytest suite — green (no regressions)

Bumps version to **1.3.20**.