### PR TITLE
chore: #474 bundle 1 — Python lint sweep — v1.3.43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.43] — 2026-04-26
+
+#474 lint sweep — 6 LOW Python correctness nits picked off in one PR (per the bundle plan from epic-research).
+
+### Fixed
+
+- **`_parse_scalar` no longer coerces `yes`/`no` inside list items** (#599, #py-l1) — a tag list like `[no, yes, maybe]` was becoming `[False, True, "maybe"]`. Recursive call now passes `coerce_bool=False` so list items stay strings; top-level scalars still coerce.
+- **`BaseAdapter.description()` survives `python -OO`** (#601, #py-l3) — `__doc__` is stripped under `-OO`, leaving the adapter listing as bare class names. Subclasses can now set `_DESCRIPTION_OVERRIDE` for a stable explicit string; the default still reads `__doc__` when available.
+- **F541: f-strings without placeholders stripped** (#606, #py-l8) — 8 unnecessary `f"..."` prefixes in the project-stub emitter at `build.py:315-328`. Mixed f-/plain in concatenation chains is fine; ruff F541 stops flagging the file.
+- **`Tuple[]` → `tuple[]` in `_frontmatter.py`** (#607, #py-l9) — last holdout of pre-PEP-585 typing; the rest of the tree already uses `tuple[]`. Removed `Tuple` from the typing import.
+- **Duplicate `Path` imports in `cli.py` removed** (#608, #py-l10) — two function-local `from pathlib import Path as _Path` re-imports of the module-level name. Both cleaned up.
+- **Cache module documents thread-safety contract** (#605, #py-l7) — added a `Thread-safety` section to `llmwiki/cache.py` docstring stating the helpers are NOT thread-safe; pure functions reentrant; batch-state callers must serialize externally.
+
 ## [1.3.42] — 2026-04-26
 
 Post-review remediation. Five Opus subagents (Python, Security, Architecture, UI/a11y, JS) reviewed v1.3.41 and converged on seven real bugs across the day's work. This release fixes all seven.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.42-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.43-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.42"
+__version__ = "1.3.43"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/_frontmatter.py
+++ b/llmwiki/_frontmatter.py
@@ -17,7 +17,7 @@ lists with `- ` bullets).
 from __future__ import annotations
 
 import re
-from typing import Any, Optional, Tuple
+from typing import Any, Optional
 
 # Accept LF, CRLF, or CR after each fence so Windows-authored (CRLF) and
 # old-Mac (CR) files parse identically to LF input. The optional newline
@@ -37,7 +37,7 @@ def _strip_bom(text: str) -> str:
     return text
 
 
-def parse_frontmatter(text: str) -> Tuple[dict[str, Any], str]:
+def parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
     """Return ``(meta, body)`` — the canonical shape.
 
     Empty or malformed input returns ``({}, text)`` so callers can
@@ -66,7 +66,7 @@ def parse_frontmatter_dict(text: str) -> dict[str, Any]:
     return parse_frontmatter(text)[0]
 
 
-def parse_frontmatter_or_none(text: str) -> Tuple[Optional[str], str]:
+def parse_frontmatter_or_none(text: str) -> tuple[Optional[str], str]:
     """Return ``(raw_frontmatter_text | None, body)`` — legacy shape
     used by ``llmwiki/tags.py`` which does its own line-level parsing
     inside the frontmatter block."""
@@ -77,11 +77,15 @@ def parse_frontmatter_or_none(text: str) -> Tuple[Optional[str], str]:
     return m.group(1), m.group(2)
 
 
-def _parse_scalar(raw: str) -> Any:
+def _parse_scalar(raw: str, *, coerce_bool: bool = True) -> Any:
     """Parse a single YAML scalar value (best-effort, no external deps).
 
     Handles: inline lists ``[a, b, c]``, quoted strings, bools, ints.
     Everything else comes back as the stripped string.
+
+    #py-l1 (#599): pass ``coerce_bool=False`` when recursing into list
+    items so a tag list like ``[no, yes, maybe]`` doesn't become
+    ``[False, True, "maybe"]``. Top-level scalars still coerce.
     """
     s = raw.strip()
     if not s:
@@ -94,12 +98,12 @@ def _parse_scalar(raw: str) -> Any:
         body = s[1:-1].strip()
         if not body:
             return []
-        return [_parse_scalar(x) for x in body.split(",")]
+        return [_parse_scalar(x, coerce_bool=False) for x in body.split(",")]
     # Bool
     low = s.lower()
-    if low in {"true", "yes"}:
+    if coerce_bool and low in {"true", "yes"}:
         return True
-    if low in {"false", "no"}:
+    if coerce_bool and low in {"false", "no"}:
         return False
     # Int
     try:

--- a/llmwiki/adapters/base.py
+++ b/llmwiki/adapters/base.py
@@ -44,10 +44,20 @@ class BaseAdapter:
 
     # ─── classmethods used by the registry + UI ────────────────────────
 
+    # #py-l3 (#601): subclasses can override _DESCRIPTION_OVERRIDE so
+    # `python3 -OO` (which strips __doc__) doesn't degrade the adapter
+    # listing to bare class names. The default reads __doc__ where
+    # available and falls back to a stable explicit string when not.
+    _DESCRIPTION_OVERRIDE: str = ""
+
     @classmethod
     def description(cls) -> str:
         """One-line description shown in `llmwiki adapters`."""
-        return cls.__doc__.split("\n")[0] if cls.__doc__ else cls.__name__
+        if cls._DESCRIPTION_OVERRIDE:
+            return cls._DESCRIPTION_OVERRIDE
+        if cls.__doc__:
+            return cls.__doc__.split("\n")[0]
+        return cls.__name__
 
     @classmethod
     def is_available(cls) -> bool:

--- a/llmwiki/build.py
+++ b/llmwiki/build.py
@@ -311,21 +311,24 @@ def ensure_project_stubs(
         # valid — slugs/summaries from real sessions occasionally contain
         # quotes (`"why didn't this work"`).
         description_safe = description.replace("\\", "\\\\").replace('"', '\\"')
+        # #py-l8 (#606): drop f-prefix on lines that have no
+        # placeholders so ruff's F541 doesn't flag the file. Mixed
+        # f-/plain in a concatenation chain is fine.
         stub = (
-            f"---\n"
+            "---\n"
             f'title: "{slug}"\n'
-            f"type: entity\n"
-            f"entity_type: project\n"
+            "type: entity\n"
+            "entity_type: project\n"
             f"project: {slug}\n"
             f"topics: {_format_topics_yaml(topics)}\n"
             f'description: "{description_safe}"\n'
-            f'homepage: ""\n'
-            f"---\n\n"
+            'homepage: ""\n'
+            "---\n\n"
             f"# {slug}\n\n"
-            f"*Auto-generated project stub. `topics` and `description` are "
-            f"pre-filled from session metadata — edit any field above and "
-            f"the build will pick it up. Fill in `homepage` to add a link "
-            f"chip to the project hero.*\n"
+            "*Auto-generated project stub. `topics` and `description` are "
+            "pre-filled from session metadata — edit any field above and "
+            "the build will pick it up. Fill in `homepage` to add a link "
+            "chip to the project hero.*\n"
         )
         target.write_text(stub, encoding="utf-8")
         written.append(target)

--- a/llmwiki/cache.py
+++ b/llmwiki/cache.py
@@ -1,5 +1,17 @@
 """Prompt caching + batch-API scaffolding (v1.1.0 · #50).
 
+Thread-safety
+-------------
+**This module is NOT thread-safe.** ``load_batch_state`` /
+``save_batch_state`` read + write a JSON file with no locking;
+concurrent callers can race on the temp-file rename. The pure-functional
+helpers (``make_cached_block``, ``build_messages``, ``estimate_tokens``,
+``estimate_cost``) are reentrant. Batch-state helpers must be called from
+a single thread or under an external lock. Today's only call sites are
+single-process CLI invocations of ``llmwiki synthesize`` so this is fine;
+a future MCP path that queues batches concurrently must serialize via its
+own mutex (#py-l7 / #605).
+
 Every `/wiki-sync` and `/wiki-ingest` bundles the same stable prefix —
 CLAUDE.md schema, `wiki/index.md`, and `wiki/overview.md` — with every
 source file it asks the model to summarize. On a 500-page wiki that

--- a/llmwiki/cli.py
+++ b/llmwiki/cli.py
@@ -480,9 +480,11 @@ def cmd_sync_status(args: argparse.Namespace) -> int:
     by ``convert_all``) and ``.llmwiki-quarantine.json`` for the failing
     sources.
     """
+    # #py-l10 (#608): Path is already imported at module top (line 25 as
+    # `from pathlib import Path`); re-importing as `_Path` here was
+    # legacy from an earlier rename. Just reuse the module-level name.
     import json as _json
     from datetime import datetime, timezone
-    from pathlib import Path as _Path
 
     from llmwiki import quarantine as _q
     from llmwiki.convert import DEFAULT_STATE_FILE
@@ -563,12 +565,12 @@ def cmd_sync_status(args: argparse.Namespace) -> int:
 
 def _resolve_key_exists(key: str) -> bool:
     """Check whether a portable state-file key points at an extant file."""
-    from pathlib import Path as _Path
+    # #py-l10 (#608): Path is already imported at module top.
     if "::" not in key:
-        return _Path(key).exists()
+        return Path(key).exists()
     _, rel = key.split("::", 1)
-    candidate = _Path.home() / rel
-    return candidate.exists() or _Path(rel).exists()
+    candidate = Path.home() / rel
+    return candidate.exists() or Path(rel).exists()
 
 
 def cmd_export(args: argparse.Namespace) -> int:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.42"
+version = "1.3.43"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Closes #599 #601 #605 #606 #607 #608. Six LOW-severity Python nits in one PR. See CHANGELOG. Bumps to **1.3.43**.