### PR TITLE
fix: activity timeline reports calendar span + date-positioned bars (#453) — v1.3.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.22] — 2026-04-26
+
+Hotfix release fixing the activity timeline label + sparkline geometry on `sessions/index.html` (#453).
+
+### Fixed
+
+- **Activity timeline label now reports calendar span, not active-day count** (#453) — `Activity timeline · 8 days · peak 1 sessions` actually meant "8 distinct dates have sessions", not "8 calendar days of activity". On a 50-sessions-over-6-months corpus the old label said "5 days" while the real span was ~180 days. The label now reads `Activity timeline · <span> days · <active> active · peak <max> sessions/day` for multi-day collections, with a single-day fallback (`1 day · peak N session(s)`).
+- **SVG sparkline bars now positioned by date offset, not array index** (#453) — bars used to be evenly spaced at `i * (innerW / dates.length)`, which hid 6-month gaps between active periods. Bars are now placed at `(date - minDate) * slotW`, so calendar gaps become visible in the chart geometry. `tests/test_activity_timeline_label.py` (7 cases) pins both the JS source contract and the calendar-span math via a Python oracle.
+
 ## [1.3.21] — 2026-04-26
 
 Hotfix release cleaning up the sessions index table — the Session column no longer duplicates the Date column, and the sticky header now stays aligned with the body as you scroll (#452).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.21-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.22-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.21"
+__version__ = "1.3.22"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/render/js.py
+++ b/llmwiki/render/js.py
@@ -786,14 +786,30 @@ document.addEventListener("DOMContentLoaded", function () {
     const dates = Array.from(counts.keys()).sort();
     const maxCount = Math.max(...counts.values());
 
+    // #453: position bars by calendar date so gaps between active days are
+    // visible. The previous behaviour stretched dates.length bars across
+    // the full width with equal spacing, which hid 6-month gaps. We now
+    // compute calendar span (minDate→maxDate) in days and lay bars out
+    // proportional to their date offset. Single-day collections fall back
+    // to a single centred bar.
+    const minDate = new Date(dates[0] + "T00:00:00Z");
+    const maxDate = new Date(dates[dates.length - 1] + "T00:00:00Z");
+    const dayMs = 86400000;
+    const spanDays = Math.round((maxDate - minDate) / dayMs) + 1;
+
     // Build an SVG sparkline
     const w = 800;
     const h = 60;
     const padX = 4;
-    const bars = dates.map(function (d, i) {
+    const innerW = w - 2 * padX;
+    const slotW = spanDays > 1 ? innerW / spanDays : innerW;
+    const bars = dates.map(function (d) {
       const count = counts.get(d);
-      const barW = Math.max(2, (w - 2 * padX) / dates.length - 2);
-      const x = padX + i * ((w - 2 * padX) / dates.length);
+      const offset = spanDays > 1
+        ? Math.round((new Date(d + "T00:00:00Z") - minDate) / dayMs)
+        : 0;
+      const x = spanDays > 1 ? padX + offset * slotW : padX + innerW / 2 - 2;
+      const barW = Math.max(2, slotW - 1);
       const barH = (count / maxCount) * (h - 16);
       const y = h - barH - 4;
       return '<rect x="' + x + '" y="' + y + '" width="' + barW + '" height="' + barH +
@@ -805,12 +821,18 @@ document.addEventListener("DOMContentLoaded", function () {
       'style="width:100%;height:' + h + 'px;display:block" aria-label="Session activity timeline">' +
       bars + '</svg>';
 
+    // #453: label now shows calendar span (matches the geometry above) plus
+    // active-day count and peak so users can read both stories from one line.
+    const labelText = spanDays === 1
+      ? 'Activity timeline · 1 day · peak ' + maxCount + (maxCount === 1 ? ' session' : ' sessions')
+      : 'Activity timeline · ' + spanDays + ' days · ' + dates.length +
+        ' active · peak ' + maxCount + (maxCount === 1 ? ' session/day' : ' sessions/day');
+
     // Create the timeline block
     const tl = document.createElement("div");
     tl.className = "timeline-block";
     tl.innerHTML =
-      '<div class="timeline-label muted">Activity timeline · ' + dates.length +
-      ' days · peak ' + maxCount + ' sessions</div>' + svg;
+      '<div class="timeline-label muted">' + labelText + '</div>' + svg;
 
     // Insert above the filter bar
     const filter = container.querySelector(".filter-bar");

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.21"
+version = "1.3.22"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_activity_timeline_label.py
+++ b/tests/test_activity_timeline_label.py
@@ -1,0 +1,86 @@
+"""#453: the Activity timeline label was reporting `dates.length` (count
+of distinct dates with at least one session) and labelling it as "days",
+which conflated active-day count with calendar span. A user with 5
+sessions clustered across a 6-month range saw "5 days" — wrong.
+
+The fix:
+  - SVG bar x-position is computed from the date offset (days since
+    minDate), so gaps between active periods become visible.
+  - Label now reads `Activity timeline · <calendar-span> days · <active>
+    active · peak <max> sessions/day` for multi-day collections, or
+    `Activity timeline · 1 day · peak N session(s)` for single-day.
+
+These tests pin both the JS source (presence of the new formulas + label
+phrasing) and the calendar-span math itself via a Python oracle that
+mirrors the JS computation so the algorithm doesn't regress.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from llmwiki.render.js import JS
+
+
+def _calendar_span_days(iso_dates: list[str]) -> int:
+    """Python oracle for the JS calendar-span computation:
+        spanDays = round((maxDate - minDate) / 86400000) + 1
+    """
+    if not iso_dates:
+        return 0
+    days = sorted(date.fromisoformat(d) for d in iso_dates)
+    return (days[-1] - days[0]).days + 1
+
+
+def test_js_uses_calendar_span_not_active_day_count() -> None:
+    """The bar layout must use the calendar offset, not the array index."""
+    assert "spanDays" in JS
+    # Old formula was `i * ((w - 2 * padX) / dates.length)`. New formula
+    # offsets by calendar days. Catch the regression by asserting the new
+    # building blocks are present.
+    assert "(maxDate - minDate)" in JS or "maxDate - minDate" in JS
+    assert "offset * slotW" in JS
+
+
+def test_js_label_uses_new_phrasing_for_multi_day() -> None:
+    """Multi-day collections must say `<span> days · <active> active`."""
+    assert "active · peak" in JS
+    assert "sessions/day" in JS
+
+
+def test_js_label_handles_single_day_specially() -> None:
+    """Single-day collection should not say `1 days · 1 active`."""
+    assert "spanDays === 1" in JS
+    assert "'Activity timeline · 1 day · peak '" in JS
+
+
+def test_calendar_span_oracle_single_day() -> None:
+    """One bar across one day == span of 1."""
+    assert _calendar_span_days(["2026-04-01"]) == 1
+
+
+def test_calendar_span_oracle_consecutive_days() -> None:
+    """8 sessions on 8 consecutive days == 8-day calendar span."""
+    days = [(date(2026, 4, 1) + timedelta(days=i)).isoformat() for i in range(8)]
+    assert _calendar_span_days(days) == 8
+
+
+def test_calendar_span_oracle_with_gaps() -> None:
+    """5 active days clustered in a 6-month window == 6-month span,
+    not 5. This is the exact bug #453 was about."""
+    iso_dates = [
+        "2026-01-15",
+        "2026-02-20",
+        "2026-03-10",
+        "2026-05-30",
+        "2026-07-14",
+    ]
+    span = _calendar_span_days(iso_dates)
+    # Jan 15 → Jul 14 inclusive = 181 days (181 = 31-15+1 + 28 + 31 + 30 + 31 + 30 + 14)
+    assert span == 181
+    # Sanity: must be much bigger than the active-day count
+    assert span > 5
+
+
+def test_calendar_span_oracle_idempotent_for_unsorted_input() -> None:
+    """Order-independent — the JS code sorts before computing min/max."""
+    assert _calendar_span_days(["2026-04-15", "2026-04-01", "2026-04-10"]) == 15


### PR DESCRIPTION
## Summary

Closes #453. Two related fixes to the sparkline above the sessions/index.html filter bar:

1. **Label semantics.** `dates.length` was being labelled `days`, but actually meant `distinct dates with at least one session`. On a 50-sessions-over-6-months corpus the label said "5 days" — the real calendar span was ~180 days. The label now reads:
   - Multi-day: `Activity timeline · <span> days · <active> active · peak <max> sessions/day`
   - Single-day: `Activity timeline · 1 day · peak N session(s)`

2. **Bar geometry.** Bars were laid out at evenly-spaced array indices (`i * innerW / dates.length`), hiding 6-month gaps between active periods. Now positioned at `(date - minDate) * slotW`, so calendar gaps are visible in the chart.

## Test plan

- [x] `tests/test_activity_timeline_label.py` (7 cases): JS source contains the new formulas + label phrasing; Python oracle verifies calendar-span math for single-day, consecutive, gappy, and unsorted inputs.
- [x] Full pytest suite — green.

Bumps version to **1.3.22**.