### PR TITLE
chore: #474 bundle 2 — exception narrowing (#592, #600, #602, #604) — v1.3.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.47] — 2026-04-26
+
+#474 exception narrowing — 4 issues from epic-research bundle 2.
+
+### Fixed
+
+- **`(ValueError, json.JSONDecodeError)` → `ValueError`** at 9 sites (#592, #py-m6) — `JSONDecodeError` is a `ValueError` subclass; the tuple was redundant. Touched `viz_tokens.py`, `changelog_timeline.py` (×2), `cache.py`, `adapters/codex_cli.py`, `synth/pipeline.py`, `synth/ollama.py`, `viz_tools.py`, `schema.py`. Pure cleanup.
+- **`IgnoreMatcher.from_file` warns on unreadable files instead of silently returning empty** (#600, #py-l2) — silent fallback was hiding real permission / IO problems from operators. Now prints to stderr; still returns a usable empty matcher so callers don't break.
+- **`BatchState.from_json` survives malformed entries** (#602, #py-l4) — `BatchJob(**bad_dict)` raised `TypeError` past the constructor, leaking out of what callers expect to be a deterministic from-disk loader. Now wraps each row, drops the bad ones with a warning, returns whatever survived.
+- **`Redactor.__init__` skips bad user patterns instead of aborting** (#604, #py-l6) — one invalid `extra_patterns` regex used to take down the entire Redactor, leaving sync running with NO redaction (worse than partial). Now compiles each pattern individually, warns on the broken ones, keeps the good ones. Default token + username redaction still runs regardless.
+
 ## [1.3.46] — 2026-04-26
 
 #472 CI hardening — 5 supply-chain fixes from epic-research bundle B.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.46-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.47-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.46"
+__version__ = "1.3.47"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/adapters/codex_cli.py
+++ b/llmwiki/adapters/codex_cli.py
@@ -87,7 +87,7 @@ class CodexCliAdapter(BaseAdapter):
                 for line in f:
                     try:
                         r = json.loads(line.strip())
-                    except (ValueError, json.JSONDecodeError):
+                    except ValueError:
                         continue
                     if r.get("type") == "session_meta":
                         cwd = r.get("payload", {}).get("cwd", "")

--- a/llmwiki/cache.py
+++ b/llmwiki/cache.py
@@ -321,9 +321,27 @@ class BatchState:
 
     @classmethod
     def from_json(cls, data: dict[str, Any]) -> "BatchState":
+        # #py-l4 (#602): wrap the BatchJob(**b) construction so a
+        # corrupt entry (extra/missing keys → TypeError) doesn't leak
+        # past the callers that expect this constructor to either
+        # succeed or return a deterministic fallback. Mirror the
+        # load_batch_state() shape: print a warning, drop the bad
+        # entries, return whatever survived.
+        import sys as _sys
+        def _safe(rows):
+            kept = []
+            for b in rows:
+                try:
+                    kept.append(BatchJob(**b))
+                except TypeError as e:
+                    print(
+                        f"warning: dropping malformed batch entry {b!r}: {e}",
+                        file=_sys.stderr,
+                    )
+            return kept
         return cls(
-            pending=[BatchJob(**b) for b in data.get("pending", [])],
-            completed=[BatchJob(**b) for b in data.get("completed", [])],
+            pending=_safe(data.get("pending", [])),
+            completed=_safe(data.get("completed", [])),
         )
 
 
@@ -340,7 +358,7 @@ def load_batch_state(repo_root: Path) -> BatchState:
         return BatchState()
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-    except (ValueError, json.JSONDecodeError):
+    except ValueError:
         return BatchState()
     return BatchState.from_json(data)
 

--- a/llmwiki/changelog_timeline.py
+++ b/llmwiki/changelog_timeline.py
@@ -70,7 +70,7 @@ def parse_changelog(meta: Mapping[str, Any]) -> tuple[list[ChangelogEntry], list
     if isinstance(raw, str):
         try:
             data = json.loads(raw)
-        except (ValueError, json.JSONDecodeError):
+        except ValueError:
             return [], ["changelog must be a JSON list"]
 
     # The lightweight frontmatter parser in `build.py` (and
@@ -90,7 +90,7 @@ def parse_changelog(meta: Mapping[str, Any]) -> tuple[list[ChangelogEntry], list
             reparsed = json.loads(stitched)
             if isinstance(reparsed, list):
                 data = reparsed
-        except (ValueError, json.JSONDecodeError):
+        except ValueError:
             pass  # fall through; the element-level validator will reject
 
     if not isinstance(data, list):

--- a/llmwiki/convert.py
+++ b/llmwiki/convert.py
@@ -310,7 +310,16 @@ class IgnoreMatcher:
             return cls([])
         try:
             text = path.read_text(encoding="utf-8")
-        except OSError:
+        except OSError as e:
+            # #py-l2 (#600): silent fallback to empty was hiding real
+            # permission / IO problems from operators. Print a warning
+            # to stderr so the failure is visible without breaking
+            # callers that expect a usable IgnoreMatcher.
+            import sys as _sys
+            print(
+                f"warning: could not read {path}: {e}; treating as no-ignores",
+                file=_sys.stderr,
+            )
             return cls([])
         return cls(text.splitlines())
 
@@ -540,7 +549,22 @@ class Redactor:
         red = config.get("redaction", {})
         self.real_user = red.get("real_username", "")
         self.repl_user = red.get("replacement_username", "USER")
-        self.patterns = [re.compile(p) for p in red.get("extra_patterns", [])]
+        # #py-l6 (#604): one bad user-supplied pattern used to abort
+        # construction of the entire Redactor — leaving sync running
+        # with NO redaction at all (worse than partial redaction).
+        # Compile each pattern individually; warn on the bad ones, keep
+        # the good ones. Default token patterns + username redaction
+        # still run regardless.
+        self.patterns = []
+        import sys as _sys
+        for p in red.get("extra_patterns", []):
+            try:
+                self.patterns.append(re.compile(p))
+            except re.error as e:
+                print(
+                    f"warning: invalid redaction pattern {p!r} skipped: {e}",
+                    file=_sys.stderr,
+                )
 
     def __call__(self, text: str) -> str:
         if not text:

--- a/llmwiki/schema.py
+++ b/llmwiki/schema.py
@@ -127,7 +127,7 @@ def _try_parse_json(value: Any) -> Any:
         if stripped.startswith(("{", "[")):
             try:
                 return json.loads(stripped)
-            except (ValueError, json.JSONDecodeError):
+            except ValueError:
                 return value
     return value
 

--- a/llmwiki/synth/ollama.py
+++ b/llmwiki/synth/ollama.py
@@ -276,7 +276,7 @@ class OllamaSynthesizer(BaseSynthesizer):
             if 200 <= status < 300:
                 try:
                     return json.loads(body)
-                except (ValueError, json.JSONDecodeError) as exc:
+                except ValueError as exc:
                     raise OllamaError(
                         f"Ollama returned non-JSON body: {exc}"
                     ) from exc

--- a/llmwiki/synth/pipeline.py
+++ b/llmwiki/synth/pipeline.py
@@ -134,7 +134,7 @@ def _load_state(state_file: Optional[Path] = None) -> dict[str, float]:
         return {}
     try:
         return json.loads(target.read_text(encoding="utf-8"))
-    except (ValueError, json.JSONDecodeError):
+    except ValueError:
         return {}
 
 

--- a/llmwiki/viz_tokens.py
+++ b/llmwiki/viz_tokens.py
@@ -72,7 +72,7 @@ def parse_token_totals(meta: Mapping[str, object]) -> dict[str, int]:
     if isinstance(raw, str):
         try:
             data = json.loads(raw)
-        except (ValueError, json.JSONDecodeError):
+        except ValueError:
             return {}
         if isinstance(data, dict):
             return {str(k): int(v) for k, v in data.items()

--- a/llmwiki/viz_tools.py
+++ b/llmwiki/viz_tools.py
@@ -105,7 +105,7 @@ def parse_tool_counts(meta: Mapping[str, object]) -> dict[str, int]:
     if isinstance(raw, str):
         try:
             data = json.loads(raw)
-        except (ValueError, json.JSONDecodeError):
+        except ValueError:
             return {}
         if isinstance(data, dict):
             return {str(k): int(v) for k, v in data.items()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.46"
+version = "1.3.47"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Closes #592 #600 #602 #604. Four exception-handling tighten-ups. See CHANGELOG. Bumps to **1.3.47**.