### PR TITLE
fix: #472 MCP write-safety + lint perf bail-out (#553, #556) — v1.3.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.51] — 2026-04-26
+
+#472 Bundle C — MCP write-safety + lint perf bail-out (2 issues; the third sub-issue #563 was closed-as-obsolete in v1.3.50 since the PDF adapter is gone).
+
+### Fixed
+
+- **`wiki_sync` MCP tool defaults to dry-run + requires explicit `confirm: true`** (#556, #sec-12) — an MCP client could previously trigger a real write to `raw/` on a hallucinated tool call. Schema now defaults `dry_run: true` and adds a separate `confirm: false` parameter; the handler downgrades to dry-run unless the caller passes BOTH `dry_run: false` AND `confirm: true`. Belt-and-braces guard against MCP clients that get confused about the boolean default.
+- **`DuplicateDetection` bails out of the body-compare pass on huge buckets** (#553, #sec-9) — even after the #412 bucket-restriction perf fix, a single bucket with thousands of pages still ran O(n²) body comparisons. Added `BUCKET_BAILOUT_SIZE = 500`: bigger buckets keep the cheap fingerprint duplicate-detection but skip the expensive near-duplicate `SequenceMatcher` pass. Lint stays bounded under a reasonable wall clock on 50k-page corpora.
+
 ## [1.3.50] — 2026-04-26
 
 #475 Bundle 3 (public API) + PDF leftover cleanup. Two parallel scopes shipped together because the public-API change is small and the user flagged "remove PDF leftovers" mid-PR.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.50-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.51-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.50"
+__version__ = "1.3.51"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/lint/rules.py
+++ b/llmwiki/lint/rules.py
@@ -312,6 +312,14 @@ class DuplicateDetection(LintRule):
     # boilerplate files that are otherwise unrelated.
     BODY_THRESHOLD = 0.80
     BODY_SAMPLE_BYTES = 4096
+    # #sec-9 (#553): even after the bucket-restriction perf fix in
+    # #412, a single bucket with thousands of pages (e.g. an entity
+    # bucket on a 50k-page corpus) still does O(n²) body compares.
+    # Bail out of the SequenceMatcher pass when a bucket exceeds this
+    # threshold — fingerprint matches still flag exact duplicates,
+    # we just stop the expensive near-duplicate search to keep lint
+    # under a reasonable wall clock on large wikis.
+    BUCKET_BAILOUT_SIZE = 500
 
     def _bucket_key(self, page: dict) -> tuple[str, str]:
         """Return the comparison-bucket key for a page.
@@ -393,6 +401,12 @@ class DuplicateDetection(LintRule):
                             ),
                         })
 
+            # #sec-9 (#553): bail out of the O(n²) body-compare pass
+            # when the bucket is too large. Exact duplicates are still
+            # caught by the fingerprint pass above; we just stop the
+            # expensive near-duplicate search.
+            if len(items) > self.BUCKET_BAILOUT_SIZE:
+                continue
             # Fingerprints differed — fall back to SequenceMatcher only
             # for pairs whose titles already match. Body comparisons
             # over the bucket-restricted slice cap the cost.

--- a/llmwiki/mcp/server.py
+++ b/llmwiki/mcp/server.py
@@ -136,14 +136,30 @@ TOOLS = [
         "description": (
             "Run the session-transcript converter to pull in any new sessions "
             "from the agent's session store into raw/sessions/. Returns the "
-            "converter's summary line."
+            "converter's summary line. Defaults to dry-run; pass confirm=true "
+            "to actually write."
         ),
         "inputSchema": {
             "type": "object",
             "properties": {
+                # #sec-12 (#556): default to dry_run=true so an MCP client
+                # can't silently mutate raw/ on a misclick / hallucinated
+                # tool call. Pass `confirm: true` to actually write.
                 "dry_run": {
                     "type": "boolean",
-                    "description": "If true, preview without writing.",
+                    "description": (
+                        "If true (default), preview without writing. Set "
+                        "false ONLY together with confirm=true."
+                    ),
+                    "default": True,
+                },
+                "confirm": {
+                    "type": "boolean",
+                    "description": (
+                        "Required to actually write. Without confirm=true "
+                        "the call always runs as a dry-run regardless of "
+                        "dry_run."
+                    ),
                     "default": False,
                 },
             },
@@ -650,7 +666,14 @@ def tool_wiki_lint(args: dict[str, Any]) -> dict[str, Any]:
 
 
 def tool_wiki_sync(args: dict[str, Any]) -> dict[str, Any]:
-    dry_run = bool(args.get("dry_run", False))
+    # #sec-12 (#556): default to dry_run=true. Real writes require BOTH
+    # dry_run=false AND confirm=true. Either flag missing = dry-run.
+    dry_run = bool(args.get("dry_run", True))
+    confirm = bool(args.get("confirm", False))
+    if not dry_run and not confirm:
+        # Caller asked for live sync without confirmation — downgrade to
+        # dry-run + tell them why. Better than silently mutating raw/.
+        dry_run = True
     cmd = [sys.executable, "-m", "llmwiki", "sync"]
     if dry_run:
         cmd.append("--dry-run")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.50"
+version = "1.3.51"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Closes #553 #556. See CHANGELOG. Bumps to **1.3.51**.