### PR TITLE
chore: #472 CI hardening — SHA pins + TAP_TOKEN mask + markdown pin — v1.3.46

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,9 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        # #sec-14 (#558): SHA-pin so a moved @v1 tag can't ship code into our CI.
+        # Bump together with claude.yml after auditing the upstream tag history.
+        uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,8 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        # #sec-14 (#558): SHA-pin — see claude-code-review.yml for the matching note.
+        uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -70,6 +70,13 @@ jobs:
           TAG: ${{ steps.tag.outputs.tag }}
         run: |
           set -e
+          # #sec-15 (#559): explicit ::add-mask:: of TAP_TOKEN so any
+          # later `set -x` debugging or accidental `echo "$TAP_TOKEN"`
+          # in this step's logs gets redacted by GitHub's log scrubber.
+          # Secrets in `env:` are scrubbed automatically when referenced
+          # via the `${{ secrets.X }}` syntax — but once they land in a
+          # plain shell variable, manual masking is the belt-and-braces.
+          echo "::add-mask::$TAP_TOKEN"
           tmp="$(mktemp -d)"
           git clone --depth 1 \
             "https://x-access-token:${TAP_TOKEN}@github.com/Pratiyush/homebrew-tap.git" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,10 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI via OIDC
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # #sec-17 (#561): SHA-pin so the publish step can't be hijacked
+        # by a moved release/v1 branch. Bump deliberately after auditing
+        # upstream changelog.
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
 
   sign:
     name: Sign with Sigstore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.46] — 2026-04-26
+
+#472 CI hardening — 5 supply-chain fixes from epic-research bundle B.
+
+### Fixed
+
+- **`anthropics/claude-code-action` SHA-pinned in claude-code-review.yml + claude.yml** (#558, #sec-14) — was `@v1` (mutable tag). Now `@567fe954a4527e81f132d87d1bdbcc94f7737434  # v1` so a moved upstream tag can't ship code into our CI without an explicit bump.
+- **`pypa/gh-action-pypi-publish` SHA-pinned in release.yml** (#561, #sec-17) — was `@release/v1` (mutable branch). Now `@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1`. Pin tightens after auditing the upstream changelog.
+- **`TAP_TOKEN` masked via `::add-mask::` in homebrew-bump.yml** (#559, #sec-15) — secrets in `env:` are auto-scrubbed when referenced via `${{ secrets.X }}`, but once they land in a plain shell variable a stray `set -x` could leak them. Belt-and-braces masking added.
+- **`setup.sh` pins `markdown>=3.9`** (#562, #sec-18) — was unpinned (`pip install markdown`). Now matches the `pyproject.toml` floor so a fresh checkout never installs a wheel older than the tested baseline.
+- **`setup.sh` SessionStart hook quotes `$SCRIPT_DIR`** (#555, #sec-11) — a user whose checkout sits under a path containing spaces would have the rendered hook command split on the space (e.g. `/Users/some` + `path/llmwiki/...`). Now JSON-escape-quoted so the paste-friendly snippet works for everyone.
+
 ## [1.3.45] — 2026-04-26
 
 #475 docs/CLI sweep — 4 documentation fixes from epic-research bundle 1. Stops llmwiki from claiming features it doesn't have.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.45-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.46-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.45"
+__version__ = "1.3.46"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.45"
+version = "1.3.46"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/setup.sh
+++ b/setup.sh
@@ -20,9 +20,12 @@ PY_VER=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))
 echo "    python: $PY_VER"
 
 # 2. Check for markdown package
+# #sec-18 (#562): pin to the same version floor as pyproject.toml so a
+# fresh setup never installs a markdown wheel older than llmwiki's
+# tested baseline. Bump both files together when the floor moves.
 if ! python3 -c "import markdown" 2>/dev/null; then
   echo "==> installing python 'markdown' (required)"
-  python3 -m pip install --user --quiet markdown 2>&1 | tail -2 || true
+  python3 -m pip install --user --quiet 'markdown>=3.9' 2>&1 | tail -2 || true
 fi
 
 # 3. Syntax highlighting (v0.5): highlight.js loads from CDN at view time,
@@ -53,4 +56,9 @@ echo
 echo "Optional SessionStart hook — auto-sync on every Claude Code launch:"
 echo "  Add this to ~/.claude/settings.json under 'hooks':"
 echo '    "SessionStart": [ { "hooks": [ { "type": "command",'
-echo "      \"command\": \"(python3 $SCRIPT_DIR/llmwiki/convert.py > /tmp/llmwiki-sync.log 2>&1 &) ; exit 0\" } ] } ]"
+# #sec-11 (#555): wrap the path in JSON-string-escaped quotes so a user
+# whose checkout sits under "/Users/some path/llmwiki" still gets a
+# valid hook entry. Without quotes the shell splits on the space, the
+# python invocation runs against `/Users/some` and the trailing
+# `path/...` becomes a separate argv. Paste-friendly + correct.
+echo "      \"command\": \"(python3 \\\"$SCRIPT_DIR/llmwiki/convert.py\\\" > /tmp/llmwiki-sync.log 2>&1 &) ; exit 0\" } ] } ]"


### PR DESCRIPTION
Closes #555 #558 #559 #561 #562. CI supply-chain hardening — 5 issues. See CHANGELOG. Bumps to **1.3.46**.