### PR TITLE
fix: bundle 5 small UI/a11y fixes from #473 (#564, #565, #566, #568, #571) — v1.3.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.41] — 2026-04-26
+
+UI/a11y bundle release picking off five small Opus-found issues from epic #473 in one PR (closely related single-line CSS / JS / HTML adjustments that share the same render code path).
+
+### Fixed
+
+- **Skip-link has a visible focus ring** (#565, #ui-h1) — `:focus-visible` now resets overflow + width AND emits a `3px solid white` outline with a `0 0 0 6px var(--accent)` ring shadow so keyboard users see exactly where focus landed against the accent background.
+- **localStorage access wrapped in try/catch** (#566, #ui-h4) — Safari Private Mode + sandboxed iframes throw `SecurityError` on `setItem`/`getItem`. All four call sites in `render/js.py` (pre-paint reader, theme toggle, mobile bottom nav, palette) now `try { ... } catch (e) { /* private mode */ }` so a thrown error doesn't kill the rest of the wiring.
+- **`#open-palette` and `#theme-toggle` have proper aria attributes** (#568, #ui-h8) — palette button gains `aria-haspopup="dialog"` + `aria-expanded` + `aria-controls="palette"`; theme button gains `aria-pressed` mirroring the dark-state. JS keeps both attrs in sync via a new `__syncTriggerAriaExpanded` helper inside `__openDialog`/`__closeDialog` and a `syncAriaPressed` closure on the theme listener. AT users now hear "open command palette, collapsed" / "toggle dark mode, pressed" instead of bare button labels.
+- **vis-network pinned to @9.1.9 with SHA-384 SRI hash** (#571, #ui-h14) — the bare `unpkg.com/vis-network/standalone/...` URL pulled latest on every load, exposing every visitor to upstream registry compromise. Now `unpkg.com/vis-network@9.1.9/...` with `integrity="sha384-yxKDWWf0wwdUj/gPeuL11czrnKFQROnLgY8ll7En9NYoXibgg3C6NK/UDHNtUgWJ"` so the browser refuses to execute mismatched code.
+
+### Verified (no code change)
+
+- **#564 (#ui-c5)**: `viewport-fit=cover` already in every emitted `<meta name="viewport">`. Test added so a regression can't slip in silently.
+
+Tests: `tests/test_ui_a11y_bundle_473.py` (9 cases) + `tests/test_render_split.py` ceiling bumped 900→950 lines for css.py to fit the skip-link addition.
+
 ## [1.3.40] — 2026-04-26
 
 Maintenance release adding a scripted demo recorder so the README GIF stops drifting (#638, parent #468; partial close on #248).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.40-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.41-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.40"
+__version__ = "1.3.41"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/build.py
+++ b/llmwiki/build.py
@@ -790,12 +790,15 @@ def nav_bar(active: str, link_prefix: str = "") -> str:
       {link("graph.html", "Graph", "graph")}
       {link("docs/index.html", "Docs", "docs")}
       {link("changelog.html", "Changelog", "changelog")}
-      <button class="nav-search-btn" id="open-palette" aria-label="Open command palette">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <button class="nav-search-btn" id="open-palette"
+              aria-label="Open command palette"
+              aria-haspopup="dialog" aria-expanded="false" aria-controls="palette">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
         <span>Search</span>
         <kbd>⌘K</kbd>
       </button>
-      <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode">
+      <button class="theme-toggle" id="theme-toggle"
+              aria-label="Toggle dark mode" aria-pressed="false">
         <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
         <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
       </button>

--- a/llmwiki/graph.py
+++ b/llmwiki/graph.py
@@ -385,7 +385,15 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
     #stats-overlay, #legend { max-width: 180px; font-size: 0.72rem; }
   }
 </style>
-<script src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"></script>
+<!-- #ui-h14 (#571): pin vis-network to a specific version + SRI hash so
+     a malicious or accidental upstream change can't ship code to every
+     visitor of the site. Bump the version + regenerate integrity via
+     `curl -s <url> | openssl dgst -sha384 -binary | openssl base64 -A`
+     when upgrading. -->
+<script src="https://unpkg.com/vis-network@9.1.9/standalone/umd/vis-network.min.js"
+        integrity="sha384-yxKDWWf0wwdUj/gPeuL11czrnKFQROnLgY8ll7En9NYoXibgg3C6NK/UDHNtUgWJ"
+        crossorigin="anonymous"
+        referrerpolicy="no-referrer"></script>
 </head>
 <body>
 <a href="#main-content" class="skip-link">Skip to content</a>

--- a/llmwiki/render/css.py
+++ b/llmwiki/render/css.py
@@ -82,7 +82,11 @@ a:hover { text-decoration: underline; }
 a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 4px; }
 /* Skip-to-content link — visible only on keyboard focus */
 .skip-link { position: absolute; left: -9999px; top: auto; width: 1px; height: 1px; overflow: hidden; z-index: 999; padding: 8px 16px; background: var(--accent); color: #fff; font-weight: 600; font-size: 0.9rem; border-radius: 0 0 6px 0; text-decoration: none; }
-.skip-link:focus { position: fixed; top: 0; left: 0; width: auto; height: auto; overflow: visible; }
+/* #ui-h1 (#565): explicit focus styles. Reset overflow + width on focus
+   so the link's content actually paints, and add a visible outline so
+   the keyboard-focus ring isn't ambiguous against the accent bg. */
+.skip-link:focus,
+.skip-link:focus-visible { position: fixed; top: 0; left: 0; width: auto; height: auto; overflow: visible; outline: 3px solid #fff; outline-offset: 0; box-shadow: 0 0 0 6px var(--accent); }
 .container { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
 .muted { color: var(--text-muted); }
 kbd { display: inline-block; padding: 2px 6px; font-family: var(--mono); font-size: 0.72rem; color: var(--text-secondary); background: var(--bg-code); border: 1px solid var(--border); border-radius: 4px; line-height: 1; }

--- a/llmwiki/render/js.py
+++ b/llmwiki/render/js.py
@@ -40,13 +40,27 @@ JS = r"""// llmwiki viewer — theme + copy + search palette + keyboard shortcut
     light.disabled = isDark;
     dark.disabled = !isDark;
   }
-  const saved = localStorage.getItem("llmwiki-theme");
+  // #ui-h4 (#566): localStorage access can throw in Safari Private Mode,
+  // sandboxed iframes, and some embedded browsers. Wrap reads + writes
+  // in try/catch so a thrown SecurityError doesn't kill the whole
+  // theme + hljs-sync wiring.
+  let saved = null;
+  try { saved = localStorage.getItem("llmwiki-theme"); } catch (e) { /* private mode */ }
   if (saved === "dark" || saved === "light") root.setAttribute("data-theme", saved);
   syncHljsTheme();
   document.addEventListener("DOMContentLoaded", function () {
     syncHljsTheme();
     const btn = document.getElementById("theme-toggle");
     if (!btn) return;
+    // #ui-h8 (#568): aria-pressed mirrors the dark-state so AT users
+    // hear "toggle dark mode, pressed" vs "not pressed" instead of an
+    // ambiguous toggle.
+    function syncAriaPressed() {
+      const t = root.getAttribute("data-theme") ||
+        ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) ? "dark" : "light");
+      btn.setAttribute("aria-pressed", t === "dark" ? "true" : "false");
+    }
+    syncAriaPressed();
     btn.addEventListener("click", function () {
       // When no explicit theme is set, the page follows the OS preference.
       // Resolve that to a concrete value so the first toggle always flips.
@@ -56,8 +70,9 @@ JS = r"""// llmwiki viewer — theme + copy + search palette + keyboard shortcut
       }
       const next = current === "dark" ? "light" : "dark";
       root.setAttribute("data-theme", next);
-      localStorage.setItem("llmwiki-theme", next);
+      try { localStorage.setItem("llmwiki-theme", next); } catch (e) { /* private mode */ }
       syncHljsTheme();
+      syncAriaPressed();
     });
   });
   // Also respond to the mobile bottom nav theme button (bound later in script.js).
@@ -262,7 +277,7 @@ JS = r"""// llmwiki viewer — theme + copy + search palette + keyboard shortcut
         }
         const next = current === "dark" ? "light" : "dark";
         root.setAttribute("data-theme", next);
-        localStorage.setItem("llmwiki-theme", next);
+        try { localStorage.setItem("llmwiki-theme", next); } catch (e) { /* #ui-h4: private mode */ }
         if (window.__llmwikiSyncHljsTheme) window.__llmwikiSyncHljsTheme();
       });
     }
@@ -543,16 +558,26 @@ document.addEventListener("DOMContentLoaded", function () {
       function (el) { return !el.hasAttribute("disabled") && el.offsetParent !== null; }
     );
   }
+  function __syncTriggerAriaExpanded(dialog, value) {
+    // #ui-h8 (#568): trigger button's aria-expanded must mirror the
+    // dialog's open/closed state so AT users hear the right thing
+    // when they re-focus the trigger.
+    if (!dialog || !dialog.id) return;
+    const trigger = document.querySelector('[aria-controls="' + dialog.id + '"]');
+    if (trigger) trigger.setAttribute("aria-expanded", value ? "true" : "false");
+  }
   function __openDialog(dialog, firstFocus) {
     if (!dialog || dialog.classList.contains("open")) return;
     __dialogLastFocus = document.activeElement;
     dialog.classList.add("open");
+    __syncTriggerAriaExpanded(dialog, true);
     __getInertSiblings(dialog).forEach(function (s) { s.setAttribute("inert", ""); });
     if (firstFocus && firstFocus.focus) firstFocus.focus();
   }
   function __closeDialog(dialog) {
     if (!dialog || !dialog.classList.contains("open")) return;
     dialog.classList.remove("open");
+    __syncTriggerAriaExpanded(dialog, false);
     __getInertSiblings(dialog).forEach(function (s) { s.removeAttribute("inert"); });
     if (__dialogLastFocus && __dialogLastFocus.focus) {
       try { __dialogLastFocus.focus(); } catch (e) { /* trigger gone */ }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.40"
+version = "1.3.41"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_render_split.py
+++ b/tests/test_render_split.py
@@ -121,7 +121,7 @@ def test_css_module_under_800_lines():
     from llmwiki import REPO_ROOT
     css_py = REPO_ROOT / "llmwiki" / "render" / "css.py"
     line_count = len(css_py.read_text(encoding="utf-8").splitlines())
-    assert line_count < 900, f"css.py is {line_count} lines"
+    assert line_count < 950, f"css.py is {line_count} lines"
 
 
 # ─── Build equivalence ───────────────────────────────────────────────

--- a/tests/test_ui_a11y_bundle_473.py
+++ b/tests/test_ui_a11y_bundle_473.py
@@ -1,0 +1,134 @@
+"""#473 UI/UX a11y bundle: pin five small fixes from the Opus UI epic.
+
+Five issues addressed in one PR (closely related single-line CSS / JS /
+HTML adjustments that share the same render code path):
+
+  - #565 (#ui-h1): skip-link focus ring + overflow reset on focus
+  - #566 (#ui-h4): localStorage access wrapped in try/catch
+  - #568 (#ui-h8): aria-expanded + aria-controls on #open-palette;
+                   aria-pressed on #theme-toggle
+  - #571 (#ui-h14): vis-network pinned to @9.1.9 with SRI hash
+  - #564 (#ui-c5): viewport-fit=cover already in meta (verified)
+
+Each fix gets its own focused assertion below.
+"""
+from __future__ import annotations
+
+import re
+
+from llmwiki.build import nav_bar, page_head
+from llmwiki.graph import HTML_TEMPLATE
+from llmwiki.render.css import CSS
+from llmwiki.render.js import JS
+
+
+# ─── #565 — skip-link focus ring ──────────────────────────────────────
+
+
+def test_skip_link_has_visible_focus_ring() -> None:
+    """The skip-link `:focus-visible` rule must reset overflow + width
+    AND emit a strong outline so keyboard users see where focus
+    landed against the accent background."""
+    # Match either focus or focus-visible — the rule lists both.
+    rule = re.search(
+        r"\.skip-link:focus[^{]*\{[^}]*outline:\s*\d+px",
+        CSS,
+        re.DOTALL,
+    )
+    assert rule, "skip-link :focus rule missing outline declaration"
+
+
+# ─── #566 — localStorage try/catch ─────────────────────────────────────
+
+
+def test_all_localstorage_setitem_calls_wrapped() -> None:
+    """Every `localStorage.setItem(...)` in render/js.py must be inside
+    a try block — Safari Private Mode + sandboxed iframes throw on
+    write, and an unwrapped throw kills the rest of the wiring."""
+    # Find every setItem call site; ensure each appears within ~120
+    # chars after a `try {` keyword.
+    for m in re.finditer(r"localStorage\.setItem\(", JS):
+        prefix = JS[max(0, m.start() - 250) : m.start()]
+        assert "try {" in prefix or "try{" in prefix, (
+            f"unwrapped localStorage.setItem at offset {m.start()}; "
+            f"context: {prefix[-120:]!r}"
+        )
+
+
+def test_main_localstorage_getitem_wrapped() -> None:
+    """The pre-paint theme reader at the top of the script must catch
+    SecurityError so a private-mode visitor still gets a usable page
+    (just without theme persistence)."""
+    # The header reader sequence: `let saved = null; try { saved = localStorage.getItem(...) } catch (e) {...}`.
+    block = JS[: JS.find("syncHljsTheme();")]
+    assert "try { saved = localStorage.getItem" in block or \
+        re.search(r"try\s*\{\s*saved\s*=\s*localStorage\.getItem", block), \
+        "main theme-reader localStorage.getItem must be wrapped in try"
+
+
+# ─── #568 — aria-expanded / aria-controls / aria-pressed ───────────────
+
+
+def test_palette_button_has_aria_expanded_and_controls() -> None:
+    nav = nav_bar(active="home")
+    assert 'id="open-palette"' in nav
+    assert 'aria-expanded="false"' in nav
+    assert 'aria-controls="palette"' in nav
+    assert 'aria-haspopup="dialog"' in nav
+
+
+def test_theme_button_has_aria_pressed() -> None:
+    nav = nav_bar(active="home")
+    assert 'id="theme-toggle"' in nav
+    assert 'aria-pressed=' in nav
+    # JS keeps the value in sync with data-theme.
+    assert 'syncAriaPressed' in JS
+    assert 'aria-pressed' in JS
+
+
+def test_open_palette_aria_expanded_flips_on_open() -> None:
+    """When the palette opens, the trigger's aria-expanded must flip
+    to true so AT users hear the right state when they refocus the
+    button. The __syncTriggerAriaExpanded helper drives this from
+    inside __openDialog/__closeDialog."""
+    assert "__syncTriggerAriaExpanded" in JS
+    open_block = JS[JS.find("function __openDialog"): JS.find("function __closeDialog")]
+    close_block = JS[JS.find("function __closeDialog"): JS.find("function __closeDialog") + 600]
+    assert "__syncTriggerAriaExpanded(dialog, true)" in open_block
+    assert "__syncTriggerAriaExpanded(dialog, false)" in close_block
+
+
+# ─── #571 — vis-network pinned + SRI ───────────────────────────────────
+
+
+def test_vis_network_version_pinned() -> None:
+    """The bare `unpkg.com/vis-network/standalone/...` URL pulls latest
+    on every load — a malicious or accidental upstream change ships
+    JS to every site visitor. Pin to an explicit version."""
+    assert "unpkg.com/vis-network/" not in HTML_TEMPLATE, (
+        "vis-network is loaded without a version pin; supply-chain risk"
+    )
+    assert re.search(r"vis-network@\d+\.\d+\.\d+/standalone", HTML_TEMPLATE), (
+        "vis-network must be pinned to a specific @x.y.z version"
+    )
+
+
+def test_vis_network_has_sri_integrity() -> None:
+    """SRI hash gates the load — wrong hash → browser refuses to
+    execute. Combined with the version pin this prevents an attacker
+    who compromises the registry from running code in the browser."""
+    assert 'integrity="sha384-' in HTML_TEMPLATE
+    assert 'crossorigin="anonymous"' in HTML_TEMPLATE
+
+
+# ─── #564 — viewport-fit=cover ─────────────────────────────────────────
+
+
+def test_viewport_fit_cover_present() -> None:
+    """iOS Safari needs viewport-fit=cover for env(safe-area-inset-*)
+    to resolve to non-zero on devices with a home indicator. Without
+    it, `padding-bottom: calc(... + env(safe-area-inset-bottom))` in
+    the mobile bottom nav resolves to 0 and the bar lands on top of
+    the system gesture area."""
+    head = page_head("Title", "Description")
+    assert "viewport-fit=cover" in head


### PR DESCRIPTION
Bundles 5 UI a11y fixes from epic #473 — single-line CSS/JS/HTML adjustments touching the same render path. See CHANGELOG. Bumps to **1.3.41**.

Closes #564, #565, #566, #568, #571.