### PR TITLE
fix: graph.html ships with the site nav (#456) — v1.3.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.24] — 2026-04-26
+
+Hotfix release ending the navigation dead-end on `/graph.html` — the page now ships with the same site nav, command palette, and keyboard shortcuts as every other page (#456).
+
+### Fixed
+
+- **Top nav now visible on `/graph.html`** (#456) — the graph viewer was a standalone HTML document with its own chrome, so navigating to it from the top bar made the whole nav vanish (visually a dead end). Now `write_html` injects `nav_bar(active="graph")` at render time, links the site stylesheet so the nav looks identical to every other page, and loads `script.js` so the Cmd+K palette, theme toggle, and `g h` / `g p` / `g s` / `/` / `?` keyboard shortcuts work here too. The `#268` lightweight back-to-site shim is removed (the nav has Home), and the standalone graph theme toggle is removed (the nav has one — script.js handles the click and the graph's own CSS variables react to `data-theme` automatically). Network canvas height adjusted to `calc(100vh - 56px - 58px)` to account for both the site nav (~56px) and the graph subheader (~58px). Tests: `tests/test_graph_top_nav.py` (10 cases) plus updates to `test_graph_viewer.py` and `test_graph_theme_sync.py` for the new contract.
+
 ## [1.3.23] — 2026-04-26
 
 Hotfix release giving the slug filter input the missing `<label>` wrapper so it aligns with its peers and announces correctly under screen readers (#454).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.23-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.24-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.23"
+__version__ = "1.3.24"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/graph.py
+++ b/llmwiki/graph.py
@@ -224,6 +224,11 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>llmwiki — Knowledge Graph</title>
+<!-- #456: pull in the same site stylesheet so the top nav we inject below
+     looks identical to every other page on the site. Loaded BEFORE the
+     graph's own <style> block so graph-specific selectors (#header, #network,
+     etc.) keep their precedence and the visualization layout is untouched. -->
+<link rel="stylesheet" href="style.css">
 <style>
   /* Theme vars — mirror the site palette so dark/light sync works. */
   :root[data-theme="dark"] {
@@ -288,7 +293,9 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
   }
   .control input::placeholder { color: var(--g-muted); }
 
-  #network { width: 100%; height: calc(100vh - 58px); position: relative; }
+  /* #456: site nav above the graph subheader takes ~56px; subheader itself
+     ~58px. Subtract both so the canvas fills the remaining viewport. */
+  #network { width: 100%; height: calc(100vh - 56px - 58px); position: relative; }
 
   /* Orphan highlight: nodes with 0 inbound links get a red stroke.
      This matches the issue's "orphan pages glow red" requirement. */
@@ -381,14 +388,10 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
 <script src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"></script>
 </head>
 <body>
+<a href="#main-content" class="skip-link">Skip to content</a>
+__SITE_NAV__
+<main id="main-content">
 <div id="header">
-  <!-- #268: lightweight back-to-site link so graph.html isn't a dead end -->
-  <a href="index.html" class="control" id="back-to-site"
-     aria-label="Back to the main site"
-     style="text-decoration: none; color: var(--g-muted);">
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5"/><path d="M12 19l-7-7 7-7"/></svg>
-    <span style="margin-left: 4px;">Home</span>
-  </a>
   <h1>llmwiki — Knowledge Graph</h1>
   <span class="crumbs" id="top-crumbs"></span>
   <span class="spacer"></span>
@@ -399,9 +402,12 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
   <button class="control" id="cluster-toggle" title="Group nodes by project / type">
     Cluster: <b id="cluster-mode">off</b>
   </button>
-  <button class="control" id="theme-toggle" title="Toggle light / dark mode">
-    Theme: <b id="theme-label">dark</b>
-  </button>
+  <!-- #456: removed the standalone back-to-site link and theme toggle —
+       both responsibilities now live in the site nav above. The site's
+       script.js wires #theme-toggle (in the nav) to data-theme +
+       localStorage.llmwiki-theme; the graph's CSS reacts to data-theme
+       via :root[data-theme=...] selectors so the visualization re-themes
+       in lockstep without needing a duplicate ID here. -->
 </div>
 
 <div id="network">
@@ -441,27 +447,24 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
     </button>
   </div>
 </div>
+</main>
+<!-- #456: load the site's script.js so the nav's command palette,
+     theme toggle, and keyboard shortcuts (g h / g p / g s / / / ?) work
+     here too. The site's theme handler reads & writes the same
+     localStorage key (`llmwiki-theme`) the pre-paint script in <head>
+     reads, so the graph's data-theme stays in sync without a local
+     handler. -->
+<script src="script.js" defer></script>
 
 <script>
 'use strict';
 const GRAPH = __GRAPH_JSON__;
 
-// ─── Theme sync with the main site (localStorage key "llmwiki-theme") ──
-// #477: standardise on "llmwiki-theme" so toggling on the graph viewer
-// persists across to the rest of the site (and vice-versa). The pre-paint
-// inline script in <head> already set data-theme; this block wires the
-// toolbar toggle.
+// #456: graph used to wire its own #theme-toggle button + #theme-label.
+// Both responsibilities now live in the site nav (script.js handles the
+// click; CSS variables react to data-theme automatically). Local handler
+// removed so two listeners don't fight over the same event.
 const root = document.documentElement;
-const savedTheme = root.getAttribute('data-theme') || 'dark';
-const themeLabel = document.getElementById('theme-label');
-if (themeLabel) themeLabel.textContent = savedTheme;
-const themeToggle = document.getElementById('theme-toggle');
-if (themeToggle) themeToggle.addEventListener('click', () => {
-  const next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
-  root.setAttribute('data-theme', next);
-  if (themeLabel) themeLabel.textContent = next;
-  try { localStorage.setItem('llmwiki-theme', next); } catch (_) { /* private mode */ }
-});
 
 // ─── Check vis-network loaded (local fallback hook) ────────────────────
 if (typeof vis === 'undefined') {
@@ -792,7 +795,16 @@ def write_html(graph: dict[str, Any], out_path: Path) -> None:
         # Extremely defensive — a wiki page title containing literal
         # `</script>` would otherwise close our block early. Escape it.
         payload = payload.replace("</script>", "<\\/script>")
-    html = HTML_TEMPLATE.replace("__GRAPH_JSON__", payload)
+    # #456: inject the site's standard nav so graph.html isn't a navigation
+    # dead end. Imported lazily to avoid a top-level circular dependency
+    # (build.py imports graph.copy_to_site).
+    from llmwiki.build import nav_bar
+    site_nav_html = nav_bar(active="graph", link_prefix="")
+    html = (
+        HTML_TEMPLATE
+        .replace("__GRAPH_JSON__", payload)
+        .replace("__SITE_NAV__", site_nav_html)
+    )
     out_path.write_text(html, encoding="utf-8")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.23"
+version = "1.3.24"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/e2e/test_axe_a11y.py
+++ b/tests/e2e/test_axe_a11y.py
@@ -126,8 +126,8 @@ def test_projects_index_has_no_critical_a11y_violations(page: Page, base_url: st
 def test_graph_page_has_no_critical_a11y_violations(page: Page, base_url: str) -> None:
     """The graph viewer is a canvas-heavy page — different a11y
     surface than text content. We test it separately because the
-    ``#back-to-site`` link and any toolbar controls are the only
-    keyboard-accessible elements."""
+    site nav (#456) and the in-page toolbar controls (search,
+    cluster toggle) are the only keyboard-accessible elements."""
     resp = page.request.get(f"{base_url}/graph.html")
     if resp.status >= 400:
         pytest.skip("graph.html not shipped (empty seeded graph)")

--- a/tests/e2e/test_graph_viewer.py
+++ b/tests/e2e/test_graph_viewer.py
@@ -59,13 +59,14 @@ def _stats_shown(page: Page) -> None:
 
 @then('the "Home" back-link is visible')
 def _back_link_visible(page: Page) -> None:
-    # The back-to-site link carries id="back-to-site" per #268.
-    link = page.locator("#back-to-site")
-    # attached rather than visible — on a tiny viewport the button may
-    # be below the fold until scrolled.
+    # #456: the #268 lightweight back-to-site shim was superseded by
+    # the full site nav. The Home link now lives in the nav header
+    # alongside Projects / Sessions / Graph / Docs / Search / Theme,
+    # so we look there.
+    link = page.locator('header.nav nav.nav-links a[href="index.html"]').first
     link.wait_for(state="attached", timeout=3000)
-    href = link.get_attribute("href")
-    assert href == "index.html", f"unexpected href: {href!r}"
+    text = (link.text_content() or "").strip()
+    assert text == "Home", f"unexpected nav link text: {text!r}"
 
 
 @then('the graph JSON payload contains "site_url"')

--- a/tests/e2e/test_user_journey.py
+++ b/tests/e2e/test_user_journey.py
@@ -97,12 +97,13 @@ def test_full_navigation_journey(page: Page, base_url: str) -> None:
     graph_resp = page.request.get(f"{base_url}/graph.html")
     if graph_resp.status < 400:
         page.goto(f"{base_url}/graph.html", wait_until="domcontentloaded")
-        # The "back to site" link is the user's escape hatch.
-        back = page.locator("#back-to-site")
-        if back.count() > 0:
-            href = back.get_attribute("href")
+        # #456: the user's escape hatch is now the Home link in the
+        # injected site nav (the #268 shim was removed).
+        nav_home = page.locator('header.nav nav.nav-links a[href="index.html"]').first
+        if nav_home.count() > 0:
+            href = nav_home.get_attribute("href")
             assert href in ("index.html", "/index.html", "../index.html"), (
-                f"#back-to-site has bad href: {href!r}"
+                f"nav Home link has bad href: {href!r}"
             )
 
     # Step 9: return home. No errors should have accumulated.

--- a/tests/test_graph_theme_sync.py
+++ b/tests/test_graph_theme_sync.py
@@ -20,13 +20,17 @@ from llmwiki.graph import HTML_TEMPLATE
 
 
 def test_graph_template_uses_llmwiki_theme_key():
-    """No remaining `localStorage.getItem('theme')` or `setItem('theme'`."""
+    """No remaining `localStorage.getItem('theme')` or `setItem('theme'`.
+
+    #456: the standalone toggle (and its setItem call) was removed from
+    the graph template — that responsibility now lives in the site nav,
+    wired by script.js. The pre-paint reader stays in the template.
+    """
     # The legacy bare 'theme' key must be gone everywhere in the template.
     assert "localStorage.getItem('theme')" not in HTML_TEMPLATE
     assert "localStorage.setItem('theme'" not in HTML_TEMPLATE
-    # The site's canonical key is the only one used.
+    # The pre-paint script reads the canonical key.
     assert "localStorage.getItem('llmwiki-theme')" in HTML_TEMPLATE
-    assert "localStorage.setItem('llmwiki-theme'" in HTML_TEMPLATE
 
 
 def test_graph_template_has_no_hardcoded_data_theme_dark():
@@ -54,12 +58,27 @@ def test_graph_template_has_pre_paint_theme_script():
     assert "data-theme" in head
 
 
-def test_graph_template_toggle_writes_canonical_key():
-    """Clicking the toolbar toggle must persist via the canonical key."""
-    # Find the toggle handler block. It writes via setItem.
-    toggle_section = HTML_TEMPLATE[HTML_TEMPLATE.find("themeToggle.addEventListener"):]
-    # Sanity: the handler exists at all.
-    assert "themeToggle.addEventListener" in HTML_TEMPLATE
-    # And it writes to the canonical key only.
-    assert "localStorage.setItem('llmwiki-theme'" in toggle_section
-    assert "localStorage.setItem('theme'" not in toggle_section
+def test_graph_template_toggle_writes_canonical_key(tmp_path):
+    """Clicking the nav theme toggle must persist via the canonical key.
+
+    #456: the toggle moved out of the graph template into the site nav.
+    The contract is now end-to-end: the rendered graph.html loads
+    script.js (which carries the click handler that writes
+    `localStorage.llmwiki-theme`) and exposes one `id="theme-toggle"`
+    in the nav for that handler to bind to. The graph's own
+    `themeToggle.addEventListener` block is intentionally gone — a
+    duplicate would flip the theme twice per click.
+    """
+    from pathlib import Path
+    from llmwiki.graph import write_html
+    g = {"nodes": [], "edges": [],
+         "stats": {"total_pages": 0, "total_edges": 0, "orphans": [], "top_linked": []}}
+    out: Path = tmp_path / "graph.html"
+    write_html(g, out)
+    rendered = out.read_text(encoding="utf-8")
+    # script.js (which carries the canonical setItem call) is loaded.
+    assert 'src="script.js"' in rendered
+    # The nav exposes a unique #theme-toggle for that handler.
+    assert rendered.count('id="theme-toggle"') == 1
+    # The local handler must be gone from the template.
+    assert "themeToggle.addEventListener" not in HTML_TEMPLATE

--- a/tests/test_graph_top_nav.py
+++ b/tests/test_graph_top_nav.py
@@ -1,0 +1,107 @@
+"""#456: graph.html used to ship with its own standalone chrome and no
+site nav, so navigating to it from the top bar made the whole nav
+disappear — visually a dead end + keyboard shortcuts + Cmd+K palette
+silently stopped working. Now the same `<header class="nav">` from
+build.py.nav_bar() is injected at the top of the body, the back-to-site
+shim and standalone theme toggle are removed (the nav has both), and
+the site script.js is loaded so the palette + keyboard shortcuts work.
+
+These tests pin the contract.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from llmwiki.graph import write_html
+
+
+def _build_minimal_graph() -> dict:
+    return {
+        "nodes": [{"id": "n1", "label": "n1", "type": "entities"}],
+        "edges": [],
+        "stats": {"total_pages": 1, "total_edges": 0, "orphans": [], "top_linked": []},
+    }
+
+
+def _render(tmp_path: Path) -> str:
+    out = tmp_path / "graph.html"
+    write_html(_build_minimal_graph(), out)
+    return out.read_text(encoding="utf-8")
+
+
+def test_site_nav_injected(tmp_path: Path) -> None:
+    text = _render(tmp_path)
+    assert '<header class="nav">' in text, "site nav missing — graph is still a dead end"
+    # The nav contains the standard link set.
+    for link_text in ("Home", "Projects", "Sessions", "Graph", "Docs"):
+        assert f">{link_text}</a>" in text, f"nav link {link_text!r} missing"
+
+
+def test_graph_link_marked_active(tmp_path: Path) -> None:
+    text = _render(tmp_path)
+    assert 'href="graph.html" class="active"' in text, (
+        "Graph link in nav must carry class=\"active\" so users see where they are"
+    )
+
+
+def test_no_duplicate_theme_toggle_id(tmp_path: Path) -> None:
+    """Both the site nav and the graph header would otherwise carry
+    `id="theme-toggle"`, which is invalid HTML and breaks
+    `getElementById` for the late-defined one."""
+    text = _render(tmp_path)
+    occurrences = re.findall(r'id="theme-toggle"', text)
+    assert len(occurrences) == 1, (
+        f"Expected exactly one #theme-toggle (site nav's), found {len(occurrences)}"
+    )
+
+
+def test_back_to_site_shim_removed(tmp_path: Path) -> None:
+    text = _render(tmp_path)
+    assert 'id="back-to-site"' not in text, (
+        "the #268 lightweight back-to-site shim should be gone — the site nav "
+        "has Home now"
+    )
+
+
+def test_site_stylesheet_loaded(tmp_path: Path) -> None:
+    text = _render(tmp_path)
+    assert 'href="style.css"' in text, (
+        "the site stylesheet must be linked so the injected nav has its visual style"
+    )
+
+
+def test_site_script_loaded(tmp_path: Path) -> None:
+    text = _render(tmp_path)
+    assert 'src="script.js"' in text, (
+        "the site script must be loaded so the palette + keyboard shortcuts work"
+    )
+
+
+def test_main_landmark_wraps_content(tmp_path: Path) -> None:
+    """A11y — the page needs a <main id="main-content"> so the
+    skip-link target works and screen readers can jump to the graph."""
+    text = _render(tmp_path)
+    assert '<main id="main-content">' in text
+    assert "</main>" in text
+
+
+def test_skip_link_present(tmp_path: Path) -> None:
+    text = _render(tmp_path)
+    assert 'class="skip-link"' in text and 'href="#main-content"' in text
+
+
+def test_no_local_theme_listener(tmp_path: Path) -> None:
+    """The graph used to attach its own click listener to #theme-toggle
+    via `themeToggle.addEventListener`. With the site nav now owning that
+    button (and script.js attaching the canonical handler), a duplicate
+    listener would flip the theme twice per click — net no-op. Make
+    sure the local handler is gone."""
+    text = _render(tmp_path)
+    assert "themeToggle.addEventListener" not in text
+    assert "themeToggle = document.getElementById" not in text
+
+
+def test_placeholder_substituted(tmp_path: Path) -> None:
+    text = _render(tmp_path)
+    assert "__SITE_NAV__" not in text, "template placeholder leaked into output"

--- a/tests/test_graph_viewer.py
+++ b/tests/test_graph_viewer.py
@@ -131,14 +131,24 @@ def test_template_has_cluster_toggle():
     assert "network.cluster(" in HTML_TEMPLATE
 
 
-def test_template_has_theme_toggle_and_localstorage():
-    assert 'id="theme-toggle"' in HTML_TEMPLATE
-    # Must persist the user's choice across reloads + share the same
-    # localStorage key as the rest of the site so dark/light syncs both
-    # ways (#477). The legacy bare 'theme' key is intentionally absent —
-    # see tests/test_graph_theme_sync.py for the dedicated regression set.
-    assert "localStorage.setItem('llmwiki-theme'" in HTML_TEMPLATE
-    assert "localStorage.getItem('llmwiki-theme'" in HTML_TEMPLATE
+def test_template_has_theme_toggle_and_localstorage(tmp_path: Path):
+    # #456: the theme toggle now lives in the SITE NAV (injected at
+    # render time by write_html). The HTML_TEMPLATE itself only carries
+    # the pre-paint reader; the click handler + setItem ship via the
+    # site script.js. We verify the rendered output here so the
+    # cross-page theme sync contract still holds end-to-end.
+    g = {"nodes": [], "edges": [],
+         "stats": {"total_pages": 0, "total_edges": 0, "orphans": [], "top_linked": []}}
+    out = tmp_path / "g.html"
+    write_html(g, out)
+    rendered = out.read_text(encoding="utf-8")
+    assert 'id="theme-toggle"' in rendered, (
+        "rendered graph.html must expose a theme toggle (now via the site nav)"
+    )
+    # Pre-paint reader still in the template head.
+    assert "localStorage.getItem('llmwiki-theme')" in HTML_TEMPLATE
+    # The setItem half lives in script.js (loaded by the rendered page).
+    assert 'src="script.js"' in rendered
 
 
 def test_template_uses_css_vars_for_theme():
@@ -200,11 +210,13 @@ def test_write_html_escapes_closing_script_tag(tmp_path: Path):
     out = tmp_path / "g.html"
     write_html(g, out)
     text = out.read_text(encoding="utf-8")
-    # Three real </script> tags exist in the template now (#477 added
-    # a pre-paint inline script in <head> alongside the CDN loader and
-    # the main inline block). A fourth would mean the </script> inside
-    # the label injected out of the payload — catch that.
-    assert text.count("</script>") == 3
+    # Four real </script> tags exist in the rendered output now: the
+    # #477 pre-paint inline block in <head>, the CDN loader, the
+    # site script.js loader (#456 — graph isn't a dead end anymore),
+    # and the main inline graph script. A fifth would mean the
+    # </script> inside the label injected out of the payload — catch
+    # that.
+    assert text.count("</script>") == 4
     # And the escaped form should be present inside the JSON payload.
     assert "<\\/script>" in text
 
@@ -304,13 +316,18 @@ def test_html_template_size_budget():
     )
 
 
-def test_graph_html_has_back_to_site_link():
-    """#268: graph.html used to be a dead end — no way to navigate back
-    to the live site without the browser back button."""
-    from llmwiki.graph import HTML_TEMPLATE
-    assert 'id="back-to-site"' in HTML_TEMPLATE, (
-        "graph.html should have a back-to-site link (see #268)"
-    )
-    assert 'href="index.html"' in HTML_TEMPLATE, (
-        "back-to-site link should point at index.html"
-    )
+def test_graph_html_has_navigation_back_to_site(tmp_path: Path):
+    """#268 was satisfied by a lightweight back-to-site shim. #456 went
+    further — the full site nav is now injected at render time, which
+    subsumes the shim. Regression contract: the rendered graph.html
+    must reach the home page via at least one Home link in the nav."""
+    g = {"nodes": [], "edges": [],
+         "stats": {"total_pages": 0, "total_edges": 0, "orphans": [], "top_linked": []}}
+    out = tmp_path / "g.html"
+    write_html(g, out)
+    text = out.read_text(encoding="utf-8")
+    assert '<header class="nav">' in text, "site nav missing from rendered graph"
+    # Find the Home link inside the nav.
+    nav_block = text[text.find('<header class="nav">') : text.find("</header>")]
+    assert 'href="index.html"' in nav_block, "Home link missing from injected nav"
+    assert ">Home</a>" in nav_block


### PR DESCRIPTION
## Summary

Closes #456. Ends the navigation dead end on `/graph.html`.

The graph viewer used to render as a standalone HTML document with its own chrome — no site nav, no command palette, no keyboard shortcuts. Navigating to it from the top bar made the whole nav vanish. The earlier #268 back-to-site shim only patched the worst symptom.

This change:

- Injects `nav_bar(active="graph")` at render time via a `__SITE_NAV__` placeholder in `HTML_TEMPLATE`. Imported lazily in `write_html` so `graph.py` keeps no top-level dependency on `build.py`.
- Links the site stylesheet so the nav looks identical everywhere.
- Loads `script.js` so Cmd+K palette + theme toggle + keyboard shortcuts (`g h` / `g p` / `g s` / `/` / `?`) work on the graph too.
- Removes the back-to-site shim (the nav has Home) and the graph's standalone theme toggle (the nav has one — `script.js` drives `data-theme` + `localStorage`; the graph CSS reacts via `:root[data-theme=...]` selectors automatically).
- Wraps content in `<main id="main-content">` so the skip-link works.
- Adjusts `#network` height to `calc(100vh - 56px - 58px)`.

## Test plan

- [x] `tests/test_graph_top_nav.py` — 10 cases (nav present, Graph link active, single `#theme-toggle`, no back-to-site shim, stylesheet loaded, script.js loaded, `<main>` landmark, skip link, no local theme listener, placeholder substituted).
- [x] Updated `tests/test_graph_viewer.py` (3 contracts) and `tests/test_graph_theme_sync.py` (2 contracts) to reflect the moved-to-nav theme toggle.
- [x] Full pytest suite — green.

Bumps version to **1.3.24**.