### PR TITLE
fix: palette + help dialog a11y (aria-hidden gate + focus trap) (#478, #479) — v1.3.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.29] — 2026-04-26
+
+Hotfix release fixing two related a11y violations in the command palette + help dialog (#478, #479).
+
+### Fixed
+
+- **Palette + help dialog no longer use `aria-hidden` as a visibility gate** (#478) — the markup was `<div id="palette" aria-hidden="true">` and CSS gated visibility via `[aria-hidden="false"] { display: block }`. axe-core's `aria-hidden-focus` rule flags this because focusable children inside an aria-hidden ancestor are unreachable to AT users, and toggling the attribute live also creates inconsistent screen-reader announcements. Both dialogs now toggle a `.open` class instead; aria-hidden is removed from the markup entirely.
+- **Focus is trapped inside open dialogs and restored on close** (#479) — the previous code only focused the input on open. Tab walked behind into the page chrome, ESC closed but never returned focus to the trigger button, and screen reader users could land in invisible/unrelated controls. Two new helpers `__openDialog` / `__closeDialog` (a) snapshot `document.activeElement` so it can be restored on close, (b) add `inert` to every direct body sibling so AT focus stays inside the dialog, (c) explicitly focus the first interactive child on open. A `__trapTab` handler wraps Tab + Shift+Tab inside the dialog's focusable elements. Tests: `tests/test_palette_dialog_a11y.py` (11 cases) covering markup, CSS, dialog helpers, focus trap, and the updated ESC handler.
+
 ## [1.3.28] — 2026-04-26
 
 Hotfix release adding a hamburger nav drawer so every top-level link is reachable on mobile (#460).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.28-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.29-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.28"
+__version__ = "1.3.29"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/build.py
+++ b/llmwiki/build.py
@@ -860,7 +860,7 @@ def page_foot(js_prefix: str = "") -> str:
     <span>Theme</span>
   </button>
 </nav>
-<div id="palette" class="palette" aria-hidden="true">
+<div id="palette" class="palette">
   <div class="palette-backdrop" id="palette-backdrop"></div>
   <div class="palette-modal" role="dialog" aria-modal="true" aria-label="Command palette">
     <div class="palette-header">
@@ -876,7 +876,7 @@ def page_foot(js_prefix: str = "") -> str:
     </div>
   </div>
 </div>
-<div id="help-dialog" class="help-dialog" aria-hidden="true">
+<div id="help-dialog" class="help-dialog">
   <div class="palette-backdrop" id="help-backdrop"></div>
   <div class="help-modal">
     <h2>Keyboard shortcuts</h2>

--- a/llmwiki/render/css.py
+++ b/llmwiki/render/css.py
@@ -306,8 +306,14 @@ kbd { display: inline-block; padding: 2px 6px; font-family: var(--mono); font-si
 .synthesis p { margin: 10px 0; }
 
 /* Command palette */
+/* #478: was gated by `[aria-hidden="false"]`. axe-core flags that as
+   `aria-hidden-focus` because focusable children inside an aria-hidden
+   element are unreachable to AT users. Now toggled via `.open` class
+   that JS sets when the dialog is active; aria-hidden is removed
+   entirely while open and `inert` is applied to sibling chrome to
+   keep AT focus inside the dialog (#479). */
 .palette { position: fixed; inset: 0; z-index: 300; display: none; }
-.palette[aria-hidden="false"] { display: block; }
+.palette.open { display: block; }
 .palette-backdrop { position: absolute; inset: 0; background: rgba(15, 23, 42, 0.5); backdrop-filter: blur(4px); }
 .palette-modal { position: relative; max-width: 600px; margin: 10vh auto 0; background: var(--bg-card); border: 1px solid var(--border); border-radius: 12px; box-shadow: var(--shadow); overflow: hidden; }
 .palette-header { display: flex; align-items: center; gap: 10px; padding: 14px 16px; border-bottom: 1px solid var(--border); }
@@ -324,8 +330,10 @@ kbd { display: inline-block; padding: 2px 6px; font-family: var(--mono); font-si
 .palette-footer { display: flex; gap: 16px; padding: 10px 16px; border-top: 1px solid var(--border); font-size: 0.75rem; background: var(--bg-alt); }
 
 /* Help dialog */
+/* #478: same .open class swap as the palette — aria-hidden gating
+   was an axe-core violation for any focusable child. */
 .help-dialog { position: fixed; inset: 0; z-index: 250; display: none; }
-.help-dialog[aria-hidden="false"] { display: block; }
+.help-dialog.open { display: block; }
 .help-modal { position: relative; max-width: 420px; margin: 15vh auto 0; background: var(--bg-card); border: 1px solid var(--border); border-radius: 12px; padding: 24px; box-shadow: var(--shadow); }
 .help-modal h2 { font-size: 1.1rem; margin-bottom: 16px; }
 .help-modal table { width: 100%; font-size: 0.88rem; margin-bottom: 16px; }

--- a/llmwiki/render/js.py
+++ b/llmwiki/render/js.py
@@ -519,12 +519,69 @@ document.addEventListener("DOMContentLoaded", function () {
     window.location.href = pathPrefix + r.url;
   }
 
+  // #478, #479: dialog focus + inert helpers shared by palette + help.
+  // Stash who opened the dialog so we can restore focus on close.
+  // Apply `inert` to every direct child of <body> EXCEPT the dialog
+  // itself so AT users can't tab into the page chrome behind the
+  // backdrop (the previous aria-hidden gate left siblings reachable).
+  var __dialogLastFocus = null;
+  function __getInertSiblings(dialog) {
+    return Array.prototype.filter.call(
+      document.body.children,
+      function (el) { return el !== dialog; }
+    );
+  }
+  function __isDialogOpen(dialog) {
+    return dialog && dialog.classList.contains("open");
+  }
+  function __getFocusable(container) {
+    return Array.prototype.filter.call(
+      container.querySelectorAll(
+        'a[href], button:not([disabled]), input:not([disabled]), ' +
+        'select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      ),
+      function (el) { return !el.hasAttribute("disabled") && el.offsetParent !== null; }
+    );
+  }
+  function __openDialog(dialog, firstFocus) {
+    if (!dialog || dialog.classList.contains("open")) return;
+    __dialogLastFocus = document.activeElement;
+    dialog.classList.add("open");
+    __getInertSiblings(dialog).forEach(function (s) { s.setAttribute("inert", ""); });
+    if (firstFocus && firstFocus.focus) firstFocus.focus();
+  }
+  function __closeDialog(dialog) {
+    if (!dialog || !dialog.classList.contains("open")) return;
+    dialog.classList.remove("open");
+    __getInertSiblings(dialog).forEach(function (s) { s.removeAttribute("inert"); });
+    if (__dialogLastFocus && __dialogLastFocus.focus) {
+      try { __dialogLastFocus.focus(); } catch (e) { /* trigger gone */ }
+    }
+    __dialogLastFocus = null;
+  }
+  // Trap Tab + Shift+Tab inside `dialog` so focus can't escape into
+  // the inert page chrome and become visually invisible.
+  function __trapTab(dialog) {
+    return function (e) {
+      if (e.key !== "Tab" || !__isDialogOpen(dialog)) return;
+      const focusable = __getFocusable(dialog);
+      if (focusable.length === 0) { e.preventDefault(); return; }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault(); last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault(); first.focus();
+      }
+    };
+  }
+
   function openPalette() {
     const p = document.getElementById("palette");
     if (!p) return;
-    p.setAttribute("aria-hidden", "false");
     const input = document.getElementById("palette-input");
-    if (input) { input.value = ""; input.focus(); }
+    if (input) { input.value = ""; }
+    __openDialog(p, input);
     // Show meta entries immediately while chunks load
     var meta = getMetaSync();
     if (meta.length && !idx) renderResults(meta.slice(0, 10));
@@ -533,17 +590,18 @@ document.addEventListener("DOMContentLoaded", function () {
 
   function closePalette() {
     const p = document.getElementById("palette");
-    if (!p) return;
-    p.setAttribute("aria-hidden", "true");
+    __closeDialog(p);
   }
 
   function openHelp() {
     const d = document.getElementById("help-dialog");
-    if (d) d.setAttribute("aria-hidden", "false");
+    if (!d) return;
+    const closeBtn = document.getElementById("help-close");
+    __openDialog(d, closeBtn);
   }
   function closeHelp() {
     const d = document.getElementById("help-dialog");
-    if (d) d.setAttribute("aria-hidden", "true");
+    __closeDialog(d);
   }
 
   document.addEventListener("DOMContentLoaded", function () {
@@ -569,6 +627,13 @@ document.addEventListener("DOMContentLoaded", function () {
     if (helpBackdrop) helpBackdrop.addEventListener("click", closeHelp);
     const helpClose = document.getElementById("help-close");
     if (helpClose) helpClose.addEventListener("click", closeHelp);
+
+    // #479: Tab focus traps. Listening on document so the handler fires
+    // even when the focused element is a backdrop / non-focusable.
+    const paletteEl = document.getElementById("palette");
+    if (paletteEl) document.addEventListener("keydown", __trapTab(paletteEl));
+    const helpEl = document.getElementById("help-dialog");
+    if (helpEl) document.addEventListener("keydown", __trapTab(helpEl));
   });
 
   function updateActive() {
@@ -594,8 +659,9 @@ document.addEventListener("DOMContentLoaded", function () {
     if (e.key === "Escape") {
       const p = document.getElementById("palette");
       const h = document.getElementById("help-dialog");
-      if (p && p.getAttribute("aria-hidden") === "false") { closePalette(); return; }
-      if (h && h.getAttribute("aria-hidden") === "false") { closeHelp(); return; }
+      // #478: state check now reads the .open class (was aria-hidden).
+      if (p && p.classList.contains("open")) { closePalette(); return; }
+      if (h && h.classList.contains("open")) { closeHelp(); return; }
       if (inInput) { e.target.blur(); return; }
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.28"
+version = "1.3.29"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/e2e/steps/ui_steps.py
+++ b/tests/e2e/steps/ui_steps.py
@@ -188,20 +188,21 @@ def _press_key(page: Page, key: str) -> None:
 @when("the command palette becomes visible")
 @then("the command palette becomes visible")
 def _palette_visible(page: Page) -> None:
-    # The palette flips `aria-hidden="false"` on open via the
-    # openPalette() JS function (see llmwiki/build.py). We retry
-    # for up to 3s because openPalette also kicks off an async
-    # loadIndex().then(...) that could race with Playwright on CI.
+    # #478: the palette toggles a `.open` class on open via the
+    # openPalette() JS function (was `aria-hidden="false"`; that
+    # gating was an axe-core violation). Retry for up to 3s because
+    # openPalette also kicks off an async loadIndex().then(...) that
+    # could race with Playwright on CI.
     page.wait_for_function(
-        "() => document.getElementById('palette')?.getAttribute('aria-hidden') === 'false'",
+        "() => document.getElementById('palette')?.classList.contains('open') === true",
         timeout=3000,
     )
 
 
 @then("the palette input is focused")
 def _palette_input_focused(page: Page) -> None:
-    # Focus is set inside openPalette() right after the aria-hidden
-    # flip. Wait up to 2s to let the input claim focus.
+    # #478/#479: focus is set inside __openDialog() right after the
+    # .open class flip. Wait up to 2s to let the input claim focus.
     page.wait_for_function(
         "() => document.activeElement && document.activeElement.id === 'palette-input'",
         timeout=2000,
@@ -310,20 +311,23 @@ def _help_dialog_visible(page: Page) -> None:
 
 @then("the command palette becomes hidden")
 def _palette_hidden(page: Page) -> None:
+    # #478: hidden state is now the absence of the .open class.
     page.wait_for_function(
-        "() => document.getElementById('palette')?.getAttribute('aria-hidden') === 'true'",
+        "() => document.getElementById('palette')?.classList.contains('open') !== true",
         timeout=3000,
     )
 
 
 @then("the help dialog becomes hidden")
 def _help_dialog_hidden(page: Page) -> None:
-    # The help dialog may unmount OR gain a hidden attribute — accept either.
+    # #478: same .open class gate as the palette. Accept either the
+    # element being unmounted (some test paths navigate away first)
+    # or simply not having the .open class.
     page.wait_for_function(
         """() => {
             const d = document.querySelector('.help-dialog');
             if (!d) return true;
-            return d.offsetParent === null || d.getAttribute('aria-hidden') === 'true';
+            return d.offsetParent === null || !d.classList.contains('open');
         }""",
         timeout=3000,
     )
@@ -554,12 +558,11 @@ def _console_clean(page: Page) -> None:
 
 @then("the command palette is hidden")
 def _palette_hidden(page: Page) -> None:
-    # Close flips aria-hidden back to "true". We assert on that
-    # directly — the Playwright `to_be_hidden` check treats
-    # aria-hidden="true" as "attached but hidden" which is exactly
-    # the state we want.
+    # #478: close removes the .open class. We assert on the absence
+    # of the class — Playwright's `to_be_hidden` check is too strict
+    # because the element stays attached for focus restoration.
     page.wait_for_function(
-        "() => document.getElementById('palette')?.getAttribute('aria-hidden') === 'true'",
+        "() => document.getElementById('palette')?.classList.contains('open') !== true",
         timeout=3000,
     )
 

--- a/tests/e2e/test_search_palette.py
+++ b/tests/e2e/test_search_palette.py
@@ -24,7 +24,7 @@ def _open_palette(page: Page) -> None:
     page.locator("body").click(position={"x": 1, "y": 1})
     page.keyboard.press("ControlOrMeta+k")
     page.wait_for_function(
-        "() => document.getElementById('palette')?.getAttribute('aria-hidden') === 'false'",
+        "() => document.getElementById('palette')?.classList.contains('open') === true",
         timeout=3000,
     )
 
@@ -82,7 +82,7 @@ def test_palette_closes_on_escape(page: Page, base_url: str) -> None:
     page.keyboard.press("Escape")
     # Wait for hide.
     page.wait_for_function(
-        "() => document.getElementById('palette')?.getAttribute('aria-hidden') === 'true'",
+        "() => document.getElementById('palette')?.classList.contains('open') !== true",
         timeout=3000,
     )
     assert page.url == starting_url, (

--- a/tests/e2e/test_user_journey.py
+++ b/tests/e2e/test_user_journey.py
@@ -83,13 +83,13 @@ def test_full_navigation_journey(page: Page, base_url: str) -> None:
     page.locator("body").click(position={"x": 1, "y": 1})
     page.keyboard.press("ControlOrMeta+k")
     page.wait_for_function(
-        "() => document.getElementById('palette')?.getAttribute('aria-hidden') === 'false'",
+        "() => document.getElementById('palette')?.classList.contains('open') === true",
         timeout=3000,
     )
     # Close it.
     page.keyboard.press("Escape")
     page.wait_for_function(
-        "() => document.getElementById('palette')?.getAttribute('aria-hidden') === 'true'",
+        "() => document.getElementById('palette')?.classList.contains('open') !== true",
         timeout=3000,
     )
 

--- a/tests/test_palette_dialog_a11y.py
+++ b/tests/test_palette_dialog_a11y.py
@@ -1,0 +1,124 @@
+"""#478 + #479: command palette + help dialog used `aria-hidden="true"`
+as their visibility gate, which axe-core flags via the
+`aria-hidden-focus` rule (focusable children of an aria-hidden ancestor
+are unreachable to AT users). They also had no focus trap — Tab walked
+behind into the page chrome — and ESC didn't return focus to the trigger.
+
+The fix swaps the gate to a `.open` class and adds:
+  - `inert` on every body sibling while a dialog is open
+  - focus trap on Tab / Shift+Tab inside the dialog
+  - focus restoration to the original trigger on close
+
+These tests pin the markup, CSS, and JS contracts.
+"""
+from __future__ import annotations
+
+from llmwiki.build import page_foot
+from llmwiki.render.css import CSS
+from llmwiki.render.js import JS
+
+
+def _foot() -> str:
+    return page_foot()
+
+
+# ─── Markup contract ──────────────────────────────────────────────────
+
+
+def test_palette_markup_no_longer_uses_aria_hidden() -> None:
+    """The palette container must NOT carry `aria-hidden="true"` —
+    that's the axe-core violation we're fixing."""
+    foot = _foot()
+    assert '<div id="palette" class="palette">' in foot
+    assert 'id="palette" class="palette" aria-hidden="true"' not in foot
+
+
+def test_help_dialog_markup_no_longer_uses_aria_hidden() -> None:
+    foot = _foot()
+    assert '<div id="help-dialog" class="help-dialog">' in foot
+    assert 'id="help-dialog" class="help-dialog" aria-hidden="true"' not in foot
+
+
+# ─── CSS contract ─────────────────────────────────────────────────────
+
+
+def test_css_uses_open_class_for_palette_visibility() -> None:
+    """Visibility now driven by `.open` — make sure the rule exists
+    and the old `[aria-hidden="false"]` gate is gone."""
+    assert ".palette.open { display: block; }" in CSS
+    assert '.palette[aria-hidden="false"]' not in CSS
+
+
+def test_css_uses_open_class_for_help_visibility() -> None:
+    assert ".help-dialog.open { display: block; }" in CSS
+    assert '.help-dialog[aria-hidden="false"]' not in CSS
+
+
+# ─── JS contract — open / close + inert + focus restoration ───────────
+
+
+def test_js_dialog_open_helper_uses_inert_and_class() -> None:
+    """__openDialog must (a) flip the `.open` class, (b) set `inert`
+    on body siblings, (c) capture the previous focused element."""
+    assert "__openDialog" in JS
+    assert 'classList.add("open")' in JS
+    assert 'setAttribute("inert"' in JS
+    assert "__dialogLastFocus = document.activeElement" in JS
+
+
+def test_js_dialog_close_helper_restores_focus_and_clears_inert() -> None:
+    """Close must (a) flip class off, (b) remove `inert` from siblings,
+    (c) restore focus to the saved trigger."""
+    assert "__closeDialog" in JS
+    assert 'classList.remove("open")' in JS
+    assert 'removeAttribute("inert")' in JS
+    assert "__dialogLastFocus.focus()" in JS
+
+
+def test_js_palette_uses_dialog_helpers() -> None:
+    """Both open/close paths route through the shared helpers so the
+    inert + focus contract is uniform across palette and help."""
+    open_block = JS[JS.find("function openPalette()"): JS.find("function closePalette()")]
+    close_block = JS[JS.find("function closePalette()"): JS.find("function openHelp()")]
+    assert "__openDialog(p, input)" in open_block
+    assert "__closeDialog(p)" in close_block
+
+
+def test_js_help_uses_dialog_helpers() -> None:
+    open_block = JS[JS.find("function openHelp()"): JS.find("function closeHelp()")]
+    close_block = JS[JS.find("function closeHelp()"): JS.find("function closeHelp()") + 200]
+    assert "__openDialog(d" in open_block
+    assert "__closeDialog(d)" in close_block
+
+
+# ─── JS contract — focus trap on Tab / Shift+Tab ──────────────────────
+
+
+def test_js_traps_tab_inside_dialog() -> None:
+    """A `__trapTab` helper must wrap focus inside the dialog so Tab
+    can't walk behind into the inert page chrome."""
+    assert "__trapTab" in JS
+    # Wrapping logic — Shift+Tab from first goes to last; Tab from last
+    # goes to first.
+    assert "shiftKey && document.activeElement === first" in JS
+    assert "!e.shiftKey && document.activeElement === last" in JS
+
+
+def test_js_focusable_walker_skips_hidden_and_disabled() -> None:
+    """The focusable-elements walk must exclude disabled inputs and
+    hidden elements (offsetParent === null)."""
+    block = JS[JS.find("__getFocusable"): JS.find("__openDialog")]
+    assert "disabled" in block.lower()
+    assert "offsetParent" in block
+
+
+# ─── ESC handler updated to read the new state ────────────────────────
+
+
+def test_esc_handler_uses_open_class_not_aria_hidden() -> None:
+    """The Esc key handler used `getAttribute('aria-hidden') === 'false'`
+    as the open-state check. Now reads the .open class."""
+    assert 'p.classList.contains("open")' in JS
+    assert 'h.classList.contains("open")' in JS
+    # Make sure the old check is gone.
+    assert 'getAttribute("aria-hidden") === "false"' not in JS


### PR DESCRIPTION
## Summary

Closes **#478** and **#479** — two related WCAG fixes for the command palette and help dialog. Bundled because the fixes share the same code path; opening separate PRs would have churned `js.py` twice for one logical change.

### #478 — `aria-hidden-focus` violation

Visibility was gated via `.palette[aria-hidden="false"] { display: block }`. axe-core flags focusable children of an aria-hidden ancestor as unreachable to AT users. Both dialogs now toggle a `.open` class; `aria-hidden` is removed from the markup entirely.

### #479 — no focus trap, no focus restoration

Tab walked behind into the page chrome, ESC closed without returning focus to the trigger, and screen-reader users could land in invisible controls.

Three new shared helpers:

- `__openDialog(d, firstFocus)` — snapshot `document.activeElement`, flip `.open`, set `inert` on every body sibling, focus a known first element.
- `__closeDialog(d)` — flip `.open` off, remove `inert`, restore focus to the snapshot.
- `__trapTab(dialog)` — wraps Tab / Shift+Tab inside the dialog's focusable children so focus can't escape into inert chrome.

ESC handler updated to read `.open` class instead of the removed `aria-hidden` state.

## Test plan

- [x] `tests/test_palette_dialog_a11y.py` — 11 cases: markup (no aria-hidden), CSS (uses `.open`), dialog helpers (open/close use inert + focus snapshot), palette + help both route through helpers, focus trap (Tab/Shift+Tab wrap), ESC handler reads new state.
- [x] Full pytest suite — green.

Bumps version to **1.3.29**.