### PR TITLE
docs: #475 bundle 1 — docs/CLI sweep (#609, #618, #623, #624) — v1.3.45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.45] — 2026-04-26
+
+#475 docs/CLI sweep — 4 documentation fixes from epic-research bundle 1. Stops llmwiki from claiming features it doesn't have.
+
+### Fixed
+
+- **`llmwiki export-obsidian` references replaced with `llmwiki sync --vault PATH`** (#609, #arch-h3) — the dedicated `export-obsidian` subcommand was removed in v1.2.0 (alongside `watch`, `export-qmd`, `export-marp`) but its name still appeared in `obsidian_output.py` docstring (3 sites), `docs/faq.md`, and `docs/tutorials/setup-guide.md`. Replaced with the canonical `sync --vault` command and added pointers to `docs/UPGRADING.md` for the migration path.
+- **README adapter status table demoted Cursor / Gemini CLI / Copilot to Beta** (#623, #arch-l1) — README claimed "✅ Production" for adapters whose own docstrings concede they're unverified ("to be pinned against a real Cursor install"). Demoted to `🧪 Beta` with a one-line note explaining the gap. Claude Code, Codex CLI, and Obsidian (input + output) stay Production.
+- **`flat_output_name` docstring clarified for sub-agent slugs** (#624, #arch-l2) — the helper was producing filenames like `2026-04-01-llm-wiki-foo-subagent-abc123.md` but the docstring promised a plain `<slug>` shape. Caller actually mixes the `-subagent-<id>` suffix into the slug arg upstream; the helper just concatenates. Docstring now states this explicitly so the next reader doesn't try to "fix" the sub-agent suffixing inside the helper.
+- **`examples/sessions_config.json` flagged as canonical, not a sample** (#618, #arch-m5) — `convert.load_config()` reads this file as the default; the `examples/` path implied "copy me, edit me." Updated the leading `_comment` field to call out that this IS the canonical config and the gitignored `./config.json` is only for per-checkout overrides.
+
 ## [1.3.44] — 2026-04-26
 
 #475 architecture quick wins — 4 mechanical fixes from epic-research bundle 2.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.44-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.45-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)
@@ -382,10 +382,10 @@ Each subcommand has its own `--help`. All commands are also wrapped in one-click
 | [Obsidian](https://obsidian.md) (input) | `llmwiki.adapters.obsidian` | ✅ Production | v0.1 |
 | [Obsidian](https://obsidian.md) (output) | `llmwiki.obsidian_output` | ✅ Production | v0.2 |
 | [Codex CLI](https://github.com/openai/codex) | `llmwiki.adapters.codex_cli` | ✅ Production | v0.3 |
-| [Cursor](https://cursor.com) | `llmwiki.adapters.cursor` | ✅ Production | v0.5 |
-| [Gemini CLI](https://ai.google.dev/gemini-api) | `llmwiki.adapters.gemini_cli` | ✅ Production | v0.5 |
-| [Copilot Chat](https://github.com/features/copilot) | `llmwiki.adapters.copilot_chat` | ✅ Production | v0.9 |
-| [Copilot CLI](https://github.com/features/copilot) | `llmwiki.adapters.copilot_cli` | ✅ Production | v0.9 |
+| [Cursor](https://cursor.com) | `llmwiki.adapters.cursor` | 🧪 Beta — needs verification against current Cursor session format | v0.5 |
+| [Gemini CLI](https://ai.google.dev/gemini-api) | `llmwiki.adapters.gemini_cli` | 🧪 Beta — layout TBC | v0.5 |
+| [Copilot Chat](https://github.com/features/copilot) | `llmwiki.adapters.copilot_chat` | 🧪 Beta | v0.9 |
+| [Copilot CLI](https://github.com/features/copilot) | `llmwiki.adapters.copilot_cli` | 🧪 Beta | v0.9 |
 | OpenCode / OpenClaw | — | ⏸ Deferred | — |
 
 Adding a new agent is [one small file](docs/framework.md) — subclass `BaseAdapter`, declare `SUPPORTED_SCHEMA_VERSIONS`, ship a fixture + snapshot test.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -94,8 +94,8 @@ Yes. llmwiki supports several export formats:
 - `llmwiki export jsonld` -- JSON-LD knowledge graph
 - `llmwiki export sitemap` -- XML sitemap
 - `llmwiki export rss` -- RSS feed
-- `llmwiki export-obsidian` -- export to an Obsidian vault
-- `llmwiki export-qmd` -- export as a qmd collection
-- `llmwiki export-marp` -- generate Marp slide decks
+- `llmwiki sync --vault PATH` -- write through to an Obsidian vault as part of the regular sync (replaces the removed `export-obsidian` subcommand)
 
 Run `llmwiki export all` to generate everything at once.
+
+> The `export-obsidian`, `export-qmd`, `export-marp`, and `watch` subcommands were removed in v1.2.0. See `docs/UPGRADING.md` for the migration path.

--- a/docs/tutorials/setup-guide.md
+++ b/docs/tutorials/setup-guide.md
@@ -268,11 +268,13 @@ Press `Cmd+K` (macOS) or `Ctrl+K` (Linux/Windows). Try:
 ### 4.5 Export for other tools
 
 ```bash
-llmwiki export-obsidian --vault ~/Documents/"Obsidian Vault"   # copy mode
-llmwiki export-qmd --out /tmp/my-qmd                            # hybrid search
-llmwiki export-marp --topic "my-topic"                          # slide deck
-llmwiki export llms-full-txt                                    # paste into any LLM
+llmwiki sync --vault ~/Documents/"Obsidian Vault"   # vault sync (replaces removed export-obsidian)
+llmwiki export llms-full-txt                          # paste into any LLM
+llmwiki export jsonld                                 # schema.org graph
+llmwiki export rss                                    # RSS 2.0 feed
 ```
+
+> The `export-obsidian`, `export-qmd`, and `export-marp` subcommands were removed in v1.2.0. See `docs/UPGRADING.md` for migration paths.
 
 ---
 

--- a/examples/sessions_config.json
+++ b/examples/sessions_config.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Copy this file to ./config.json (gitignored) and edit to your taste.",
+  "_comment": "#arch-m5 (#618): despite living under examples/, this IS the canonical config llmwiki ships. Loaded by convert.load_config() when no ./config.json exists. Copy to ./config.json (gitignored) only if you need a per-checkout override.",
 
   "filters": {
     "live_session_minutes": 60,

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.44"
+__version__ = "1.3.45"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/convert.py
+++ b/llmwiki/convert.py
@@ -1009,6 +1009,12 @@ def flat_output_name(
     The date+time+project+slug format ensures chronological sort,
     project traceability, and uniqueness without nested directories.
 
+    Note (#arch-l2 / #624): the ``slug`` argument may already carry a
+    ``-subagent-<agent_id>`` suffix when the caller is rendering a
+    sub-agent transcript. ``flat_output_name`` does NOT add that
+    suffix itself — it's mixed in upstream (see ``render_session_*``
+    sites in this file) so this helper stays single-purpose.
+
     ``disambiguator`` (#339): when two distinct source jsonls would
     produce the same filename (subagents that inherit the parent's
     start-time + slug, or top-level sessions that happen to start in

--- a/llmwiki/obsidian_output.py
+++ b/llmwiki/obsidian_output.py
@@ -19,9 +19,10 @@ Usage:
     from llmwiki.obsidian_output import export_to_vault
     export_to_vault(vault="~/Documents/Obsidian Vault", subfolder="LLM Wiki")
 
-Or via the CLI:
-
-    python3 -m llmwiki export-obsidian --vault "~/Documents/Obsidian Vault"
+#arch-h3 (#609): the ``llmwiki export-obsidian`` CLI subcommand was
+removed in v1.2.0 alongside ``llmwiki watch`` (see docs/UPGRADING.md).
+Use the function above directly, or run ``llmwiki sync --vault PATH``
+which writes through to Obsidian as part of the regular sync pipeline.
 """
 
 from __future__ import annotations
@@ -173,7 +174,8 @@ transcripts.
 - **{n_pages}** pages exported
 - **Source:** `{wiki_source}`
 - **Do not edit directly.** Changes here will be overwritten the next time you
-  run `llmwiki export-obsidian`.
+  run `llmwiki sync --vault PATH` (the dedicated `export-obsidian` subcommand
+  was removed in v1.2.0; vault sync now lives under the main `sync` flow).
 
 ## Structure
 
@@ -201,6 +203,6 @@ transcripts.
 From the llmwiki repo:
 
 ```bash
-python3 -m llmwiki export-obsidian --vault "~/Documents/Obsidian Vault"
+python3 -m llmwiki sync --vault "~/Documents/Obsidian Vault"
 ```
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.44"
+version = "1.3.45"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Closes #609 #618 #623 #624. Documentation cleanup. See CHANGELOG. Bumps to **1.3.45**.