### PR TITLE
fix: post-review remediation — 7 findings from 5-agent code review — v1.3.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.42] — 2026-04-26
+
+Post-review remediation. Five Opus subagents (Python, Security, Architecture, UI/a11y, JS) reviewed v1.3.41 and converged on seven real bugs across the day's work. This release fixes all seven.
+
+### Fixed
+
+- **Dialog focus restoration with interleaved palette + help** — `__dialogLastFocus` was a single shared closure variable. If the help-dialog opened while the palette was already open (reachable via `?` after `Cmd+K`), the second `__openDialog` call clobbered the palette's saved trigger; closing both dialogs dropped focus into the void. Now a `Map` keyed by `dialog.id` so each dialog has its own restoration target.
+- **`inert` removal no longer strips an open sibling's chrome guard** — `__closeDialog` called `removeAttribute("inert")` on every body sibling, including any sibling that was itself still an open dialog. Closing help-dialog while palette was open re-exposed the chrome behind the palette to AT users. Added `__isOpenDialog` check that skips siblings still carrying `.open`.
+- **Latent XSS in related-pages innerHTML** — `s.entry.title`, `s.entry.url`, and `s.entry.date` were concatenated into `innerHTML` unescaped. Future adapter/raw-import paths that ship session frontmatter with `<` characters or `javascript:` URLs would have executed code in every visitor's browser. Now built via `createElement` + `textContent`, with a `_safeHref()` validator that rejects `javascript:`/`data:`/`vbscript:` URL schemes.
+- **`role="menu"` removed from `nav-drawer`** — children are plain `<a>` elements, not `role="menuitem"`. Screen readers were instructing users to "press arrow keys" which did nothing. Replaced with `aria-label="Main navigation"`; the hamburger's `aria-controls` already provides the trigger→drawer association so no role is needed on the container.
+- **Mobile bottom-nav `#mbn-theme` syncs `aria-pressed`** — desktop `#theme-toggle` already kept `aria-pressed` in sync via `syncAriaPressed()`; the mobile sibling never did, so VoiceOver/TalkBack heard "Toggle theme, button" with no state. Added a parallel `_mbnSyncPressed()` closure that fires on init + after every click, plus `aria-pressed="false"` baked into the static markup.
+- **Palette `<input>` has accessible label** — added `aria-label="Search pages"` so AT announces something persistent after the placeholder disappears on first keystroke.
+- **`render_models_section` + `render_vs_section` no longer NameError** — both functions referenced 8 names (`discover_model_entities*`, `render_models_index`, `render_model_info_card`, `generate_pairs`, `render_comparisons_index`, `discover_user_overrides`, `pair_slug`, `render_comparison_body`) without ever importing them. Build doesn't currently call either function so the bug was latent, but the next person wiring them up would have hit `NameError` on first call. Added lazy imports inside both functions.
+
+### Tests
+
+- **`tests/test_post_review_remediation.py`** — 10 cases pinning each of the seven contracts above so they can't silently regress in a future palette refactor or build.py reshuffle. Plus updates to `tests/test_palette_dialog_a11y.py` (2 contracts) for the new Map-backed focus stash.
+
 ## [1.3.41] — 2026-04-26
 
 UI/a11y bundle release picking off five small Opus-found issues from epic #473 in one PR (closely related single-line CSS / JS / HTML adjustments that share the same render code path).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.41-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.42-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.41"
+__version__ = "1.3.42"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/build.py
+++ b/llmwiki/build.py
@@ -764,7 +764,13 @@ def nav_bar(active: str, link_prefix: str = "") -> str:
         + (' active' if key == active else '') + '">'
         + label + '</a>'
     )
-    nav_drawer_html = f"""<div id="nav-drawer" class="nav-drawer" hidden role="menu" aria-labelledby="nav-hamburger">
+    # Post-review: dropped `role="menu"` + `aria-labelledby` — children
+    # are plain <a>, not role="menuitem", so screen readers were being
+    # told "press arrow keys" which did nothing. The drawer is a
+    # disclosure nav, not an ARIA menu. The hamburger's aria-controls
+    # already provides the trigger→drawer association; no role needed
+    # on the container.
+    nav_drawer_html = f"""<div id="nav-drawer" class="nav-drawer" hidden aria-label="Main navigation">
 {drawer_link("index.html", "Home", "home")}
 {drawer_link("projects/index.html", "Projects", "projects")}
 {drawer_link("sessions/index.html", "Sessions", "sessions")}
@@ -858,7 +864,7 @@ def page_foot(js_prefix: str = "") -> str:
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
     <span>Search</span>
   </button>
-  <button type="button" class="mbn-link" id="mbn-theme" aria-label="Toggle theme">
+  <button type="button" class="mbn-link" id="mbn-theme" aria-label="Toggle theme" aria-pressed="false">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
     <span>Theme</span>
   </button>
@@ -868,7 +874,7 @@ def page_foot(js_prefix: str = "") -> str:
   <div class="palette-modal" role="dialog" aria-modal="true" aria-label="Command palette">
     <div class="palette-header">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-      <input type="text" id="palette-input" placeholder="Search… or type:session project:llm-wiki date:>2026-03 sort:date" autocomplete="off" spellcheck="false">
+      <input type="text" id="palette-input" aria-label="Search pages" placeholder="Search… or type:session project:llm-wiki date:>2026-03 sort:date" autocomplete="off" spellcheck="false">
       <kbd>ESC</kbd>
     </div>
     <ul class="palette-results" id="palette-results"></ul>
@@ -1740,6 +1746,15 @@ def render_models_section(out_dir: Path) -> tuple[Optional[Path], int]:
     `wiki/entities/` directory OR no model pages there, we still write
     an empty-state index so the nav link doesn't 404.
     """
+    # Post-review: imports lazily so this function actually works the
+    # next time someone wires it from the CLI. Previously these names
+    # were referenced but never imported — function body was reachable
+    # but would crash with NameError on first call.
+    from llmwiki.models_page import (  # noqa: F401
+        discover_model_entities_with_meta,
+        render_models_index,
+        render_model_info_card,
+    )
     entities_dir = REPO_ROOT / "wiki" / "entities"
     entries_with_meta = discover_model_entities_with_meta(entities_dir)
     # Backwards-compatible list without meta for render_models_index.
@@ -1844,6 +1859,17 @@ def render_vs_section(
     `(index_path, pair_count)`. Always writes the index so the nav
     link resolves even when no entities exist.
     """
+    # Post-review: lazy imports so this function actually works the
+    # next time someone wires it. Previously these names were referenced
+    # but never imported — first call would have crashed with NameError.
+    from llmwiki.models_page import discover_model_entities  # noqa: F401
+    from llmwiki.compare import (  # noqa: F401
+        discover_user_overrides,
+        generate_pairs,
+        pair_slug,
+        render_comparison_body,
+        render_comparisons_index,
+    )
     entities_dir = REPO_ROOT / "wiki" / "entities"
     overrides_dir = REPO_ROOT / "wiki" / "vs"
     entries = discover_model_entities(entities_dir)

--- a/llmwiki/render/js.py
+++ b/llmwiki/render/js.py
@@ -269,6 +269,15 @@ JS = r"""// llmwiki viewer — theme + copy + search palette + keyboard shortcut
     // Wire the theme button to toggle
     const themeBtn = document.getElementById("mbn-theme");
     if (themeBtn) {
+      // Post-review: keep aria-pressed in sync with the dark-state on
+      // the mobile theme button so VoiceOver / TalkBack hear the right
+      // state. Mirrors what #theme-toggle does on desktop.
+      function _mbnSyncPressed() {
+        const t = document.documentElement.getAttribute("data-theme") ||
+          ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) ? "dark" : "light");
+        themeBtn.setAttribute("aria-pressed", t === "dark" ? "true" : "false");
+      }
+      _mbnSyncPressed();
       themeBtn.addEventListener("click", function () {
         const root = document.documentElement;
         let current = root.getAttribute("data-theme");
@@ -279,6 +288,7 @@ JS = r"""// llmwiki viewer — theme + copy + search palette + keyboard shortcut
         root.setAttribute("data-theme", next);
         try { localStorage.setItem("llmwiki-theme", next); } catch (e) { /* #ui-h4: private mode */ }
         if (window.__llmwikiSyncHljsTheme) window.__llmwikiSyncHljsTheme();
+        _mbnSyncPressed();
       });
     }
   });
@@ -539,12 +549,23 @@ document.addEventListener("DOMContentLoaded", function () {
   // Apply `inert` to every direct child of <body> EXCEPT the dialog
   // itself so AT users can't tab into the page chrome behind the
   // backdrop (the previous aria-hidden gate left siblings reachable).
-  var __dialogLastFocus = null;
+  //
+  // Post-review: stash is a Map keyed by dialog.id so opening a second
+  // dialog while the first is still open doesn't clobber the first
+  // dialog's restoration target. Equally, inert is only removed from
+  // siblings that are NOT themselves currently-open dialogs, so closing
+  // help while palette is still open doesn't strip the palette's inert
+  // wrapping of the rest of the chrome.
+  var __dialogLastFocus = new Map();
   function __getInertSiblings(dialog) {
     return Array.prototype.filter.call(
       document.body.children,
       function (el) { return el !== dialog; }
     );
+  }
+  function __isOpenDialog(el) {
+    return el && el.classList && el.classList.contains("open") &&
+           (el.id === "palette" || el.id === "help-dialog");
   }
   function __isDialogOpen(dialog) {
     return dialog && dialog.classList.contains("open");
@@ -568,7 +589,7 @@ document.addEventListener("DOMContentLoaded", function () {
   }
   function __openDialog(dialog, firstFocus) {
     if (!dialog || dialog.classList.contains("open")) return;
-    __dialogLastFocus = document.activeElement;
+    if (dialog.id) __dialogLastFocus.set(dialog.id, document.activeElement);
     dialog.classList.add("open");
     __syncTriggerAriaExpanded(dialog, true);
     __getInertSiblings(dialog).forEach(function (s) { s.setAttribute("inert", ""); });
@@ -578,11 +599,17 @@ document.addEventListener("DOMContentLoaded", function () {
     if (!dialog || !dialog.classList.contains("open")) return;
     dialog.classList.remove("open");
     __syncTriggerAriaExpanded(dialog, false);
-    __getInertSiblings(dialog).forEach(function (s) { s.removeAttribute("inert"); });
-    if (__dialogLastFocus && __dialogLastFocus.focus) {
-      try { __dialogLastFocus.focus(); } catch (e) { /* trigger gone */ }
+    // Only strip inert from siblings that are NOT themselves an open
+    // dialog — otherwise closing the help-dialog while palette is open
+    // re-exposes the palette's inert chrome guard.
+    __getInertSiblings(dialog).forEach(function (s) {
+      if (!__isOpenDialog(s)) s.removeAttribute("inert");
+    });
+    var lf = dialog.id ? __dialogLastFocus.get(dialog.id) : null;
+    if (lf && lf.focus) {
+      try { lf.focus(); } catch (e) { /* trigger gone */ }
     }
-    __dialogLastFocus = null;
+    if (dialog.id) __dialogLastFocus.delete(dialog.id);
   }
   // Trap Tab + Shift+Tab inside `dialog` so focus can't escape into
   // the inert page chrome and become visually invisible.
@@ -1022,20 +1049,40 @@ document.addEventListener("DOMContentLoaded", function () {
           .slice(0, 5);
         if (!scored.length) return;
 
+        // Post-review remediation: title + url + date used to be
+        // interpolated into innerHTML without escaping. Build the DOM
+        // tree explicitly with createElement / textContent so a malicious
+        // session frontmatter title (e.g. "<img src=x onerror=...>") or
+        // a `javascript:` URL can't execute in the visitor's browser.
+        function _safeHref(raw) {
+          // Reject anything that isn't a relative path or http(s).
+          // Same-origin checks happen at the browser; we just gate the
+          // protocol prefix here to stop `javascript:` / `data:` etc.
+          var s = String(raw || "");
+          if (/^(javascript|data|vbscript):/i.test(s)) return "#";
+          return s;
+        }
         const section = document.createElement("div");
         section.className = "related-pages";
-        section.innerHTML =
-          "<h3>Related pages</h3>" +
-          '<ul>' +
-          scored.map(function (s) {
-            const href = "../../" + s.entry.url;
-            const title = s.entry.title;
-            const date = s.entry.date || "";
-            return '<li><a href="' + href + '">' + title + '</a>' +
-              (date ? ' <span class="muted">· ' + date + '</span>' : '') +
-              '</li>';
-          }).join("") +
-          '</ul>';
+        const heading = document.createElement("h3");
+        heading.textContent = "Related pages";
+        section.appendChild(heading);
+        const ul = document.createElement("ul");
+        scored.forEach(function (s) {
+          const li = document.createElement("li");
+          const a = document.createElement("a");
+          a.href = _safeHref("../../" + (s.entry.url || ""));
+          a.textContent = String(s.entry.title || "");
+          li.appendChild(a);
+          if (s.entry.date) {
+            const span = document.createElement("span");
+            span.className = "muted";
+            span.textContent = " \u00b7 " + String(s.entry.date);
+            li.appendChild(span);
+          }
+          ul.appendChild(li);
+        });
+        section.appendChild(ul);
         article.appendChild(section);
       })
       .catch(function () {});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.41"
+version = "1.3.42"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_palette_dialog_a11y.py
+++ b/tests/test_palette_dialog_a11y.py
@@ -59,20 +59,30 @@ def test_css_uses_open_class_for_help_visibility() -> None:
 
 def test_js_dialog_open_helper_uses_inert_and_class() -> None:
     """__openDialog must (a) flip the `.open` class, (b) set `inert`
-    on body siblings, (c) capture the previous focused element."""
+    on body siblings, (c) capture the previous focused element.
+
+    Post-review (#642 remediation): focus is now stashed in a Map
+    keyed by dialog id so interleaving palette + help-dialog doesn't
+    clobber either restoration target."""
     assert "__openDialog" in JS
     assert 'classList.add("open")' in JS
     assert 'setAttribute("inert"' in JS
-    assert "__dialogLastFocus = document.activeElement" in JS
+    assert "__dialogLastFocus.set(dialog.id, document.activeElement)" in JS
 
 
 def test_js_dialog_close_helper_restores_focus_and_clears_inert() -> None:
     """Close must (a) flip class off, (b) remove `inert` from siblings,
-    (c) restore focus to the saved trigger."""
+    (c) restore focus to the saved trigger.
+
+    Post-review (#642 remediation): focus is fetched from the Map by
+    dialog id; siblings that are themselves still-open dialogs are
+    skipped during inert removal so closing one doesn't strip the
+    other's chrome guard."""
     assert "__closeDialog" in JS
     assert 'classList.remove("open")' in JS
     assert 'removeAttribute("inert")' in JS
-    assert "__dialogLastFocus.focus()" in JS
+    assert "__dialogLastFocus.get(dialog.id)" in JS
+    assert "lf.focus()" in JS
 
 
 def test_js_palette_uses_dialog_helpers() -> None:

--- a/tests/test_post_review_remediation.py
+++ b/tests/test_post_review_remediation.py
@@ -1,0 +1,161 @@
+"""Pin the contract for the post-review remediation PR (v1.3.42).
+
+Five-agent code review (local + GitHub claude-review) of v1.3.41
+surfaced these real bugs which this PR addresses:
+
+  1. `__dialogLastFocus` was a single shared slot — interleaving
+     palette + help dialogs corrupted focus restoration. Now a Map
+     keyed by dialog id.
+
+  2. `__closeDialog` stripped `inert` from a sibling that was itself
+     still an open dialog. Closing help while palette is open
+     re-exposed the chrome behind the palette. Fixed by skipping
+     siblings that match the open-dialog id list.
+
+  3. `innerHTML` of the related-pages panel concatenated unescaped
+     `s.entry.title` / `url` / `date` — latent XSS if a session
+     frontmatter title contains HTML. Now built via createElement +
+     textContent + a `_safeHref` validator that rejects
+     `javascript:` / `data:` / `vbscript:` URLs.
+
+  4. `role="menu"` on `nav-drawer` was wrong (children are plain
+     `<a>`, not `role="menuitem"`). Removed; replaced with a plain
+     `aria-label="Main navigation"` since the drawer is a disclosure
+     nav, not an ARIA menu.
+
+  5. `#mbn-theme` (mobile bottom-nav theme button) never synced
+     `aria-pressed`. Added a `_mbnSyncPressed()` closure that fires
+     on init + after every click, and added `aria-pressed="false"`
+     to the static markup.
+
+  6. `#palette-input` had no programmatic label. Added
+     `aria-label="Search pages"`.
+
+  7. `render_models_section` + `render_vs_section` referenced 8
+     names that were never imported. The build doesn't currently call
+     either function, but they would have crashed with `NameError` on
+     first wire-up. Added lazy imports inside both functions.
+"""
+from __future__ import annotations
+
+import re
+
+from llmwiki.build import nav_bar, render_models_section, render_vs_section
+from llmwiki.render.js import JS
+
+
+# 1. Per-dialog focus stash.
+
+def test_dialog_last_focus_is_a_map_not_single_slot() -> None:
+    assert "var __dialogLastFocus = new Map()" in JS
+    # set + get + delete via dialog.id key.
+    assert "__dialogLastFocus.set(dialog.id, document.activeElement)" in JS
+    assert "__dialogLastFocus.get(dialog.id)" in JS
+    assert "__dialogLastFocus.delete(dialog.id)" in JS
+
+
+# 2. inert removal respects still-open sibling dialogs.
+
+def test_close_dialog_does_not_strip_inert_from_open_siblings() -> None:
+    assert "function __isOpenDialog" in JS
+    # The close path must call __isOpenDialog before removing inert.
+    close_block = JS[JS.find("function __closeDialog"):
+                     JS.find("function __closeDialog") + 800]
+    assert "__isOpenDialog(s)" in close_block
+    assert "removeAttribute(\"inert\")" in close_block
+
+
+# 3. Related-pages renderer escapes its inputs.
+
+def test_related_pages_built_via_createElement_not_innerHTML() -> None:
+    """The related-pages renderer must build its DOM via createElement
+    + textContent so an unescaped wiki title can't ship to the browser.
+
+    Locate the right block by looking for the post-review safe-href
+    helper rather than the section heading text (the heading also
+    appears in a file-header comment higher up)."""
+    block_start = JS.find("function _safeHref(")
+    assert block_start != -1, "_safeHref helper missing from JS"
+    block = JS[block_start: block_start + 1800]
+    assert "createElement" in block
+    assert "textContent" in block
+
+
+def test_safe_href_rejects_javascript_protocol() -> None:
+    """The _safeHref helper must reject javascript:/data:/vbscript:
+    URLs so a malicious frontmatter URL can't slip past the new
+    DOM-tree builder."""
+    assert "javascript|data|vbscript" in JS or "javascript|data" in JS
+
+
+# 4. nav-drawer no longer claims role=menu without role=menuitem children.
+
+def test_nav_drawer_has_no_role_menu() -> None:
+    nav = nav_bar(active="home")
+    assert 'role="menu"' not in nav
+    # The container still needs an accessible name.
+    assert 'aria-label="Main navigation"' in nav
+
+
+# 5. Mobile theme button keeps aria-pressed in sync.
+
+def test_mbn_theme_has_aria_pressed_in_markup() -> None:
+    """page_foot emits the mobile bottom nav. Its theme button now
+    ships with `aria-pressed="false"` baked in (JS overwrites on
+    page load so the initial value is just a placeholder)."""
+    from llmwiki.build import page_foot
+    foot = page_foot()
+    # Find the mbn-theme button + its attrs.
+    m = re.search(r'id="mbn-theme"[^>]*', foot)
+    assert m, "mbn-theme button missing from page_foot output"
+    assert 'aria-pressed' in m.group(0)
+
+
+def test_mbn_theme_js_handler_calls_sync_pressed() -> None:
+    """The click handler for the mobile theme button must invoke the
+    aria-pressed sync helper after toggling data-theme."""
+    handler_block = JS[JS.find('"mbn-theme"'):
+                       JS.find('"mbn-theme"') + 1500]
+    assert "_mbnSyncPressed" in handler_block
+    assert "_mbnSyncPressed()" in handler_block
+
+
+# 6. Palette input has accessible label.
+
+def test_palette_input_has_aria_label() -> None:
+    from llmwiki.build import page_foot
+    foot = page_foot()
+    m = re.search(r'id="palette-input"[^>]*', foot)
+    assert m, "palette-input missing from page_foot output"
+    assert 'aria-label="Search pages"' in m.group(0)
+
+
+# 7. render_models_section + render_vs_section import their dependencies.
+
+def test_render_models_section_does_not_raise_name_error_at_load_time() -> None:
+    """Either the imports are at module level OR they're lazy inside
+    the function body. Either way, importing build doesn't fail and
+    calling the function on a no-entities tree just returns cleanly."""
+    # Module imported at the top — that already proves no ImportError
+    # at load time. Now exercise the function on a tmp tree to make
+    # sure lazy imports inside resolve.
+    import tempfile
+    from pathlib import Path
+    with tempfile.TemporaryDirectory() as td:
+        out = Path(td) / "site"
+        out.mkdir(parents=True)
+        # No wiki/entities under REPO_ROOT (test environment), so
+        # the function should return (path, 0) cleanly.
+        result = render_models_section(out)
+        # Tuple-of-2 contract.
+        assert isinstance(result, tuple) and len(result) == 2
+
+
+def test_render_vs_section_does_not_raise_name_error_at_load_time() -> None:
+    import tempfile
+    from pathlib import Path
+    with tempfile.TemporaryDirectory() as td:
+        out = Path(td) / "site"
+        out.mkdir(parents=True)
+        result = render_vs_section(out)
+        assert isinstance(result, tuple) and len(result) == 2


### PR DESCRIPTION
## Summary

Five Opus subagents (python, security, architecture, UI/a11y, JS) reviewed v1.3.41 and converged on seven real bugs across today's 22 patch releases. This PR fixes all seven.

| # | Finding | Severity | Files |
|---|---|---|---|
| 1 | `__dialogLastFocus` single-slot clobber on interleaved palette+help | HIGH | `render/js.py` |
| 2 | `__closeDialog` strips `inert` from still-open sibling dialog | HIGH | `render/js.py` |
| 3 | XSS in related-pages `innerHTML` (unescaped title/url/date) | HIGH | `render/js.py` |
| 4 | `role="menu"` on `nav-drawer` w/o menuitem children | HIGH | `build.py` |
| 5 | `#mbn-theme` never syncs `aria-pressed` | HIGH | `render/js.py`, `build.py` |
| 6 | `#palette-input` has no accessible label | MEDIUM | `build.py` |
| 7 | `render_models_section` + `render_vs_section` reference 8 unimported names | HIGH (latent) | `build.py` |

Each fix lands with a focused test that pins the contract — see `tests/test_post_review_remediation.py` (10 cases). `tests/test_palette_dialog_a11y.py` (2 contracts) updated for the new `Map`-backed focus stash.

## Test plan

- [x] `tests/test_post_review_remediation.py` — 10 cases.
- [x] Full pytest suite — green.
- [x] Each fix has an accompanying CHANGELOG bullet.

Bumps version to **1.3.42**.