### PR TITLE
fix: drop headerlink permalinks (axe link-in-text-block) (#646) — v1.3.60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.60] — 2026-04-26
+
+#646 — drop Python-Markdown headerlink permalinks (axe `link-in-text-block` violation).
+
+### Fixed
+
+- **`<h2-h3>` no longer get an unstyled `.headerlink` ¶ anchor** (#646) — the Python-Markdown TOC extension's `permalink: True` mode was emitting `<a class="headerlink" href="#anchor" title="Permanent link">¶</a>` next to every heading. The site CSS doesn't style `.headerlink` (only `.deep-link`), so axe-core flagged every ¶ link as a `link-in-text-block` violation (link not visually distinguishable). On `/changelog.html` that meant 99 nodes failing AA. Removed `permalink: True`; the JS-driven `.deep-link` icon next to each heading (in `render/js.py`) remains the canonical deep-link affordance — it has CSS, hover state, and `aria-hidden` treatment. Anchor targets (`<h2 id="...">`) still ship so links to `#section-name` keep working. Re-enabled `/changelog.html` in `tests/e2e/test_axe_a11y_broadened.py::PAGES_TO_AUDIT`.
+
 ## [1.3.59] — 2026-04-26
 
 #473 UI medium tail — filter persistence + lang/dir + inline-style sweep (3 issues).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.59-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.60-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.59"
+__version__ = "1.3.60"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/build.py
+++ b/llmwiki/build.py
@@ -529,7 +529,19 @@ def _md_to_html_uncached(body: str) -> str:
     # and auto-detection for untagged blocks.
     extensions = ["fenced_code", "tables", "toc", "sane_lists"]
     ext_configs: dict[str, dict[str, Any]] = {
-        "toc": {"permalink": True, "toc_depth": "2-3"},
+        # #646: drop `permalink: True`. The Python-Markdown TOC
+        # extension's permalink emits a `<a class="headerlink">¶</a>`
+        # next to every heading; the site CSS doesn't style
+        # `.headerlink` (only `.deep-link` is styled), so axe-core
+        # flags every one as a `link-in-text-block` violation
+        # (links that aren't visually distinguishable). The JS-
+        # driven `.deep-link` icon next to each heading (rendered by
+        # render/js.py) is the canonical deep-link affordance — it
+        # has CSS + hover state + aria-hidden treatment. Two emitters
+        # for the same job; the markdown one is the older one. Anchor
+        # targets (`<h2 id="...">`) still ship via toc — links to
+        # `#section-name` keep working.
+        "toc": {"toc_depth": "2-3"},
     }
     md = markdown.Markdown(extensions=extensions, extension_configs=ext_configs)
     # v0.5 (#74): escape raw HTML tags in prose so session content mentioning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.59"
+version = "1.3.60"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/e2e/test_axe_a11y_broadened.py
+++ b/tests/e2e/test_axe_a11y_broadened.py
@@ -26,13 +26,12 @@ from tests.e2e.test_axe_a11y import (  # type: ignore[import-not-found]
     _scan,
 )
 
-# Pages that pass axe today. /changelog.html has a known
-# `link-in-text-block` violation on every `.headerlink` permalink (¶
-# anchor on each heading) — filed separately as a follow-up so this
-# test doesn't double up as a hard gate against pre-existing findings.
+# #646: changelog headerlinks fixed by dropping `permalink: True` from
+# the TOC extension config in build.py — re-add /changelog.html.
 PAGES_TO_AUDIT = [
     "/sessions/index.html",
     "/docs/index.html",
+    "/changelog.html",
 ]
 
 


### PR DESCRIPTION
Closes #646. See CHANGELOG. Bumps to **1.3.60**.