### PR TITLE
feat: cross-browser smoke matrix (#636, parent #468) — v1.3.35

### DIFF
--- a/.github/workflows/cross-browser.yml
+++ b/.github/workflows/cross-browser.yml
@@ -1,0 +1,67 @@
+name: Cross-browser smoke
+
+# #636 (#pw-x8): runs the small cross-browser smoke (homepage, sessions
+# index, graph, theme toggle) against chromium + firefox + webkit on
+# every PR. The full e2e suite stays chromium-only to keep cost down;
+# this job only installs all three engines for the smoke subset.
+
+on:
+  pull_request:
+    paths:
+      - "llmwiki/build.py"
+      - "llmwiki/render/css.py"
+      - "llmwiki/render/js.py"
+      - "llmwiki/graph.py"
+      - "tests/e2e/test_cross_browser_smoke.py"
+      - ".github/workflows/cross-browser.yml"
+  push:
+    branches: ["master"]
+    paths:
+      - "llmwiki/build.py"
+      - "llmwiki/render/css.py"
+      - "llmwiki/render/js.py"
+      - "llmwiki/graph.py"
+      - "tests/e2e/test_cross_browser_smoke.py"
+      - ".github/workflows/cross-browser.yml"
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    name: ${{ matrix.browser }} smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install llmwiki + e2e extras
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[e2e]'
+
+      - name: Install ${{ matrix.browser }} + OS deps
+        run: python -m playwright install --with-deps ${{ matrix.browser }}
+
+      - name: Run cross-browser smoke
+        run: |
+          python -m pytest tests/e2e/test_cross_browser_smoke.py \
+            --browser=${{ matrix.browser }} \
+            --tracing=retain-on-failure \
+            -v
+
+      - name: Upload trace on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.browser }}-trace
+          path: test-results/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.35] — 2026-04-26
+
+Maintenance release adding cross-browser smoke matrix to CI (#636, parent #468).
+
+### Added
+
+- **`tests/e2e/test_cross_browser_smoke.py`** + **`.github/workflows/cross-browser.yml`** (#636) — small smoke (4 tests: homepage loads with nav, sessions index renders table, graph canvas has nonzero size, theme toggle flips data-theme) runs against chromium / firefox / webkit on every PR via a new matrix workflow. Catches engine-specific regressions in CSS variable resolution, sticky-thead behaviour, canvas + vis-network init, and localStorage. The full e2e suite stays chromium-only to keep cost down; this is a focused 4-test subset that runs in under 5 min per browser.
+
 ## [1.3.34] — 2026-04-26
 
 Maintenance release broadening axe-core a11y coverage in the e2e harness (#631, parent #468).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.34-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.35-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.34"
+__version__ = "1.3.35"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.34"
+version = "1.3.35"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -330,15 +330,23 @@ def base_url(server: ThreadingHTTPServer) -> str:
 
 
 @pytest.fixture(scope="session")
-def browser_context_args(browser_context_args: dict[str, object]) -> dict[str, object]:
+def browser_context_args(browser_context_args: dict[str, object], browser_name: str) -> dict[str, object]:
     """Override the default pytest-playwright context args so the
     browser permissions include clipboard access (needed for the
-    copy-as-markdown test). Merges with the upstream defaults."""
-    return {
+    copy-as-markdown test). Merges with the upstream defaults.
+
+    #636: clipboard-read / clipboard-write are chromium-only permission
+    names — Firefox + WebKit raise `Unknown permission` if they're
+    granted. Only set the permission list when running on chromium so
+    the cross-browser smoke matrix can run without monkey-patching.
+    """
+    args: dict[str, object] = {
         **browser_context_args,
-        "permissions": ["clipboard-read", "clipboard-write"],
         "viewport": {"width": 1280, "height": 800},
     }
+    if browser_name == "chromium":
+        args["permissions"] = ["clipboard-read", "clipboard-write"]
+    return args
 
 
 @pytest.fixture()

--- a/tests/e2e/test_cross_browser_smoke.py
+++ b/tests/e2e/test_cross_browser_smoke.py
@@ -1,0 +1,90 @@
+"""#636 (#pw-x8): cross-browser smoke for the highest-traffic pages.
+
+The full e2e suite runs only against chromium (browser-install cost +
+test-runtime budget). This module is a small smoke — homepage, sessions
+index, graph — that's *meant* to run against chromium / firefox /
+webkit via a separate CI workflow. Catches engine-specific regressions
+in CSS variable resolution, custom-element scoping, SVG behaviour, or
+Promise semantics that only surface outside chromium.
+
+Run locally:
+
+    pytest tests/e2e/test_cross_browser_smoke.py --browser=firefox
+    pytest tests/e2e/test_cross_browser_smoke.py --browser=webkit
+
+CI matrixes over all three browsers via `.github/workflows/cross-browser.yml`.
+
+Each test stays small and fast — anything bigger lives in the chromium-
+only suite to keep the cross-browser job under 5 minutes.
+"""
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import Page
+
+
+def test_homepage_loads_with_nav_and_title(page: Page, base_url: str) -> None:
+    """The single most important page — title bar + sticky nav must
+    render in every engine. Catches engine-specific CSS variable
+    resolution failures + missing-feature regressions."""
+    page.goto(f"{base_url}/index.html", wait_until="domcontentloaded")
+    title = page.title()
+    assert "LLM Wiki" in title or "llmwiki" in title.lower(), (
+        f"unexpected document title: {title!r}"
+    )
+    nav = page.locator("header.nav").first
+    assert nav.is_visible(timeout=3000), "site nav not visible on homepage"
+
+
+def test_sessions_index_renders_table(page: Page, base_url: str) -> None:
+    """Table layout regressions across engines: tables with
+    `table-layout: fixed` + sticky thead behave subtly differently
+    on Firefox vs WebKit. Catches the family of #452-style
+    column-alignment bugs across engines."""
+    resp = page.request.get(f"{base_url}/sessions/index.html")
+    if resp.status >= 400:
+        pytest.skip(f"sessions index not shipped (HTTP {resp.status})")
+    page.goto(f"{base_url}/sessions/index.html", wait_until="domcontentloaded")
+    table = page.locator("table.sessions-table").first
+    assert table.is_visible(timeout=3000)
+    # At least one row in the body — the seeded harness has 8 demo sessions.
+    rows = page.locator("table.sessions-table tbody tr").count()
+    assert rows >= 1, f"sessions table has {rows} rows — expected ≥1"
+
+
+def test_graph_page_loads_canvas(page: Page, base_url: str) -> None:
+    """Canvas + vis-network behaviour varies by engine. Smoke checks
+    that the canvas is at least attached + has nonzero size — full
+    graph render uses CDN-loaded vis-network which has its own engine
+    quirks."""
+    resp = page.request.get(f"{base_url}/graph.html")
+    if resp.status >= 400:
+        pytest.skip("graph.html not shipped")
+    page.goto(f"{base_url}/graph.html", wait_until="domcontentloaded")
+    page.wait_for_timeout(1500)  # let vis-network init
+    box = page.evaluate(
+        "() => { const c = document.querySelector('canvas'); "
+        "return c ? c.getBoundingClientRect() : null; }"
+    )
+    assert box is not None, "no <canvas> in graph.html"
+    assert box["width"] > 0 and box["height"] > 0, (
+        f"canvas has zero size in this engine: {box}"
+    )
+
+
+def test_theme_toggle_flips_data_theme(page: Page, base_url: str) -> None:
+    """Theme toggle relies on localStorage + custom property updates;
+    Firefox + WebKit each have their own quirks here. Confirms the
+    cross-engine contract."""
+    page.goto(f"{base_url}/index.html", wait_until="domcontentloaded")
+    page.locator("body").click(position={"x": 1, "y": 1})
+    initial = page.evaluate("() => document.documentElement.getAttribute('data-theme')")
+    btn = page.locator("#theme-toggle").first
+    if not btn.is_visible():
+        pytest.skip("no #theme-toggle on this build")
+    btn.click()
+    page.wait_for_timeout(200)
+    after = page.evaluate("() => document.documentElement.getAttribute('data-theme')")
+    assert after != initial, (
+        f"theme toggle did not flip data-theme: {initial!r} -> {after!r}"
+    )


### PR DESCRIPTION
Closes #636. Adds 4-test smoke matrix across chromium/firefox/webkit. See CHANGELOG. Bumps to **1.3.35**.