### PR TITLE
fix: filter-by-slug input gets <label>Slug</label> wrapper (#454) — v1.3.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.23] — 2026-04-26
+
+Hotfix release giving the slug filter input the missing `<label>` wrapper so it aligns with its peers and announces correctly under screen readers (#454).
+
+### Fixed
+
+- **Filter-by-slug input now has a `<label>Slug` wrapper** (#454) — Project, Model, From, and To filters were each wrapped in `<label>` tags that contributed a small text header above the control; the slug input was a bare `<input>` with only a placeholder. Two consequences: (a) the slug input baseline sat ~16px higher than its peers (visual misalignment) and (b) screen readers announced it as just "edit text, Filter by slug" with no programmatic label. Wrapping the input in `<label>Slug ...</label>` corrects both. `tests/test_filter_slug_label.py` (3 cases) pins the contract for the slug input plus all four neighbouring filters so the regression can't reappear.
+
 ## [1.3.22] — 2026-04-26
 
 Hotfix release fixing the activity timeline label + sparkline geometry on `sessions/index.html` (#453).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.22-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.23-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.22"
+__version__ = "1.3.23"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/build.py
+++ b/llmwiki/build.py
@@ -1333,7 +1333,9 @@ def render_sessions_index(
       <label>To
         <input type="date" id="filter-date-to">
       </label>
-      <input type="text" id="filter-text" placeholder="Filter by slug…">
+      <label>Slug
+        <input type="text" id="filter-text" placeholder="part of slug…">
+      </label>
       <button class="btn" id="filter-clear">Clear</button>
       <span class="filter-count muted" id="filter-count"></span>
     </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.22"
+version = "1.3.23"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_filter_slug_label.py
+++ b/tests/test_filter_slug_label.py
@@ -1,0 +1,75 @@
+"""#454: every input/select in the filter bar above sessions/index.html
+must be wrapped in a `<label>` so screen readers announce it consistently
+and the visual baseline doesn't drift below its peers.
+
+The slug input was the only bare control; this test pins the label
+contract for it and verifies all four neighbouring controls keep theirs.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from llmwiki.build import render_sessions_index
+
+
+def _src(slug: str = "x", project: str = "demo", date: str = "2026-04-01"):
+    fm = {
+        "title": f"Session: {slug} — {date}",
+        "slug": slug,
+        "project": project,
+        "date": date,
+        "model": "claude-sonnet-4-6",
+        "started": f"{date}T00:00:00+00:00",
+    }
+    return (Path(f"raw/sessions/{date}T00-00-{project}-{slug}.md"), fm, "body")
+
+
+def _render(tmp_path: Path) -> str:
+    sources = [_src("a"), _src("b", date="2026-04-02")]
+    out = render_sessions_index(sources, {"demo": sources}, tmp_path)
+    return out.read_text(encoding="utf-8")
+
+
+def test_slug_input_wrapped_in_label(tmp_path: Path) -> None:
+    html_text = _render(tmp_path)
+    # Find a label that contains the slug input. Span across newlines so
+    # the wrapper layout is allowed.
+    pattern = re.compile(
+        r'<label>\s*Slug\s*<input[^>]*id="filter-text"',
+        re.IGNORECASE,
+    )
+    assert pattern.search(html_text), (
+        "filter-text input must be wrapped in a `<label>Slug ...</label>` "
+        "so screen readers announce it consistently with the other filters"
+    )
+
+
+def test_filter_text_no_longer_bare(tmp_path: Path) -> None:
+    """Defensive — make sure no bare `<input ... id="filter-text">` survives
+    outside a label wrapper."""
+    html_text = _render(tmp_path)
+    # Every occurrence of id="filter-text" must be preceded (within ~80
+    # chars) by an opening <label> tag. The current renderer emits exactly
+    # one such input, so this is a tight contract.
+    occurrences = [m.start() for m in re.finditer(r'id="filter-text"', html_text)]
+    assert occurrences, "filter-text input missing from rendered html"
+    for start in occurrences:
+        prefix = html_text[max(0, start - 120) : start]
+        assert "<label>" in prefix, f"filter-text input not wrapped in label: {prefix!r}"
+
+
+def test_all_filters_have_labels(tmp_path: Path) -> None:
+    """Project, Model, From, To, and Slug all need a `<label>` wrapper."""
+    html_text = _render(tmp_path)
+    for control_id in (
+        "filter-project",
+        "filter-model",
+        "filter-date-from",
+        "filter-date-to",
+        "filter-text",
+    ):
+        m = re.search(r'id="' + control_id + r'"', html_text)
+        assert m, f"{control_id} not in rendered html"
+        prefix = html_text[max(0, m.start() - 200) : m.start()]
+        assert "<label>" in prefix, f"{control_id} not wrapped in label"


### PR DESCRIPTION
## Summary

Closes #454. The slug filter on `sessions/index.html` was the only bare control in the filter bar — Project, Model, From, To were all wrapped in `<label>` tags, but the slug input had only a placeholder. Two consequences:

1. **Visual baseline drift.** The bare input sat ~16px higher than its labelled peers because labels stack their text header above the control.
2. **A11y regression.** Screen readers announced the slug input as just `edit text, Filter by slug` — no programmatic label, inconsistent with the rest of the bar.

Wrap the input in `<label>Slug ...</label>` to fix both.

## Test plan

- [x] `tests/test_filter_slug_label.py` (3 cases): slug input wrapped in `<label>Slug>`, no bare `filter-text` survives outside a label, all five filters (project, model, date-from, date-to, text) wrapped in `<label>`.
- [x] Full pytest suite — green.

Bumps version to **1.3.23**.