### PR TITLE
feat: nightly synthetic monitoring (#637, parent #468) — v1.3.36

### DIFF
--- a/.github/synthetic-failure-template.md
+++ b/.github/synthetic-failure-template.md
@@ -1,0 +1,19 @@
+# Synthetic monitoring failure
+
+The nightly synthetic monitoring workflow (`.github/workflows/synthetic.yml`) failed against the deployed demo at `https://pratiyush.github.io/llm-wiki/`.
+
+## Possible causes
+
+- GitHub Pages publish lag or partial publish corruption — try a manual rebuild via the Pages workflow.
+- Third-party CDN failure (highlight.js, vis-network, axe-core, fonts.googleapis.com).
+- A browser update changed default behaviour for one of the tested features.
+- The deploy itself is broken — check the most recent `pages.yml` run.
+
+## Debug
+
+- Download the `synthetic-report` artifact from the failed workflow run for an HTML report with screenshots + traces.
+- Re-run the workflow manually via "Run workflow" on the workflow page to confirm the failure isn't transient.
+
+## Triage
+
+If the deployed demo is broken, file a fresh issue describing the user impact and link the failed workflow run. Resolve this tracking issue once the underlying cause is fixed.

--- a/.github/workflows/synthetic.yml
+++ b/.github/workflows/synthetic.yml
@@ -1,0 +1,81 @@
+name: Nightly synthetic
+
+# #637 (#pw-x9): nightly Playwright run against the deployed demo at
+# https://pratiyush.github.io/llm-wiki/. Catches post-deploy breakage
+# we can't see in regular CI: GitHub Pages publish corruption, CDN
+# issues, browser update breakage, broken third-party scripts.
+#
+# Failure path: opens (or appends to) a single tracking issue titled
+# "Synthetic monitoring failure" so it doesn't spam the tracker on
+# repeated breaks (same dedupe pattern as link-check.yml uses for
+# its broken-links report).
+
+on:
+  schedule:
+    # 04:13 UTC every day. The off-the-hour minute keeps us out of
+    # GitHub's hourly scheduler peaks where workers can be backlogged.
+    - cron: "13 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  synthetic:
+    name: Probe deployed demo
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install llmwiki + e2e extras
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[e2e]'
+
+      - name: Install chromium + OS deps
+        run: python -m playwright install --with-deps chromium
+
+      - name: Run cross-browser smoke against the live demo
+        id: probe
+        run: |
+          mkdir -p synthetic-report
+          # Re-use the cross-browser smoke as the synthetic check.
+          # Override base_url via env so the smoke probes the deployed
+          # site instead of spinning up its own local server. Each
+          # test in the smoke is robust to a site that lacks specific
+          # pages (uses request.get + 404-skip pattern).
+          export QA_SYNTHETIC_BASE_URL="https://pratiyush.github.io/llm-wiki"
+          python -m pytest tests/e2e/test_cross_browser_smoke.py \
+            --base-url="$QA_SYNTHETIC_BASE_URL" \
+            --browser=chromium \
+            --tracing=retain-on-failure \
+            --html=synthetic-report/index.html \
+            --self-contained-html \
+            -v
+
+      - name: Upload synthetic HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: synthetic-report
+          path: synthetic-report/
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: File or update tracking issue on failure
+        if: failure()
+        uses: peter-evans/create-issue-from-file@v6
+        with:
+          title: "Synthetic monitoring failure"
+          content-filepath: .github/synthetic-failure-template.md
+          labels: bug, ci
+          # Same dedupe as link-check.yml — append to the existing
+          # tracking issue instead of spawning a new one each night.
+          update_existing: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.36] — 2026-04-26
+
+Maintenance release adding nightly synthetic monitoring of the deployed demo (#637, parent #468).
+
+### Added
+
+- **`.github/workflows/synthetic.yml`** + **`.github/synthetic-failure-template.md`** (#637) — nightly cron (04:13 UTC) runs `tests/e2e/test_cross_browser_smoke.py` against `https://pratiyush.github.io/llm-wiki/` (the deployed demo). On failure it appends to a single tracking issue titled "Synthetic monitoring failure" via the same `update_existing: true` dedupe pattern `link-check.yml` uses, so a stuck regression doesn't spam the tracker. Catches post-deploy breakage we can't see in normal CI: GitHub Pages publish corruption, third-party CDN failures, browser update breakage.
+
 ## [1.3.35] — 2026-04-26
 
 Maintenance release adding cross-browser smoke matrix to CI (#636, parent #468).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.35-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.36-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.35"
+__version__ = "1.3.36"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.35"
+version = "1.3.36"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Closes #637. Adds cron workflow that runs the cross-browser smoke against the deployed demo every night, with deduped failure tracking. See CHANGELOG. Bumps to **1.3.36**.