### PR TITLE
fix: synthesize subcommand argparse mutual-exclusion group (#610) — v1.3.55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.55] — 2026-04-26
+
+#475 #arch-h7 — synthesize subcommand argparse mutual exclusion (#610).
+
+### Fixed
+
+- **`synthesize` rejects mutually-exclusive flags loudly** (#610, #arch-h7) — `--check`, `--estimate`, `--list-pending`, `--complete` were independent flags; argparse accepted any combination. The body of `cmd_synthesize` had a quiet if/elif chain that ran the FIRST set flag and silently dropped the rest, so `synthesize --check --estimate` ran the connectivity probe and dropped the cost estimate request. Wrapped the four mode flags in `add_mutually_exclusive_group()` so argparse rejects the combination with a clear `argument --estimate: not allowed with argument --check`. `--force` is intentionally outside the group (it modifies the default flow).
+
 ## [1.3.54] — 2026-04-26
 
 #473 Bundle A — theme follow-system + kbd wikilink + iOS sticky thead (3 HIGH a11y/UX issues).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.54-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.55-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.54"
+__version__ = "1.3.55"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/cli.py
+++ b/llmwiki/cli.py
@@ -1224,26 +1224,37 @@ def build_parser() -> argparse.ArgumentParser:
         "synthesize",
         help="Synthesize wiki source pages from raw sessions via LLM backend",
     )
-    syn.add_argument(
+    # #arch-h7 (#610): the four "what should this invocation do?" flags
+    # used to be independently set-able. argparse silently honoured the
+    # first one in `cmd_synthesize`'s if/elif chain, so e.g.
+    # `synthesize --check --estimate` ran --check and silently dropped
+    # --estimate. Use a mutually-exclusive group so the parser rejects
+    # the combination loudly with a useful error.
+    syn_mode = syn.add_mutually_exclusive_group()
+    syn_mode.add_argument(
         "--check", action="store_true",
         help="Probe backend availability and exit (exit 0 if reachable)",
     )
-    syn.add_argument(
-        "--force", action="store_true",
-        help="Ignore state file, re-synthesize all sessions",
-    )
-    syn.add_argument(
+    syn_mode.add_argument(
         "--estimate", action="store_true",
         help="Print cached-vs-fresh token + dollar estimate without calling a backend (#50)",
     )
-    # #316 — agent-delegate backend helpers.
-    syn.add_argument(
+    # #316 — agent-delegate backend helpers (mutually-exclusive with the
+    # default synthesize-all flow + with --check / --estimate above).
+    syn_mode.add_argument(
         "--list-pending", action="store_true",
         help="List pending prompts awaiting agent synthesis (agent-delegate backend, #316)",
     )
-    syn.add_argument(
+    syn_mode.add_argument(
         "--complete", metavar="UUID", default=None,
         help="Complete a pending synthesis: read body from --body or stdin, rewrite --page in place (#316)",
+    )
+    # --force is orthogonal (modifies the default re-synthesize-all flow)
+    # and stays outside the exclusion group so callers can pass
+    # `synthesize --force` for a forced full re-run.
+    syn.add_argument(
+        "--force", action="store_true",
+        help="Ignore state file, re-synthesize all sessions",
     )
     syn.add_argument(
         "--page", metavar="PATH", default=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.54"
+version = "1.3.55"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Closes #610. See CHANGELOG. Bumps to **1.3.55**.