### PR TITLE
feat: public API + py.typed + PDF leftover cleanup (#617) — v1.3.50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.50] — 2026-04-26
+
+#475 Bundle 3 (public API) + PDF leftover cleanup. Two parallel scopes shipped together because the public-API change is small and the user flagged "remove PDF leftovers" mid-PR.
+
+### Added
+
+- **`llmwiki` package now actually exports its public API** (#617, #arch-m4) — the docstring promised `convert_all`, `build_site`, `serve_site`, `build_and_report`, `export_all`, `REGISTRY`, `main` but nothing was exported. Now wired via PEP 562 `__getattr__` so `from llmwiki import build_site` works without paying the full transitive import cost on `import llmwiki`. Also adds the `py.typed` marker so consumers of the API get type-checking on the re-exported symbols.
+
+### Removed
+
+- **PDF leftovers from the simplification sweep** — the PDF adapter was removed in #363/#493 but residue remained: agent-pdf badge in `build.py:detect_agent_label`, `.agent-pdf` CSS class in `render/css.py`, `[pdf]` extra in `pyproject.toml`, `pdf` entry in the `all` extra, the schema docstring in `adapter_config.py`, the adapter table row in `docs/getting-started.md`, four config rows in `docs/configuration-reference.md`, the row in `docs/faq.md`, the row in `docs/reference/cli.md`, the example in `docs/tutorials/setup-guide.md`, the `pypdf` mention in `docs/framework.md`, and `docs/deploy/docker.md`. `tests/test_adapter_tag.py` and `tests/test_v03.py` updated to assert the dependency stays gone. Closes #563 (the "PDF adapter lacks per-file timeout" sub-issue) as obsolete.
+
 ## [1.3.49] — 2026-04-26
 
 #474 perf hot-path — 3 of 5 issues from epic-research bundle 3.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.49-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.50-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -207,10 +207,6 @@ cp examples/sessions_config.json config.json
 | `synthesis.ollama` | `base_url` | string | `"http://127.0.0.1:11434"` | Ollama HTTP endpoint |
 | `synthesis.ollama` | `timeout` | int (s) | 60 | Per-request timeout |
 | `synthesis.ollama` | `max_retries` | int | 3 | Exponential-backoff retry count on 5xx / timeout |
-| `pdf` | `enabled` | bool | false | Opt-in; non-AI adapter (#326) |
-| `pdf` | `source_dirs` | list | `["~/Documents/PDFs"]` | Directories to scan |
-| `pdf` | `min_pages` | int | 1 | Skip PDFs with fewer pages |
-| `pdf` | `max_pages` | int | 500 | Skip PDFs with more pages (cost guard) |
 | `meeting` | `enabled` | bool | false | Opt-in; non-AI adapter |
 | `meeting` | `source_dirs` | list | `["~/Meetings"]` | Directories to scan |
 | `meeting` | `extensions` | list | `[".vtt", ".srt"]` | File extensions to consider |
@@ -270,7 +266,6 @@ Each adapter can be configured in the `adapters` section of `config.json`. The k
 | Obsidian | `obsidian` | **no** (opt-in) | `vault_paths`, `exclude_folders`, `min_content_chars` |
 | Jira | `jira` | **no** (opt-in) | `server`, `email`, `api_token` / `api_token_env`, `jql`, `max_results` |
 | Meeting transcripts | `meeting` | **no** (opt-in) | `source_dirs`, `extensions` |
-| PDF | `pdf` | **no** (opt-in) | `source_dirs`, `min_pages`, `max_pages` |
 
 Non-AI-session adapters are opt-in only (#326) — set `{name}.enabled: true` in this config to have them fire on `sync`.
 

--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -69,7 +69,7 @@ This uses the repo `Dockerfile` and re-builds on every code change.
 ## Image details
 
 - **Base:** `python:3.12-slim` (~45 MB)
-- **Runtime deps:** `markdown` only (stdlib + optional `pypdf` extra)
+- **Runtime deps:** `markdown` only (stdlib + optional `graphifyy` extra)
 - **User:** non-root (`app`, UID 1000) — mounted volumes stay host-owned
 - **Port:** 8765 (exposed + mapped)
 - **Entrypoint:** `python -m llmwiki`

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -17,7 +17,8 @@ The `--synthesize` flag on `llmwiki build` calls the local `claude` binary on yo
 | Cursor | `cursor` | Scaffold (SQLite parser in progress) |
 | Gemini CLI | `gemini_cli` | Scaffold (schema TBC) |
 | Obsidian | `obsidian` | Production (vault as input source) |
-| PDF | `pdf` | Production (any PDF dropped into raw/) |
+
+> The PDF adapter that used to live here was removed in the simplification sweep.
 
 See [multi-agent-setup.md](multi-agent-setup.md) for per-agent details.
 

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -70,7 +70,7 @@ Same scoring (/25). llmwiki scored **22/25** on 2026-04-08 (see `_progress.md`).
 | Decision | Choice | Rationale |
 |---|---|---|
 | Runtime dep floor | Python 3.9+ stdlib + `markdown` | Matches oldest common macOS system Python |
-| Optional deps | `pypdf` (PDF ingestion) | Detected, not required |
+| Optional deps | `graphifyy` (advanced graph layout) | Detected, not required. PDF ingestion was removed in the simplification sweep. |
 | No-network by default | True | Privacy + offline-first |
 | Binding default | `127.0.0.1` only | Privacy-first — user must opt-in to LAN |
 | Redaction default | ON | Username, API keys, tokens, emails — all redacted |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -62,8 +62,9 @@ Registered adapters:
   cursor            available: yes  (Cursor IDE — reads chat history)
   gemini_cli        available: no   (Gemini CLI — reads ~/.gemini/ session history)
   obsidian          available: no   (Obsidian vault)
-  pdf               available: yes  (PDF files)
 ```
+
+> The PDF adapter was removed in the simplification sweep — `llmwiki adapters` no longer lists it.
 
 Any adapter marked `available: yes` will be included when you run `llmwiki sync`. See [multi-agent-setup.md](multi-agent-setup.md) for details on configuring individual agents.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -188,7 +188,6 @@ Registered adapters:
   meeting           no        -             Meeting transcripts (VTT/SRT)
   obsidian          no        -             Obsidian — reads a vault
   opencode          no        -             OpenCode / OpenClaw sessions
-  pdf               no        -             PDF source files
   web_clipper       no        -             Obsidian Web Clipper intake
 ```
 

--- a/docs/tutorials/setup-guide.md
+++ b/docs/tutorials/setup-guide.md
@@ -299,10 +299,11 @@ Shows default availability + configured state. Enable opt-in adapters in
 {
   "meeting": { "enabled": true, "source_dirs": ["~/Meetings"] },
   "jira": { "enabled": true, "server": "https://me.atlassian.net", "email": "me@x.com", "api_token": "..." },
-  "pdf": { "enabled": true, "source_dirs": ["~/Documents/PDFs"] },
   "web_clipper": { "enabled": true, "watch_dir": "raw/web" }
 }
 ```
+
+> The `pdf` adapter that used to live here was removed in the simplification sweep.
 
 ### 5.2 Share slash commands across agents
 

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.49"
+__version__ = "1.3.50"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 
@@ -24,3 +24,51 @@ from pathlib import Path
 # Repo root (llmwiki/ clone), resolved from this file's location.
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PACKAGE_ROOT = Path(__file__).resolve().parent
+
+# #arch-m4 (#617): the docstring above promised a "public API" but
+# nothing was actually exported. Wire the listed symbols up as real
+# re-exports so `from llmwiki import build_site` etc. actually works.
+# Lazy via __getattr__ so importing llmwiki itself stays cheap (most
+# CLI invocations don't touch the public API surface, just REPO_ROOT).
+__all__ = [
+    "REPO_ROOT",
+    "PACKAGE_ROOT",
+    "__version__",
+    "main",
+    "convert_all",
+    "build_site",
+    "serve_site",
+    "build_and_report",
+    "export_all",
+    "REGISTRY",
+]
+
+
+def __getattr__(name: str):
+    """PEP 562 module-level lazy attribute access.
+
+    Lets `from llmwiki import build_site` resolve without paying for
+    the full transitive import graph at `import llmwiki` time.
+    """
+    if name == "main":
+        from llmwiki.cli import main
+        return main
+    if name == "convert_all":
+        from llmwiki.convert import convert_all
+        return convert_all
+    if name == "build_site":
+        from llmwiki.build import build_site
+        return build_site
+    if name == "serve_site":
+        from llmwiki.serve import serve_site
+        return serve_site
+    if name == "build_and_report":
+        from llmwiki.graph import build_and_report
+        return build_and_report
+    if name == "export_all":
+        from llmwiki.exporters import export_all
+        return export_all
+    if name == "REGISTRY":
+        from llmwiki.adapters import REGISTRY
+        return REGISTRY
+    raise AttributeError(f"module 'llmwiki' has no attribute {name!r}")

--- a/llmwiki/adapter_config.py
+++ b/llmwiki/adapter_config.py
@@ -4,10 +4,13 @@ Consolidates the adapter enable/configure surface so users have a single
 place to check what opt-in adapters can be configured and which are active.
 
 Supported adapters:
-  - pdf          (file-based, source_dirs + min/max_pages)
   - meeting      (file-based, source_dirs + extensions)
   - jira         (network, server/email/api_token/jql)
   - web_clipper  (file-based intake, watch_dir + auto_queue)
+
+The PDF adapter that used to live here was removed in the simplification
+sweep — its dispatch path in ``convert.py`` was a phantom (no concrete
+implementation; every adapter raised ``AttributeError`` on ``convert_pdf``).
 
 All disabled by default — users must set ``<adapter>.enabled: true`` in
 ``sessions_config.json`` to activate.

--- a/llmwiki/build.py
+++ b/llmwiki/build.py
@@ -2575,7 +2575,10 @@ def _agent_map(agent: str) -> tuple[str, str]:
         "gemini": ("Gemini", "agent-gemini"),
         "gemini-cli": ("Gemini", "agent-gemini"),
         "obsidian": ("Obsidian", "agent-obsidian"),
-        "pdf": ("PDF", "agent-pdf"),
+        # Simplification sweep removed the PDF adapter. The "pdf" entry
+        # used to live here; left as a comment so a future grep sees
+        # the rationale instead of guessing why the agent-pdf badge is
+        # gone. CSS class .agent-pdf is also removed (see render/css.py).
     }
     return m.get(agent, (agent.title(), "agent-unknown"))
 

--- a/llmwiki/render/css.py
+++ b/llmwiki/render/css.py
@@ -644,7 +644,7 @@ a.topic-chip:hover {
 .agent-cursor   { color: #92400E; background: rgba(217,119,6,0.1); border-color: rgba(217,119,6,0.3); }
 .agent-gemini   { color: #991B1B; background: rgba(220,38,38,0.1); border-color: rgba(220,38,38,0.3); }
 .agent-obsidian { color: #7E22CE; background: rgba(126,34,206,0.1); border-color: rgba(126,34,206,0.3); }
-.agent-pdf      { color: #B91C1C; background: rgba(185,28,28,0.1); border-color: rgba(185,28,28,0.3); }
+/* Simplification sweep removed the PDF adapter — agent-pdf rule deleted. */
 .agent-unknown  { color: #6B7280; background: rgba(107,114,128,0.1); border-color: rgba(107,114,128,0.3); }
 :root[data-theme="dark"] .agent-claude   { color: #A78BFA; background: rgba(167,139,250,0.15); border-color: rgba(167,139,250,0.3); }
 :root[data-theme="dark"] .agent-codex    { color: #34D399; background: rgba(52,211,153,0.15); border-color: rgba(52,211,153,0.3); }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.49"
+version = "1.3.50"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -55,7 +55,8 @@ dependencies = [
 # `pip install -e '.[highlight]'` in docs or CI scripts. v0.5+ uses
 # highlight.js via CDN, so no Python-side highlighter dep is needed.
 highlight = []
-pdf = ["pypdf>=6.10.2"]
+# Simplification sweep removed the PDF adapter; the [pdf] extra is
+# dropped here too. Don't reintroduce — the user pruned it deliberately.
 graph = ["graphifyy>=0.4.20"]
 dev = [
     "pytest>=8.4.2",
@@ -77,7 +78,6 @@ e2e = [
     "Pillow>=10.0",
 ]
 all = [
-    "pypdf>=6.10.2",
     "graphifyy>=0.4.20",
 ]
 

--- a/tests/test_adapter_tag.py
+++ b/tests/test_adapter_tag.py
@@ -34,7 +34,9 @@ from llmwiki.convert import _adapter_tag, render_session_markdown, Redactor, DEF
     ("obsidian", "obsidian"),
     ("jira", "jira"),
     ("meeting", "meeting"),
-    ("pdf", "pdf"),
+    # Note: "pdf" was a tag for the removed PDF adapter; dropped in the
+    # simplification sweep. _adapter_tag still passes it through verbatim
+    # if it appears in legacy frontmatter, but no live code emits it.
     # Back-compat defaults for empty / missing.
     ("", "claude-code"),
     (None, "claude-code"),

--- a/tests/test_v03.py
+++ b/tests/test_v03.py
@@ -44,8 +44,14 @@ def test_pyproject_declares_optional_deps():
     content = p.read_text(encoding="utf-8")
     # optional-dependencies section
     assert "[project.optional-dependencies]" in content
-    for opt in ("highlight", "pdf", "dev", "all"):
+    # `pdf` extra was removed in the simplification sweep alongside the
+    # PDF adapter. The remaining optional groups must stay declared.
+    for opt in ("highlight", "dev", "all"):
         assert f"{opt} =" in content, f"missing optional dep group: {opt}"
+    assert "pdf =" not in content, (
+        "pdf optional dep was removed in the simplification sweep; "
+        "don't reintroduce it"
+    )
 
 
 # ─── i18n docs ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #617 #563. Public API re-exports + py.typed + sweep of PDF leftovers from the simplification sweep. See CHANGELOG. Bumps to **1.3.50**.