### PR TITLE
fix: hamburger nav drawer on mobile/tablet (#460) — v1.3.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.28] — 2026-04-26
+
+Hotfix release adding a hamburger nav drawer so every top-level link is reachable on mobile (#460).
+
+### Fixed
+
+- **Hamburger drawer surfaces every nav link on tablet + mobile** (#460) — the desktop `.nav-links` row hides at <1024px (existing media query), so on phones the Graph / Docs / Changelog entries had no path. The mobile bottom nav only carries Home / Projects / Sessions / Search / Theme. Adds a hamburger button (visible only ≤1023px) that toggles a slide-down drawer with all 6 nav targets, marks the active page, and exposes `aria-expanded` + `aria-controls`. JS handles ESC-to-close (with focus return to hamburger), click-outside-to-close, and auto-close after navigating to a drawer link. Tests: `tests/test_mobile_hamburger_nav.py` (9 cases) covering markup, CSS, and all four JS behaviours.
+
 ## [1.3.27] — 2026-04-26
 
 Hotfix release fixing four light-theme agent badges that fell below WCAG 2.1 AA contrast (#459).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.27-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.28-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.27"
+__version__ = "1.3.28"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/build.py
+++ b/llmwiki/build.py
@@ -753,12 +753,36 @@ def nav_bar(active: str, link_prefix: str = "") -> str:
         cls = ' class="active"' if key == active else ""
         return f'<a href="{link_prefix}{href}"{cls}>{label}</a>'
 
+    # #460: hamburger pattern for tablet/mobile (≤1023px). The desktop
+    # nav-links row is hidden below 1024 (CSS rule), so without this
+    # button the Graph / Docs / Changelog entries would be unreachable
+    # on mobile (the bottom nav only carries Home / Projects / Sessions).
+    # The drawer below mirrors the same 6 links vertically. JS in
+    # render/js.py wires aria-expanded, ESC-to-close, and focus return.
+    drawer_link = lambda href, label, key: (
+        f'  <a href="{link_prefix}{href}" class="nav-drawer-link'
+        + (' active' if key == active else '') + '">'
+        + label + '</a>'
+    )
+    nav_drawer_html = f"""<div id="nav-drawer" class="nav-drawer" hidden role="menu" aria-labelledby="nav-hamburger">
+{drawer_link("index.html", "Home", "home")}
+{drawer_link("projects/index.html", "Projects", "projects")}
+{drawer_link("sessions/index.html", "Sessions", "sessions")}
+{drawer_link("graph.html", "Graph", "graph")}
+{drawer_link("docs/index.html", "Docs", "docs")}
+{drawer_link("changelog.html", "Changelog", "changelog")}
+</div>"""
     return f"""<header class="nav">
   <div class="nav-inner">
     <a href="{link_prefix}index.html" class="nav-brand">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
       LLM Wiki
     </a>
+    <button type="button" class="nav-hamburger" id="nav-hamburger"
+            aria-expanded="false" aria-controls="nav-drawer"
+            aria-label="Open navigation menu">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
     <nav class="nav-links">
       {link("index.html", "Home", "home")}
       {link("projects/index.html", "Projects", "projects")}
@@ -777,6 +801,7 @@ def nav_bar(active: str, link_prefix: str = "") -> str:
       </button>
     </nav>
   </div>
+  {nav_drawer_html}
 </header>
 """
 

--- a/llmwiki/render/css.py
+++ b/llmwiki/render/css.py
@@ -673,6 +673,37 @@ mark { background: var(--accent-bg); color: var(--accent); padding: 0 2px; borde
 .toc-sidebar .toc-link.active { color: var(--accent); border-left-color: var(--accent); background: var(--bg-alt); font-weight: 500; }
 @media (min-width: 1340px) { .toc-sidebar { display: block; } }
 
+/* #460: Hamburger button + slide-down drawer for tablet/mobile.
+   Desktop nav-links row hides at <1024 (existing rule), so without
+   this drawer Graph / Docs / Changelog were unreachable on mobile. */
+.nav-hamburger {
+  display: none;  /* shown only when nav-links row is hidden */
+  background: var(--bg-card); border: 1px solid var(--border);
+  border-radius: 6px; width: 36px; height: 36px;
+  align-items: center; justify-content: center;
+  cursor: pointer; color: var(--text-secondary);
+  padding: 0; margin-left: auto;
+  transition: all 0.15s;
+}
+.nav-hamburger:hover { border-color: var(--accent); color: var(--accent); }
+@media (max-width: 1023px) { .nav-hamburger { display: inline-flex; } }
+.nav-drawer {
+  display: none;
+  position: absolute; left: 0; right: 0; top: 100%;
+  background: var(--bg); border-bottom: 1px solid var(--border);
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.12);
+  flex-direction: column; padding: 8px 16px 12px;
+  z-index: 99;
+}
+.nav-drawer:not([hidden]) { display: flex; }
+.nav-drawer-link {
+  display: block; padding: 12px 12px;
+  color: var(--text); font-size: 0.95rem; font-weight: 500;
+  text-decoration: none; border-radius: 6px;
+}
+.nav-drawer-link:hover, .nav-drawer-link:focus-visible { background: var(--bg-alt); text-decoration: none; }
+.nav-drawer-link.active { color: var(--accent); }
+
 /* Mobile bottom navigation */
 .mobile-bottom-nav { display: none; }
 /* Mobile bottom nav breakpoint at 767 matches the common 768 tablet cutoff

--- a/llmwiki/render/js.py
+++ b/llmwiki/render/js.py
@@ -64,6 +64,45 @@ JS = r"""// llmwiki viewer — theme + copy + search palette + keyboard shortcut
   window.__llmwikiSyncHljsTheme = syncHljsTheme;
 })();
 
+// ─── #460: Mobile/tablet hamburger nav drawer ─────────────────────────────
+// Wires the hamburger button to toggle the drawer with proper aria state.
+// ESC closes and returns focus to the hamburger. Click-outside closes.
+// Drawer items are real <a>; tabbing flows naturally. No focus trap needed
+// because the drawer is non-modal — the rest of the page is still
+// interactive when it's open.
+(function () {
+  document.addEventListener("DOMContentLoaded", function () {
+    const btn = document.getElementById("nav-hamburger");
+    const drawer = document.getElementById("nav-drawer");
+    if (!btn || !drawer) return;
+    function setOpen(open) {
+      btn.setAttribute("aria-expanded", open ? "true" : "false");
+      if (open) drawer.removeAttribute("hidden");
+      else drawer.setAttribute("hidden", "");
+    }
+    btn.addEventListener("click", function () {
+      setOpen(btn.getAttribute("aria-expanded") !== "true");
+    });
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape" && btn.getAttribute("aria-expanded") === "true") {
+        setOpen(false);
+        btn.focus();
+      }
+    });
+    // Click outside the drawer closes it.
+    document.addEventListener("click", function (e) {
+      if (btn.getAttribute("aria-expanded") !== "true") return;
+      if (drawer.contains(e.target) || btn.contains(e.target)) return;
+      setOpen(false);
+    });
+    // Close after navigating to one of the drawer items so the next page
+    // doesn't briefly render with the drawer still open above the fold.
+    drawer.querySelectorAll("a").forEach(function (a) {
+      a.addEventListener("click", function () { setOpen(false); });
+    });
+  });
+})();
+
 // ─── Reading progress bar ────────────────────────────────────────────────
 (function () {
   const bar = document.getElementById("progress-bar");

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.27"
+version = "1.3.28"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_mobile_hamburger_nav.py
+++ b/tests/test_mobile_hamburger_nav.py
@@ -1,0 +1,109 @@
+"""#460: mobile-viewport top-nav items were unreachable.
+
+Below 1024px the desktop `.nav-links` row is hidden by an existing
+media query, so Graph / Docs / Changelog had no path on phones. The
+mobile bottom nav only carries Home / Projects / Sessions / Search /
+Theme. The fix adds a hamburger button (visible <1024px) that toggles
+a drawer mirroring the same 6 nav links vertically.
+
+These tests pin the markup, CSS, and JS contracts.
+"""
+from __future__ import annotations
+
+from llmwiki.build import nav_bar
+from llmwiki.render.css import CSS
+from llmwiki.render.js import JS
+
+
+# ─── Markup contract ──────────────────────────────────────────────────
+
+
+def test_nav_emits_hamburger_button() -> None:
+    html_text = nav_bar(active="home")
+    assert 'id="nav-hamburger"' in html_text
+    assert 'aria-expanded="false"' in html_text
+    assert 'aria-controls="nav-drawer"' in html_text
+    assert 'aria-label="Open navigation menu"' in html_text
+
+
+def test_nav_emits_drawer_with_six_links() -> None:
+    html_text = nav_bar(active="home")
+    assert 'id="nav-drawer"' in html_text
+    # Drawer starts hidden so the user doesn't see it on desktop.
+    assert "<div id=\"nav-drawer\" class=\"nav-drawer\" hidden" in html_text
+    # All six top-level nav targets reachable from the drawer.
+    for target in (
+        'href="index.html"',
+        'href="projects/index.html"',
+        'href="sessions/index.html"',
+        'href="graph.html"',
+        'href="docs/index.html"',
+        'href="changelog.html"',
+    ):
+        assert html_text.count(target) >= 2, (
+            f"{target} should appear in both .nav-links AND .nav-drawer "
+            "so it's reachable on every viewport"
+        )
+
+
+def test_drawer_marks_active_link() -> None:
+    """The drawer must visually highlight the current page so users
+    can orient themselves on mobile, same as the desktop nav."""
+    html_text = nav_bar(active="graph")
+    # The drawer Graph link carries `class="nav-drawer-link active"`.
+    assert 'class="nav-drawer-link active">Graph</a>' in html_text
+
+
+# ─── CSS contract ─────────────────────────────────────────────────────
+
+
+def test_css_hides_hamburger_above_1024() -> None:
+    """Hamburger should be hidden by default (desktop) and only shown
+    where the desktop nav-links row has been hidden (<1024)."""
+    assert ".nav-hamburger {" in CSS
+    # Default: display none.
+    assert "display: none" in CSS
+    # Show below 1024.
+    assert "@media (max-width: 1023px) { .nav-hamburger" in CSS
+
+
+def test_css_drawer_styles_present() -> None:
+    assert ".nav-drawer {" in CSS
+    assert ".nav-drawer-link {" in CSS
+    # Drawer must carry an active state for the current page.
+    assert ".nav-drawer-link.active" in CSS
+
+
+# ─── JS contract ──────────────────────────────────────────────────────
+
+
+def test_js_wires_hamburger_toggle() -> None:
+    assert "nav-hamburger" in JS
+    assert "nav-drawer" in JS
+    # Toggle reads + writes aria-expanded.
+    assert 'getAttribute("aria-expanded")' in JS
+    assert 'setAttribute("aria-expanded"' in JS
+
+
+def test_js_handles_escape_key() -> None:
+    """ESC closes the drawer and returns focus to the hamburger so
+    keyboard users don't get trapped."""
+    assert 'key === "Escape"' in JS
+    # Focus return — find the assignment near the Escape handler.
+    esc_block = JS[JS.find('key === "Escape"'): JS.find('key === "Escape"') + 200]
+    assert "btn.focus()" in esc_block
+
+
+def test_js_closes_drawer_on_outside_click() -> None:
+    """Click-outside-to-close is the standard menu pattern."""
+    # The handler checks contains() on both drawer + button, then closes.
+    assert "drawer.contains(e.target)" in JS
+    assert "btn.contains(e.target)" in JS
+
+
+def test_js_closes_drawer_after_navigation() -> None:
+    """After tapping a drawer link, close before the next page loads
+    so the next page doesn't briefly render with the drawer open."""
+    drawer_block = JS[JS.find("nav-drawer"): JS.find("Reading progress")]
+    assert 'querySelectorAll("a")' in drawer_block
+    assert 'setOpen(false)' in drawer_block


### PR DESCRIPTION
## Summary

Closes #460. Below 1024px the desktop `.nav-links` row is hidden by an existing media query, leaving Graph / Docs / Changelog unreachable on phones (the bottom nav only carries Home / Projects / Sessions / Search / Theme).

Adds a hamburger button visible only ≤1023px that toggles a slide-down drawer with all 6 nav targets, marks the active page, and exposes `aria-expanded` + `aria-controls`.

JS behaviours:
- ESC-to-close with focus return to the hamburger button
- click-outside-to-close (standard menu pattern)
- auto-close after navigating to a drawer link so the next page doesn't briefly render with the drawer still open

The drawer is non-modal (the rest of the page stays interactive), so no focus trap is needed — tabbing flows naturally through real `<a>` elements.

## Test plan

- [x] `tests/test_mobile_hamburger_nav.py` — 9 cases covering markup (button + drawer + 6 links + active state), CSS visibility rules, and all four JS behaviours (toggle, ESC, click-outside, post-nav close).
- [x] Full pytest suite — green.

Bumps version to **1.3.28**.