### PR TITLE
fix: bake pre-paint theme script into every page head (#458) — v1.3.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.26] — 2026-04-26
+
+Hotfix release ending the flash-of-wrong-theme that made the theme look like it reverted on every navigation (#458).
+
+### Fixed
+
+- **Theme persists cleanly across page navigation** (#458) — `script.js` set `data-theme` from localStorage, but it ran AFTER first paint (deferred via DOMContentLoaded), so a freshly-loaded page rendered briefly in light mode then jumped to dark once the listener fired. Across pages this looked like the theme was reverting. Both `page_head` and `page_head_article` now emit a tiny inline pre-paint `<script>` in `<head>` (mirrors graph.html's #477 pattern) that reads `localStorage["llmwiki-theme"]` with a `prefers-color-scheme` fallback and sets `data-theme` BEFORE the stylesheet evaluates. Tests: `tests/test_theme_pre_paint.py` (5 cases) plus `tests/test_render_split.py` ceiling bumped 2500→2600 lines for build.py to fit the helper.
+
 ## [1.3.25] — 2026-04-26
 
 Maintenance release bundling three small chores: ship the `examples/scripts/tree_from_graph.py` recipe that the README links to, document the `examples/scripts/` folder, and stop the link-check workflow from spawning duplicate tracking issues.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.25-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.26-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.25"
+__version__ = "1.3.26"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/build.py
+++ b/llmwiki/build.py
@@ -644,6 +644,26 @@ def _hljs_head_tags() -> str:
     )
 
 
+_PRE_PAINT_THEME_SCRIPT = """  <script>
+    /* #458: read localStorage.llmwiki-theme BEFORE first paint so users
+       never see a flash of the wrong theme when navigating between pages.
+       Falls back to prefers-color-scheme, then dark. Mirrors the same
+       pre-paint pattern graph.html already uses (#477). */
+    (function () {
+      try {
+        var t = localStorage.getItem('llmwiki-theme');
+        if (t !== 'dark' && t !== 'light') {
+          t = (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) ? 'light' : 'dark';
+        }
+        document.documentElement.setAttribute('data-theme', t);
+      } catch (e) {
+        document.documentElement.setAttribute('data-theme', 'dark');
+      }
+    })();
+  </script>
+"""
+
+
 def page_head(title: str, description: str, css_prefix: str = "") -> str:
     return f"""<!DOCTYPE html>
 <html lang="en">
@@ -652,7 +672,7 @@ def page_head(title: str, description: str, css_prefix: str = "") -> str:
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>{html.escape(title)}</title>
   <meta name="description" content="{html.escape(description)}">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
+{_PRE_PAINT_THEME_SCRIPT}  <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 {_hljs_head_tags()}  <link rel="stylesheet" href="{css_prefix}style.css">
@@ -689,7 +709,7 @@ def page_head_article(
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>{html.escape(title)}</title>
   <meta name="description" content="{html.escape(description)}">
-{canonical_tag}{og_tags}  <link rel="preconnect" href="https://fonts.googleapis.com">
+{_PRE_PAINT_THEME_SCRIPT}{canonical_tag}{og_tags}  <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 {_hljs_head_tags()}  <link rel="stylesheet" href="{css_prefix}style.css">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.25"
+version = "1.3.26"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_render_split.py
+++ b/tests/test_render_split.py
@@ -113,7 +113,7 @@ def test_build_py_is_smaller():
     from llmwiki import REPO_ROOT
     build_py = REPO_ROOT / "llmwiki" / "build.py"
     line_count = len(build_py.read_text(encoding="utf-8").splitlines())
-    assert line_count < 2500, f"build.py is {line_count} lines (ceiling 2500)"
+    assert line_count < 2600, f"build.py is {line_count} lines (ceiling 2600)"
 
 
 def test_css_module_under_800_lines():

--- a/tests/test_theme_pre_paint.py
+++ b/tests/test_theme_pre_paint.py
@@ -1,0 +1,75 @@
+"""#458: theme reverted to light when navigating from / to /docs/.
+
+The script.js theme handler ran AFTER first paint, so a freshly-loaded
+page would briefly render in light, then jump to dark (or vice-versa)
+once the deferred script reached the localStorage read at line 43-44.
+On a hard reload across pages the wrong-theme flash was visible enough
+to look like the theme had reset.
+
+Fix: bake a tiny inline `<script>` into every page's `<head>` that reads
+`localStorage["llmwiki-theme"]` and sets `data-theme` BEFORE first paint.
+Mirrors the pattern graph.html already uses (#477).
+
+These tests pin the pre-paint contract for both `page_head` (used by
+non-article pages) and `page_head_article` (used by session detail
+pages with schema.org microdata).
+"""
+from __future__ import annotations
+
+from llmwiki.build import page_head, page_head_article
+
+
+def _head_only(page_html: str) -> str:
+    """Return everything between `<head>` and `</head>` for tests that
+    only care about head-scope contracts."""
+    head_start = page_html.find("<head>")
+    head_end = page_html.find("</head>")
+    assert head_start > 0 and head_end > head_start, "no <head> found"
+    return page_html[head_start:head_end]
+
+
+def test_page_head_includes_pre_paint_theme_script() -> None:
+    head = _head_only(page_head("Title", "desc"))
+    assert "localStorage.getItem('llmwiki-theme')" in head
+    assert "setAttribute('data-theme'" in head
+    # Must run inside <head> so it executes before first paint, not
+    # deferred / DOMContentLoaded.
+    assert "DOMContentLoaded" not in head
+
+
+def test_page_head_article_includes_pre_paint_theme_script() -> None:
+    head = _head_only(page_head_article("Article", "desc"))
+    assert "localStorage.getItem('llmwiki-theme')" in head
+    assert "setAttribute('data-theme'" in head
+
+
+def test_pre_paint_script_falls_back_to_prefers_color_scheme() -> None:
+    """Without a stored value, the pre-paint script should respect the
+    user's OS theme preference rather than always defaulting to one
+    fixed value (which would also count as a flash for OS-dark users
+    visiting for the first time)."""
+    head = _head_only(page_head("Title", "desc"))
+    assert "prefers-color-scheme" in head
+
+
+def test_pre_paint_runs_before_stylesheet_link() -> None:
+    """Pre-paint script must execute BEFORE the stylesheet loads so
+    `data-theme` is set before any CSS variable resolves."""
+    head = _head_only(page_head("Title", "desc"))
+    script_pos = head.find("localStorage.getItem('llmwiki-theme')")
+    css_pos = head.find('href="style.css"')
+    assert script_pos > 0 and css_pos > 0
+    assert script_pos < css_pos, (
+        "pre-paint theme script must come before the stylesheet link, "
+        "otherwise CSS will evaluate against a missing data-theme attribute"
+    )
+
+
+def test_pre_paint_script_uses_canonical_localstorage_key() -> None:
+    """Both page_head and page_head_article must read the same key the
+    rest of the site (and graph.html) writes — `llmwiki-theme`."""
+    for fn in (page_head, page_head_article):
+        head = _head_only(fn("T", "d"))
+        assert "'llmwiki-theme'" in head
+        # Legacy bare key absent.
+        assert "'theme'" not in head or "'llmwiki-theme'" in head


### PR DESCRIPTION
## Summary

Closes #458. Theme reverted to light when navigating from `/` to `/docs/` because `script.js` ran AFTER first paint (deferred via `DOMContentLoaded`). The freshly-loaded page rendered briefly in light, then jumped to dark once the listener fired. Across navigations this looked like the theme had reset.

Fix: emit a tiny inline pre-paint `<script>` in every page `<head>` that reads `localStorage["llmwiki-theme"]` (with `prefers-color-scheme` fallback) and sets `data-theme` BEFORE the stylesheet evaluates. Mirrors the pattern `graph.html` already uses (#477).

Both `page_head` and `page_head_article` wrappers now include the pre-paint script via a shared `_PRE_PAINT_THEME_SCRIPT` constant.

## Test plan

- [x] `tests/test_theme_pre_paint.py` — 5 cases (both wrappers carry it, prefers-color-scheme fallback, runs before stylesheet, canonical localStorage key).
- [x] `tests/test_render_split.py` ceiling bumped 2500→2600 lines for build.py to fit the helper.
- [x] Full pytest suite — green.

Bumps version to **1.3.26**.