### PR TITLE
chore: ship example script + dedupe link-check issues (#498-#544) — v1.3.25

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -61,3 +61,8 @@ jobs:
           title: "Broken external links detected"
           content-filepath: lychee-report.md
           labels: docs, chore
+          # #544+: without update_existing every weekly cron + every push
+          # filed a fresh issue with the same title. Use the action's
+          # built-in update path so a single tracking issue gets the
+          # latest report appended instead of spawning duplicates.
+          update_existing: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.25] — 2026-04-26
+
+Maintenance release bundling three small chores: ship the `examples/scripts/tree_from_graph.py` recipe that the README links to, document the `examples/scripts/` folder, and stop the link-check workflow from spawning duplicate tracking issues.
+
+### Fixed
+
+- **README link to `examples/scripts/tree_from_graph.py` now resolves** (#544 + 23 stale link-check noise issues #498–#542) — the script existed locally but was never committed, so every fresh checkout (including CI) saw the link as broken. The single ERROR in lychee's report was driving the auto-opened tracking issues. Adds the script to git plus an `examples/scripts/README.md` so the folder has context for new contributors.
+- **Link-check workflow no longer spawns a fresh issue every run** — `peter-evans/create-issue-from-file@v6` defaults to creating duplicates when a same-titled issue already exists. Set `update_existing: true` so the same `Broken external links detected` issue gets the latest report appended instead. Closes the noise root-cause behind 24+ duplicate issues filed since #498.
+
 ## [1.3.24] — 2026-04-26
 
 Hotfix release ending the navigation dead-end on `/graph.html` — the page now ships with the same site nav, command palette, and keyboard shortcuts as every other page (#456).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.24-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.25-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/examples/scripts/README.md
+++ b/examples/scripts/README.md
@@ -1,0 +1,28 @@
+# examples/scripts
+
+Stdlib-only Python recipes that consume the artefacts `llmwiki build` emits.
+
+Each script is fully self-contained — no third-party deps, no llmwiki import — so you can copy one into your own project as a starting point for whatever aggregation you need.
+
+## Scripts
+
+| File | Reads | Prints |
+|---|---|---|
+| `tree_from_graph.py` | `site/graph.jsonld` | A `tree`-style ASCII view of every project and its sessions, sorted by session count then date. |
+
+## Run
+
+```bash
+# from the repo root, after `llmwiki build`
+python3 examples/scripts/tree_from_graph.py
+```
+
+The default input path is `site/graph.jsonld`; pass an explicit path to read from elsewhere:
+
+```bash
+python3 examples/scripts/tree_from_graph.py path/to/graph.jsonld
+```
+
+## Why these exist
+
+`site/graph.jsonld` is one of the AI-consumable exports the static site ships alongside the HTML. The shape is JSON-LD with `@graph` flat structure (root → projects → sessions). These scripts illustrate the access pattern so you can write your own — count sessions per model, list every entity that appears in 3+ sessions, slice by date range, etc.

--- a/examples/scripts/tree_from_graph.py
+++ b/examples/scripts/tree_from_graph.py
@@ -1,0 +1,61 @@
+"""Print sessions as a tree from `site/graph.jsonld`.
+
+Demonstrates programmatic access to the AI-consumable JSON-LD graph
+that `llmwiki build` emits. Stdlib-only, runs anywhere.
+
+Usage:
+    python3 examples/scripts/tree_from_graph.py [path/to/graph.jsonld]
+
+Default path: site/graph.jsonld (relative to cwd).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def main(graph_path: str = "site/graph.jsonld") -> int:
+    path = Path(graph_path)
+    if not path.is_file():
+        print(f"error: {path} not found — run `llmwiki build` first", file=sys.stderr)
+        return 1
+
+    nodes = json.loads(path.read_text(encoding="utf-8"))["@graph"]
+
+    root = next((n for n in nodes if n["@id"] == "llmwiki"), {})
+    projects = {n["@id"]: n for n in nodes if n["@id"].startswith("project/")}
+    sessions = [n for n in nodes if n["@id"].startswith("session/")]
+
+    by_proj: dict[str, list[dict]] = defaultdict(list)
+    for s in sessions:
+        by_proj[s["isPartOf"]["@id"]].append(s)
+
+    total = sum(p.get("numberOfItems", 0) for p in projects.values())
+    print()
+    print(f"📚 {total} sessions across {len(projects)} projects")
+    print(f"   ({path} v{root.get('version', '?')})")
+    print()
+
+    print(f"{root.get('name', 'llmwiki')}/")
+    proj_items = sorted(projects.items(), key=lambda kv: -kv[1].get("numberOfItems", 0))
+    for pi, (pid, p) in enumerate(proj_items):
+        last_proj = pi == len(proj_items) - 1
+        proj_prefix = "└──" if last_proj else "├──"
+        proj_sessions = sorted(by_proj[pid], key=lambda s: s.get("dateCreated", ""))
+        n = len(proj_sessions)
+        print(f"{proj_prefix} {p['name']}/  ({n} session{'s' if n != 1 else ''})")
+        leg = "    " if last_proj else "│   "
+        for i, s in enumerate(proj_sessions):
+            child_prefix = "└──" if i == n - 1 else "├──"
+            date = s.get("dateCreated", "")[:10]
+            title = s.get("name", "").replace("Session: ", "").split(" — ")[0]
+            print(f"{leg}{child_prefix} {date}  {title}")
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1] if len(sys.argv) > 1 else "site/graph.jsonld"))

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.24"
+__version__ = "1.3.25"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.24"
+version = "1.3.25"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Bundled chore + Maintenance + docs MR per the new rule. Closes the bulk of the broken-link noise.

Three small fixes:

1. **Track `examples/scripts/tree_from_graph.py`.** The README links to this script ("The full script is stdlib-only at examples/scripts/tree_from_graph.py") but the file existed only in my local working tree — never committed. CI sees it as a broken link, which is the single `ERROR` driving every weekly lychee report. Adding the file fixes the link end-to-end.
2. **Add `examples/scripts/README.md`** so new contributors landing in that folder understand what's there and how to run the recipes.
3. **`update_existing: true` on `link-check.yml`.** Without that flag, `peter-evans/create-issue-from-file@v6` defaults to opening a fresh issue with the same title every run. That's why 24+ duplicate `Broken external links detected` issues stacked up (#498 through #544). With it, the same tracking issue gets the latest report appended.

Closes #498, #503, #504, #506, #507, #508, #510, #512, #514, #516, #518, #520, #522, #524, #526, #528, #530, #532, #534, #536, #538, #540, #542, #544 (24 stale duplicates of the same broken link).

## Test plan

- [x] Full pytest suite — green.
- [x] `examples/scripts/tree_from_graph.py` is now tracked (`git ls-files`).
- [x] No new external URLs added that need link-check validation (per the new code-review rule).

Bumps version to **1.3.25**.