### PR TITLE
fix: #474 Bundle 5 — CLI/MCP HIGH (#582, #584, #587, #589) — v1.3.53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.53] — 2026-04-26
+
+#474 Bundle 5 — CLI/MCP HIGH (4 of 6; #583 cmd_all argv re-parse + #585 Ollama prompt re-render deferred as standalones).
+
+### Fixed
+
+- **MCP `wiki_sync` streams output instead of buffering all of it** (#582, #py-h1) — `subprocess.run(capture_output=True)` would hold the entire sync stdout in RAM and could OOM on a chatty multi-thousand-session sync. Now uses `Popen` + line-by-line read with a 256 KB tail cap and explicit deadline; long output truncates to a marker instead of crashing the server.
+- **`synth/pipeline._render_synth_page` no longer silently drops curated tags** (#584, #py-h5) — the broad `except Exception` was eating real parse failures + unicode errors silently, dropping maintainer-curated tags on every regression. Narrowed to `(OSError, ValueError, UnicodeDecodeError)` and added a stderr warning so a tag-loss diff is loud, not silent.
+- **`synth/pipeline.py` imports `parse_frontmatter` from `_frontmatter` directly** (#587 / #arch-h5, #py-m1) — was importing from `build` which drags 145+ transitive imports into every synth call. The parser sits cleanly in `_frontmatter.py` with no deps; switching trims the cold-start cost for `llmwiki synthesize`.
+- **`MODEL_PRICING` includes `claude-haiku-4-5-20251001`** (#589, #py-m3) — `synthesize_overview` actually invokes the date-suffixed haiku alias; cost-estimate code was raising `ValueError: unknown model`. Same rate card as the bare `claude-haiku-4` entry.
+
+### Deferred
+
+- #583 (cmd_all argv re-parse) — needs an argparse-injection refactor; better as standalone alongside #611 (synthesize flag exclusion group).
+- #585 (Ollama re-renders prompt) — synth backend contract realignment, file as standalone.
+
 ## [1.3.52] — 2026-04-26
 
 #474 Bundle 4 — build/serve correctness (4 of 5; the 5th #594 single-pass refactor deferred as standalone).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.52-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.53-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.52"
+__version__ = "1.3.53"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/cache.py
+++ b/llmwiki/cache.py
@@ -100,6 +100,16 @@ MODEL_PRICING: dict[str, ModelRates] = {
         "cache_write": 1.00,
         "output": 4.00,
     },
+    # #py-m3 (#589): synthesize_overview actually invokes
+    # `claude-haiku-4-5-20251001` (the date-suffixed alias). Without
+    # this entry, cost-estimate code raises `ValueError: unknown model`.
+    # Same rate card as the bare claude-haiku-4 above.
+    "claude-haiku-4-5-20251001": {
+        "input": 0.80,
+        "cached_input": 0.08,
+        "cache_write": 1.00,
+        "output": 4.00,
+    },
     "claude-opus-4": {
         "input": 15.00,
         "cached_input": 1.50,

--- a/llmwiki/mcp/server.py
+++ b/llmwiki/mcp/server.py
@@ -26,6 +26,7 @@ import json
 import re
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -677,15 +678,46 @@ def tool_wiki_sync(args: dict[str, Any]) -> dict[str, Any]:
     cmd = [sys.executable, "-m", "llmwiki", "sync"]
     if dry_run:
         cmd.append("--dry-run")
+    # #py-h1 (#582): capture_output=True buffers all stdout in RAM. A
+    # very chatty sync (thousands of sessions) can blow past the
+    # 1 GB-ish ceiling Python can hold + grow before OOM-killing.
+    # Stream stdout via Popen + readline, capping the captured tail
+    # to a fixed byte budget so the MCP response stays bounded.
+    OUTPUT_CAP_BYTES = 256 * 1024  # 256 KB tail in the response
+    captured: list[str] = []
+    captured_bytes = 0
+    truncated = False
     try:
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, cwd=str(REPO_ROOT), timeout=120,
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            cwd=str(REPO_ROOT),
         )
+        # Read line-by-line so a hung child doesn't block forever — the
+        # outer try wraps a 120s timeout via proc.wait below.
+        assert proc.stdout is not None
+        deadline = time.time() + 120.0
+        for line in proc.stdout:
+            if captured_bytes < OUTPUT_CAP_BYTES:
+                captured.append(line)
+                captured_bytes += len(line)
+            else:
+                truncated = True
+            if time.time() > deadline:
+                proc.kill()
+                return _err("sync timed out after 120s")
+        proc.wait(timeout=max(0.1, deadline - time.time()))
     except subprocess.TimeoutExpired:
+        try: proc.kill()  # type: ignore[name-defined]
+        except Exception: pass
         return _err("sync timed out after 120s")
-    except Exception as e:
+    except (OSError, subprocess.SubprocessError) as e:
         return _err(f"sync failed: {e}")
-    output = result.stdout + (f"\n--- stderr ---\n{result.stderr}" if result.stderr else "")
+    output = "".join(captured)
+    if truncated:
+        output += f"\n[output truncated at {OUTPUT_CAP_BYTES // 1024} KB]"
     return _ok(output or "(no output)")
 
 

--- a/llmwiki/synth/pipeline.py
+++ b/llmwiki/synth/pipeline.py
@@ -25,7 +25,10 @@ from pathlib import Path
 from typing import Any, Optional
 
 from llmwiki import REPO_ROOT
-from llmwiki.build import parse_frontmatter
+# #py-m1 (#587) / #arch-h5 (#610): import directly from _frontmatter
+# instead of via build.py. The build module pulls in 145+ transitive
+# imports; the parser sits cleanly in _frontmatter.py with no deps.
+from llmwiki._frontmatter import parse_frontmatter
 from llmwiki.synth.base import BaseSynthesizer, DummySynthesizer
 
 
@@ -545,6 +548,13 @@ def _build_source_page(
     ai_tags, clean_body = _extract_suggested_tags(synthesized_body)
 
     # Preserve any maintainer-curated tags on re-synthesize.
+    # #py-h5 (#584): the broad `except Exception` was eating real
+    # parse failures + unicode errors silently, dropping the curated
+    # tags on every regression. Narrow to the failures that are
+    # actually expected here (file read OSError, frontmatter format
+    # issues): everything else (MemoryError, KeyboardInterrupt,
+    # surprise type errors) bubbles up so the regression is visible
+    # instead of silently producing a tag-loss diff.
     existing_tags: list[str] = []
     if existing_page_path is not None and existing_page_path.exists():
         try:
@@ -552,8 +562,14 @@ def _build_source_page(
                 existing_page_path.read_text(encoding="utf-8")
             )
             existing_tags = list(existing_meta.get("tags", []) or [])
-        except Exception:
-            # Never fail synthesis on a frontmatter read error.
+        except (OSError, ValueError, UnicodeDecodeError) as e:
+            # Log loud — silent drop is what #584 was about.
+            import sys as _sys
+            print(
+                f"warning: could not preserve tags from "
+                f"{existing_page_path}: {e}",
+                file=_sys.stderr,
+            )
             existing_tags = []
 
     baseline = _derive_baseline_tags(meta)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.52"
+version = "1.3.53"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Closes #582 #584 #587 #589. See CHANGELOG. Bumps to **1.3.53**.