### PR TITLE
feat: per-page performance budgets e2e (#630, parent #468) — v1.3.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.37] — 2026-04-26
+
+Maintenance release adding per-page performance budgets to the e2e harness (#630, parent #468).
+
+### Added
+
+- **`tests/perf-budgets.json`** + **`tests/e2e/test_perf_budgets.py`** (#630) — Playwright captures `domContentLoadedEventEnd` and `loadEventEnd` for each page-type and asserts they're under the per-page budget. Catches bundle bloat + asset regressions that don't show in static analysis. Budgets are conservative starting points (DCL 2500-4000ms, load 4000-6500ms depending on page complexity); we can graduate to LCP/INP/CLS once baseline numbers stabilise — DCL + load are deterministic enough to catch ≥500ms regressions without flaking on shared CI runners.
+
 ## [1.3.36] — 2026-04-26
 
 Maintenance release adding nightly synthetic monitoring of the deployed demo (#637, parent #468).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.36-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.37-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.36"
+__version__ = "1.3.37"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.36"
+version = "1.3.37"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/e2e/test_perf_budgets.py
+++ b/tests/e2e/test_perf_budgets.py
@@ -1,0 +1,78 @@
+"""#630 (#pw-x2): per-page performance budgets.
+
+Captures `performance.timing.domContentLoadedEventEnd` and
+`loadEventEnd` for each emitted page-type and asserts they're under
+the per-page budget defined in `tests/perf-budgets.json`. Catches
+bundle bloat + asset regressions that don't show up in static
+analysis but degrade real-page perceived load.
+
+Why these signals (not LCP/INP/CLS): the Web Vitals trio is more
+faithful to user perception, but the captures fluctuate by ±200ms
+on shared CI runners depending on noisy-neighbour load. DCL +
+load are deterministic enough to catch regressions of ≥500ms
+without flaking. We can graduate to LCP once baseline numbers
+stabilise (tracked as a follow-up, not blocking on it).
+
+The budgets file is intentionally conservative — set well above
+the seeded build's actual numbers so flakiness doesn't drown the
+real signal. Tighten via a deliberate baseline pass on the live
+demo when we have one.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page
+
+BUDGETS_FILE = Path(__file__).parent.parent / "perf-budgets.json"
+
+
+def _load_budgets() -> dict[str, dict[str, int]]:
+    raw = json.loads(BUDGETS_FILE.read_text(encoding="utf-8"))
+    return {k: v for k, v in raw.items() if not k.startswith("_")}
+
+
+BUDGETS = _load_budgets()
+
+
+def _capture_timings(page: Page) -> dict[str, float]:
+    """Return DCL + load times in ms relative to navigationStart."""
+    return page.evaluate(
+        """() => {
+            const t = performance.timing;
+            const start = t.navigationStart;
+            return {
+                dcl_ms: Math.round(t.domContentLoadedEventEnd - start),
+                load_ms: Math.round(t.loadEventEnd - start),
+            };
+        }"""
+    )
+
+
+@pytest.mark.parametrize("path", list(BUDGETS.keys()))
+def test_page_meets_perf_budget(page: Page, base_url: str, path: str) -> None:
+    """Load the page, wait for `load`, capture timing, compare to
+    the budget for that path. Skip cleanly when the page isn't
+    shipped on this build (e.g. graph.html on an empty wiki)."""
+    resp = page.request.get(f"{base_url}{path}")
+    if resp.status >= 400:
+        pytest.skip(f"{path} not shipped on this build (HTTP {resp.status})")
+
+    page.goto(f"{base_url}{path}", wait_until="load")
+    timings = _capture_timings(page)
+    budget = BUDGETS[path]
+
+    failures = []
+    for metric in ("dcl_ms", "load_ms"):
+        if timings[metric] > budget[metric]:
+            failures.append(
+                f"{metric} = {timings[metric]}ms > budget {budget[metric]}ms"
+            )
+    if failures:
+        pytest.fail(
+            f"{path} blew its perf budget:\n  "
+            + "\n  ".join(failures)
+            + f"\n  (timings={timings}, budget={budget})"
+        )

--- a/tests/perf-budgets.json
+++ b/tests/perf-budgets.json
@@ -1,0 +1,9 @@
+{
+  "_doc": "Per-page performance budgets used by tests/e2e/test_perf_budgets.py (#630). Values are conservative starting points based on a local seeded build; tighten after baselining the live demo. Times in milliseconds. domContentLoaded is the most stable signal across CI runners; LCP fluctuates with image decode + font load.",
+  "/index.html":              { "dcl_ms": 2500, "load_ms": 4000 },
+  "/projects/index.html":     { "dcl_ms": 2500, "load_ms": 4000 },
+  "/sessions/index.html":     { "dcl_ms": 3000, "load_ms": 5000 },
+  "/changelog.html":          { "dcl_ms": 3000, "load_ms": 5000 },
+  "/docs/index.html":         { "dcl_ms": 2500, "load_ms": 4000 },
+  "/graph.html":              { "dcl_ms": 4000, "load_ms": 6500 }
+}


### PR DESCRIPTION
Closes #630. Test-only addition. See CHANGELOG. Bumps to **1.3.37**.