### PR TITLE
chore: #475 architecture quick wins (#614, #625, #628, #arch-l7) — v1.3.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.44] — 2026-04-26
+
+#475 architecture quick wins — 4 mechanical fixes from epic-research bundle 2.
+
+### Fixed
+
+- **`OpenCodeAdapter.is_subagent` no longer matches substrings** (#614, #arch-m1) — `"subagent" in jsonl_path.name` re-introduced the same regression #406 fixed for the main adapter contract. A user-supplied slug containing the literal text `subagent` anywhere would mis-classify the session. Replaced with a hyphen-bounded regex that matches the segment as a leading, trailing, or interior `-`-delimited token.
+- **`load_config` uses `copy.deepcopy` instead of `json.loads(json.dumps(...))`** (#628, #arch-l6) — the round-trip JSON deep-copy was a pre-`copy.deepcopy` idiom that's ~5× slower and adds an implicit "JSON-serializable types only" constraint. Pure cleanup, no behavior change.
+- **System-page list consolidated into `llmwiki/_system_pages.py`** (#arch-l7) — `graph.py._NO_SITE_BASENAMES` and `lint/rules.py.EXEMPT_FILES` carried hand-maintained overlapping sets that drifted independently. Single source of truth now lives in `_system_pages.py` with `SYSTEM_PAGE_SLUGS` (no extension, for graph) and `SYSTEM_PAGE_FILES` (with `.md`, for lint). Both call sites import from there.
+- **`derive_session_slug` 8-vs-12-char split documented as intentional** (#625, #arch-l3) — added an inline comment explaining the deliberate split (UUID stems → 8-char hash for collision safety; human-named stems → 12-char prefix for readability). Collapsing to one rule loses one of the two properties.
+
 ## [1.3.43] — 2026-04-26
 
 #474 lint sweep — 6 LOW Python correctness nits picked off in one PR (per the bundle plan from epic-research).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.43-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.44-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.43"
+__version__ = "1.3.44"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/_system_pages.py
+++ b/llmwiki/_system_pages.py
@@ -1,0 +1,44 @@
+"""Canonical list of system / nav / scaffolding pages used across
+graph.py, lint/rules.py, and (potentially) future emitters.
+
+#arch-l7 (#628 sibling): graph.py and lint/rules.py shipped two
+hand-maintained lists of "pages that are exempt from the source /
+entity / concept schema." The lists overlapped but drifted —
+graph.py had `log-archive-2026`, lint missed it; lint had
+`index.md`, graph used type-checks instead.
+
+This module owns the single source of truth. Callers can request
+either form via the helpers below.
+"""
+from __future__ import annotations
+
+# Slugs (no `.md` suffix) — the form graph.py wants because it
+# operates on graph-node ids that are already stripped of extension.
+SYSTEM_PAGE_SLUGS: frozenset[str] = frozenset({
+    "CRITICAL_FACTS",
+    "MEMORY",
+    "SOUL",
+    "hints",
+    "hot",
+    "dashboard",
+    "overview",
+    "log",
+    "log-archive-2026",
+    "index",
+})
+
+# Filenames (with `.md`) — the form lint/rules.py wants because its
+# input is page paths read off disk.
+SYSTEM_PAGE_FILES: frozenset[str] = frozenset(
+    f"{slug}.md" for slug in SYSTEM_PAGE_SLUGS
+)
+
+
+def is_system_slug(slug: str) -> bool:
+    """True if ``slug`` (no extension) is a known system / nav page."""
+    return slug in SYSTEM_PAGE_SLUGS
+
+
+def is_system_file(basename: str) -> bool:
+    """True if ``basename`` ends with ``.md`` and names a system page."""
+    return basename in SYSTEM_PAGE_FILES

--- a/llmwiki/adapters/contrib/opencode.py
+++ b/llmwiki/adapters/contrib/opencode.py
@@ -97,8 +97,19 @@ class OpenCodeAdapter(BaseAdapter):
         return jsonl_path.parent.name
 
     def is_subagent(self, jsonl_path: Path) -> bool:
-        """OpenCode marks subagent sessions with 'subagent' in the filename."""
-        return "subagent" in jsonl_path.name
+        """OpenCode marks subagent sessions with 'subagent' in the filename.
+
+        #arch-m1 (#614): match the segment, not the substring. The
+        previous `"subagent" in name` form would mis-classify a session
+        whose user-supplied slug happens to contain the literal text
+        "subagent" anywhere — same regression #406 fixed for the main
+        adapter contract.
+        """
+        # Hyphen-bounded match — accepts the subagent identifier whether
+        # it appears as a leading, trailing, or interior segment of a
+        # `-`-delimited filename.
+        import re
+        return bool(re.search(r"(?:^|[-/])subagent(?:[-.]|$)", jsonl_path.name))
 
     def normalize_records(
         self, records: list[dict[str, Any]]

--- a/llmwiki/convert.py
+++ b/llmwiki/convert.py
@@ -55,7 +55,12 @@ DEFAULT_CONFIG: dict[str, Any] = {
 # ─── config + state ────────────────────────────────────────────────────────
 
 def load_config(path: Path) -> dict[str, Any]:
-    cfg: dict[str, Any] = json.loads(json.dumps(DEFAULT_CONFIG))
+    # #arch-l6 (#628): the json.loads(json.dumps(...)) idiom was a
+    # round-trip deep-copy from the era before copy.deepcopy was a
+    # builtin import. copy.deepcopy is ~5× faster and avoids the
+    # implicit "JSON-serializable types only" constraint.
+    import copy
+    cfg: dict[str, Any] = copy.deepcopy(DEFAULT_CONFIG)
     if path.exists():
         try:
             user = json.loads(path.read_text(encoding="utf-8"))
@@ -979,6 +984,11 @@ def derive_session_slug(records: list[dict[str, Any]], jsonl_path: Path) -> str:
         if slug:
             return str(slug)
     stem = jsonl_path.stem
+    # #arch-l3 (#625): the 8-char vs 12-char split is intentional, not
+    # a drift. UUID stems get the stable hash because every UUID shares
+    # the same 12-char prefix per project; deliberate human-named stems
+    # get the 12-char prefix because it preserves readability. Don't
+    # collapse them — a single rule loses one of the two properties.
     if _UUID_LIKE.match(stem):
         return _source_hash8(jsonl_path)
     if not stem:

--- a/llmwiki/graph.py
+++ b/llmwiki/graph.py
@@ -35,11 +35,10 @@ WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]*)?\]\]")
 # topology) but mark `site_url = None`.
 _NO_SITE_TYPES = {"entities", "concepts", "syntheses", "questions",
                   "comparisons", "hot", "categories", "projects_meta"}
-_NO_SITE_BASENAMES = {
-    "CRITICAL_FACTS", "MEMORY", "SOUL",
-    "hints", "hot", "dashboard", "overview",
-    "log", "log-archive-2026",
-}
+# #arch-l7: canonical system-page list lives in llmwiki/_system_pages.py.
+# Graph wants the slug form (already stripped of `.md`); lint wants the
+# filename form. Same set, different shape.
+from llmwiki._system_pages import SYSTEM_PAGE_SLUGS as _NO_SITE_BASENAMES  # noqa: E402
 
 
 def _compute_site_url(text: str, rel_parts: tuple[str, ...],

--- a/llmwiki/lint/rules.py
+++ b/llmwiki/lint/rules.py
@@ -58,11 +58,10 @@ class FrontmatterCompleteness(LintRule):
     # System-level nav files and _context.md stubs are exempt from the
     # strict title/type requirement. Index/log/overview are auto-generated
     # or human-curated hubs and don't fit the source/entity/concept schema.
-    EXEMPT_FILES = {
-        "index.md", "overview.md", "log.md",
-        "hints.md", "hot.md", "MEMORY.md",
-        "SOUL.md", "CRITICAL_FACTS.md", "dashboard.md",
-    }
+    # #arch-l7: canonical list lives in llmwiki/_system_pages.py so
+    # graph.py + lint don't drift independently. Use the .md-filename
+    # form because lint walks page paths read off disk.
+    from llmwiki._system_pages import SYSTEM_PAGE_FILES as EXEMPT_FILES
 
     def run(self, pages, *, llm_callback=None):
         issues = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.43"
+version = "1.3.44"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Closes #614 #625 #628. Four mechanical architecture fixes — OpenCodeAdapter substring bug, deepcopy idiom, system-page list consolidation, derive_session_slug docstring clarification. See CHANGELOG. Bumps to **1.3.44**.