### PR TITLE
perf: #474 hot-path bundle (#586, #595, #597) — v1.3.49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.49] — 2026-04-26
+
+#474 perf hot-path — 3 of 5 issues from epic-research bundle 3.
+
+### Fixed
+
+- **`Redactor._redact_username` caches the compiled regex** (#586, #py-h8) — was recompiling the same alternation regex on every call. On a 500-session sync that's thousands of needless `re.compile()` invocations. Now keyed on `self.real_user`; rebuild only when the username changes.
+- **`_close_open_fence` short-circuits on fence-free prose** (#595, #py-m9) — full `splitlines()` walk was running on every page even when the prose had no fences at all (frontmatter-only snippets, summaries, quotes). Quick `"```" not in text and "~~~" not in text` check returns immediately when both are absent.
+- **`fnmatch` hoisted to module-level** (#597, #py-m11) — was imported inside `IgnoreMatcher._match_one` on every call. Moved to a module-level `import fnmatch as _fnmatch` so the import resolution doesn't repeat thousands of times during a sync.
+
+### Deferred to follow-ups
+
+- #596 (synthesize_estimate_report double-walk) and #585 (OllamaSynthesizer re-renders prompt) — bigger refactors than the hot-path bundle absorbed; will land in a synth-perf bundle.
+
 ## [1.3.48] — 2026-04-26
 
 #472 input-validation hardening — 6 security guards from epic-research bundle A.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.48-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.49-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.48"
+__version__ = "1.3.49"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/convert.py
+++ b/llmwiki/convert.py
@@ -9,6 +9,7 @@ mtime, so re-running on unchanged files is a fast no-op.
 
 from __future__ import annotations
 
+import fnmatch as _fnmatch  # #py-m11 (#597): module-level alias
 import json
 import re
 import sys
@@ -330,8 +331,14 @@ class IgnoreMatcher:
         We emulate gitignore-ish behaviour with stdlib fnmatch, extended to
         handle `**` by translating it to `*` and also matching the pattern
         against any path suffix.
+
+        #py-m11 (#597): fnmatch was imported per-call. The module is in
+        the stdlib (no actual disk hit), but the resolution still costs
+        a few microseconds × thousands of calls during a sync. Hoisted
+        to a module-level alias.
         """
-        import fnmatch
+        # Use the module-level _fnmatch alias hoisted below.
+        fnmatch = _fnmatch
 
         # Normalize path separators
         target = target.replace("\\", "/")
@@ -624,6 +631,15 @@ class Redactor:
 
         Username can contain hyphens, underscores, and unicode.
         """
+        # #py-h8 (#586): cache the compiled username pattern on the
+        # instance so a long sync doesn't recompile the same regex
+        # thousands of times. Key on the real_user string so a config
+        # change between calls (rare) still rebuilds the pattern.
+        cached = getattr(self, "_username_pattern_cache", None)
+        if cached and cached[0] == self.real_user:
+            return cached[1].sub(
+                lambda m: m.group("prefix") + self.repl_user, text
+            )
         u = re.escape(self.real_user)
         repl_user = self.repl_user
         # Single regex with prefix alternation; word-style boundary
@@ -658,6 +674,8 @@ class Redactor:
             + r"(?P<user>" + u + r")"
             + r"(?=$|[/\\])"
         )
+        # Cache for next call.
+        self._username_pattern_cache = (self.real_user, pattern)
         return pattern.sub(lambda m: m.group("prefix") + repl_user, text)
 
 
@@ -675,6 +693,13 @@ def _close_open_fence(text: str) -> str:
     Counts only lines whose first non-whitespace characters are triple
     backticks or triple tildes (real fences, not inline code).
     """
+    # #py-m9 (#595): short-circuit on prose with no fences. The full
+    # splitlines + lstrip walk is O(n) on every page; pages without any
+    # fence at all (lots of them — quotes, summaries, frontmatter-only
+    # snippets) get the fast `in` check instead. Both `\`\`\`` and `~~~`
+    # must be absent for the early-out to be safe.
+    if "```" not in text and "~~~" not in text:
+        return text
     backtick_count = 0
     tilde_count = 0
     for line in text.splitlines():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.48"
+version = "1.3.49"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Closes #586 #595 #597. Three perf wins. #585 + #596 deferred. Bumps to **1.3.49**.