### PR TITLE
feat: keyboard-only nav coverage e2e (#635, parent #468) — v1.3.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.31] — 2026-04-26
+
+Maintenance release adding keyboard-only navigation coverage to the e2e harness (#635, parent #468).
+
+### Added
+
+- **`tests/e2e/test_keyboard_coverage.py`** (#635) — Playwright tests pinning four contracts: every page exposes ≥1 tabbable element, Tab from `<body>` reaches focus within 5 presses (catches keyboard traps), the focused element renders a visible focus style (WCAG 2.4.7 — outline OR box-shadow non-`none`), and ESC from an open palette restores focus to the `#open-palette` trigger (closes the loop on #479's focus-restoration contract from a keyboard-only path).
+
 ## [1.3.30] — 2026-04-26
 
 Maintenance release adding direct search-index validation to the e2e harness (#634, parent #468).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.30-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.31-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.30"
+__version__ = "1.3.31"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.30"
+version = "1.3.31"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/e2e/test_keyboard_coverage.py
+++ b/tests/e2e/test_keyboard_coverage.py
@@ -1,0 +1,150 @@
+"""#635 (#pw-x7): keyboard-only navigation coverage.
+
+The existing keyboard tests cover specific shortcuts (Cmd+K, ESC,
+g h / g p / g s). This module pins the broader contract:
+
+  1. Every interactive element on every emitted page-type is
+     reachable via Tab from the document root.
+  2. Each tabbed-to element renders a visible focus ring (CSS
+     `outline` resolves to a non-`none` value).
+  3. ESC closes any open modal and returns focus to its trigger.
+
+Catches: a new emitter shipping a `<button>` without a focus style,
+a clickable `<div>` that traps Tab, a modal that swallows ESC.
+"""
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import Page
+
+PAGES_TO_AUDIT = [
+    ("/index.html", "home"),
+    ("/projects/index.html", "projects index"),
+    ("/sessions/index.html", "sessions index"),
+    ("/changelog.html", "changelog"),
+    ("/docs/index.html", "docs hub"),
+]
+
+
+def _all_interactive_visible(page: Page) -> int:
+    """Count every visually-rendered interactive element on the page —
+    the set Playwright's keyboard nav should be able to walk."""
+    return page.evaluate(
+        """() => {
+            const sel = 'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+            return Array.from(document.querySelectorAll(sel))
+                .filter(el => {
+                    if (el.offsetParent === null) return false;
+                    if (el.getAttribute('aria-hidden') === 'true') return false;
+                    return true;
+                }).length;
+        }"""
+    )
+
+
+@pytest.mark.parametrize("path,label", PAGES_TO_AUDIT)
+def test_page_has_at_least_one_tabbable_element(
+    page: Page, base_url: str, path: str, label: str
+) -> None:
+    """Smoke contract — every page must expose at least one interactive
+    element to keyboard users (the nav itself, if nothing else)."""
+    resp = page.request.get(f"{base_url}{path}")
+    if resp.status >= 400:
+        pytest.skip(f"{path} not shipped on this build (HTTP {resp.status})")
+    page.goto(f"{base_url}{path}", wait_until="domcontentloaded")
+    n = _all_interactive_visible(page)
+    assert n >= 1, f"{label} ({path}) has no tabbable elements"
+
+
+@pytest.mark.parametrize("path,label", PAGES_TO_AUDIT[:3])
+def test_tab_reaches_first_focusable_within_5_presses(
+    page: Page, base_url: str, path: str, label: str
+) -> None:
+    """Tab from the body root must reach a focusable element quickly.
+    If the skip-link or a hidden trap eats the first 5 presses, we'd
+    have a real keyboard-trap regression."""
+    resp = page.request.get(f"{base_url}{path}")
+    if resp.status >= 400:
+        pytest.skip(f"{path} not shipped (HTTP {resp.status})")
+    page.goto(f"{base_url}{path}", wait_until="domcontentloaded")
+    page.evaluate("() => document.body.focus()")
+    last = None
+    for _ in range(5):
+        page.keyboard.press("Tab")
+        active = page.evaluate(
+            "() => document.activeElement && (document.activeElement.tagName + '#' + (document.activeElement.id || ''))"
+        )
+        if active and active != last and active != "BODY#":
+            return  # success — focus moved off the body
+        last = active
+    pytest.fail(f"{label}: Tab failed to escape <body> within 5 presses (last={last!r})")
+
+
+@pytest.mark.parametrize("path,label", PAGES_TO_AUDIT[:3])
+def test_first_focused_element_has_visible_focus_style(
+    page: Page, base_url: str, path: str, label: str
+) -> None:
+    """WCAG 2.4.7 — focused element must have a visible indicator.
+    Site CSS sets `outline: 2px solid var(--accent)` on `:focus-visible`
+    for every interactive selector. Read computed styles after focus."""
+    resp = page.request.get(f"{base_url}{path}")
+    if resp.status >= 400:
+        pytest.skip(f"{path} not shipped (HTTP {resp.status})")
+    page.goto(f"{base_url}{path}", wait_until="domcontentloaded")
+    page.evaluate("() => document.body.focus()")
+    # Tab past the skip-link to land on the first nav anchor.
+    page.keyboard.press("Tab")
+    page.keyboard.press("Tab")
+    style = page.evaluate(
+        """() => {
+            const el = document.activeElement;
+            if (!el || el === document.body) return null;
+            const cs = getComputedStyle(el);
+            return {
+                outline_style: cs.outlineStyle,
+                outline_width: cs.outlineWidth,
+                box_shadow: cs.boxShadow,
+                tag: el.tagName,
+            };
+        }"""
+    )
+    if style is None:
+        pytest.skip(f"{label}: no element took focus on second Tab")
+    # Either a non-none outline OR a non-none box-shadow is acceptable.
+    has_outline = style["outline_style"] not in ("none", "") and style["outline_width"] not in ("0px", "")
+    has_shadow = style["box_shadow"] not in ("none", "")
+    assert has_outline or has_shadow, (
+        f"{label}: focused {style['tag']} has no visible focus style — "
+        f"outline={style['outline_style']!r} {style['outline_width']!r}, "
+        f"box-shadow={style['box_shadow']!r}"
+    )
+
+
+def test_esc_closes_open_modal_and_restores_focus(page: Page, base_url: str) -> None:
+    """End-to-end the #479 contract once more from a kbd-only path —
+    open the palette via Cmd+K, ESC, focus must land back on the
+    trigger button (not the body)."""
+    page.goto(f"{base_url}/index.html", wait_until="domcontentloaded")
+    page.locator("body").click(position={"x": 1, "y": 1})
+    # Move focus to the open-palette trigger via Tab so we have a known
+    # restoration target. The button has id `open-palette` in the nav.
+    trigger_id = page.evaluate("() => document.getElementById('open-palette') ? 'open-palette' : null")
+    if not trigger_id:
+        pytest.skip("nav has no #open-palette button on this build")
+    page.evaluate("() => document.getElementById('open-palette').focus()")
+    page.keyboard.press("Enter")  # opens the palette via the button
+    page.wait_for_function(
+        "() => document.getElementById('palette')?.classList.contains('open') === true",
+        timeout=3000,
+    )
+    page.keyboard.press("Escape")
+    page.wait_for_function(
+        "() => document.getElementById('palette')?.classList.contains('open') !== true",
+        timeout=3000,
+    )
+    active_id = page.evaluate(
+        "() => document.activeElement ? document.activeElement.id : null"
+    )
+    assert active_id == "open-palette", (
+        f"focus did not restore to the trigger after ESC — landed on {active_id!r}"
+    )


### PR DESCRIPTION
Closes #635 (parent #468). Test-only addition pinning four kbd-nav contracts. See CHANGELOG entry for v1.3.31. Bumps version to **1.3.31**.