### PR TITLE
feat: human-readable session descriptions from first user turn (#471) — v1.3.62

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.62] — 2026-04-26
+
+Phase 2 (a) — human-readable session descriptions (#471).
+
+### Added
+
+- **Sessions now ship a `description:` frontmatter field** (#471) — auto-derived at convert time from the first non-trivial user prompt, replacing the opaque `clever-munching-parnas — 2026-04-07` slug-date title in listings. The `derive_description(records, redact)` helper walks user records, skips trivial openers ("hi", "thanks", "continue"), strips path-noise prefixes (`/Users/x/...`), skips code-fence opens, and truncates at 120 chars on a word boundary. All output flows through the same `Redactor` the body uses so the description never leaks redacted content.
+
+### Changed
+
+- **Session detail page renders the description as a subtitle** (#471) — between the hero strip and the meta line. Older sessions without the field skip the block cleanly.
+- **Sessions index table shows the description below the slug** (#471) — `.session-cell-desc` muted class, ellipsis-truncated. The slug stays in the URL; the description is the new human anchor.
+
+### Tests
+
+- **`tests/test_session_description.py`** (11 cases) — empty records, no-user-turn fallback, trivial-opener skip, code-fence skip, path-noise strip, word-boundary truncation, block-form content, redactor pass-through, frontmatter emit happy + empty paths.
+
+### Deferred to follow-up
+
+- `llmwiki backfill --field description` subcommand for re-writing existing `raw/sessions/*.md` frontmatter without re-converting the body. New sessions get the field via `sync`; existing ones keep their old frontmatter until `--force`-resync or the backfill tool ships.
+- `description` in `graph.jsonld` session nodes — small follow-up.
+
 ## [1.3.61] — 2026-04-26
 
 Phase 1 housekeeping — vault helper extraction + schema-versions hoist (#620, #621).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.61-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.62-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.61"
+__version__ = "1.3.62"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/build.py
+++ b/llmwiki/build.py
@@ -1116,6 +1116,13 @@ def render_session(
         )
         + nav_bar("sessions", link_prefix="../../")
         + hero(str(title_raw), meta_strip, size="hero-sm", subtitle_is_html=True)
+        # #471: human-readable description rendered as a subtitle below
+        # the hero, before the meta-strip. Only emit if frontmatter
+        # carries the field; older sessions skip this block cleanly.
+        + (
+            f'<div class="container session-description"><p>{html.escape(str(meta["description"]))}</p></div>'
+            if meta.get("description") else ""
+        )
         + f'<section class="section">\n  <div class="container">\n{breadcrumbs}\n{tools_preview}\n{actions_html}\n{tool_chart_block}\n{token_card_block}\n    <article class="content" itemscope itemtype="https://schema.org/Article">\n'
         + f'<meta itemprop="headline" content="{html.escape(str(title_raw))}">\n'
         + f'<meta itemprop="datePublished" content="{html.escape(str(meta.get("started") or date))}">\n'
@@ -1369,13 +1376,22 @@ def render_sessions_index(
             title = title[: -(len(date) + 3)]
         # Truncate long titles for table display
         display_title = title[:70] + "..." if len(title) > 70 else title
+        # #471: human-readable description from the first user turn —
+        # if frontmatter carries one, render it as a small muted line
+        # below the slug. Falls back to no second line for older
+        # sessions without the field.
+        description = str(meta.get("description") or "").strip()
+        desc_line = (
+            f'<div class="session-cell-desc muted">{html.escape(description)}</div>'
+            if description else ""
+        )
         model = meta.get("model", "")
         umsgs = meta.get("user_messages", "")
         tcalls = meta.get("tool_calls", "")
         href = f"{project}/{p.stem}.html"
         rows.append(
             f"""        <tr data-project="{html.escape(str(project))}" data-model="{html.escape(str(model))}" data-date="{html.escape(str(date))}" data-slug="{html.escape(str(slug))}">
-          <td><a href="{html.escape(str(href))}">{html.escape(str(display_title))}</a></td>
+          <td><a href="{html.escape(str(href))}">{html.escape(str(display_title))}</a>{desc_line}</td>
           <td>{render_agent_badge(meta)}</td>
           <td><a href="../projects/{html.escape(str(project))}.html">{html.escape(str(project))}</a></td>
           <td>{html.escape(str(date))}</td>

--- a/llmwiki/convert.py
+++ b/llmwiki/convert.py
@@ -1127,6 +1127,70 @@ def _adapter_tag(adapter_name: str) -> str:
     return normalised
 
 
+def derive_description(records: list[dict[str, Any]], redact: "Redactor") -> str:
+    """#471: derive a 120-char human-readable description from the
+    first non-trivial user prompt in the session.
+
+    Walks the records looking for the first user message, strips path
+    noise, skips trivial openers ("hi", "thanks", "continue"), and
+    truncates to ~120 chars at a word boundary.
+
+    Empty / un-derivable input returns ``""``; callers can fall back
+    to the slug. Always passes the result through the same Redactor
+    the body uses so the description doesn't leak any path / token
+    that the body would have redacted.
+    """
+    TRIVIAL = {"hi", "hello", "hey", "thanks", "thank you", "ok",
+               "continue", "go on", "ya", "yes", "no", "."}
+    MAX_CHARS = 120
+    PATH_PREFIX_RE = re.compile(r"^/?(?:Users|home|mnt/[a-z]|cygdrive/[a-z])/[^/\s]+/")
+
+    for r in records:
+        if not isinstance(r, dict):
+            continue
+        if r.get("type") != "user":
+            continue
+        msg = r.get("message", {})
+        if not isinstance(msg, dict):
+            continue
+        content = msg.get("content")
+        text = ""
+        if isinstance(content, str):
+            text = content
+        elif isinstance(content, list):
+            # Take the first text-shaped block.
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    text = block.get("text") or ""
+                    break
+                if isinstance(block, str):
+                    text = block
+                    break
+        if not text:
+            continue
+
+        # First non-empty line (skip code-fence opens + path-noise).
+        for raw_line in text.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            if line.startswith("```") or line.startswith("~~~"):
+                continue
+            # Strip leading absolute-path prefix from "two tasks in /Users/x/..." style.
+            line = PATH_PREFIX_RE.sub("", line, count=1)
+            # Skip trivial openers (case-insensitive).
+            if line.lower().rstrip(" ?!.") in TRIVIAL:
+                continue
+            # Truncate at word boundary.
+            if len(line) > MAX_CHARS:
+                cut = line.rfind(" ", 0, MAX_CHARS - 3)
+                if cut < MAX_CHARS // 2:
+                    cut = MAX_CHARS - 3
+                line = line[:cut].rstrip() + "..."
+            return redact(line)
+    return ""
+
+
 def render_session_markdown(
     records: list[dict[str, Any]],
     jsonl_path: Path,
@@ -1167,10 +1231,17 @@ def render_session_markdown(
     # sessions were mis-tagged and grouped under the wrong chip on
     # the compiled site.
     tag_adapter = _adapter_tag(adapter_name)
+    # #471: human-readable description from the first non-trivial user
+    # turn — replaces the opaque slug-date title in listings.
+    description = derive_description(records, redact)
+    # YAML-escape inner double quotes so the frontmatter parser doesn't
+    # truncate at the first internal `"`.
+    description_safe = description.replace("\\", "\\\\").replace('"', '\\"')
     front = [
         "---",
         f'title: "{title}"',
         "type: source",
+        f'description: "{description_safe}"',
         f"tags: [{tag_adapter}, session-transcript]",
         f"date: {date_str}",
         f"source_file: raw/sessions/{started.strftime('%Y-%m-%dT%H-%M')}-{project_slug}-{slug}.md",

--- a/llmwiki/render/css.py
+++ b/llmwiki/render/css.py
@@ -255,6 +255,11 @@ kbd { display: inline-block; padding: 2px 6px; font-family: var(--mono); font-si
 .card-meta { font-size: 0.82rem; color: var(--text-secondary); }
 /* #455: small muted activity date range under the meta line. */
 .card-date-range { font-size: 0.72rem; color: var(--text-muted); margin-top: 2px; font-variant-numeric: tabular-nums; }
+/* #471: human-readable session description rendered as a subtitle on
+   session detail pages and as a small line beneath the slug in the
+   sessions index table. */
+.session-description { font-size: 0.95rem; color: var(--text-secondary); margin: -8px 0 16px; line-height: 1.5; }
+.session-cell-desc { font-size: 0.78rem; color: var(--text-muted); margin-top: 2px; line-height: 1.3; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .card-stats { font-size: 0.78rem; margin-top: 6px; }
 .card-badge { margin-top: 8px; }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.61"
+version = "1.3.62"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_session_description.py
+++ b/tests/test_session_description.py
@@ -1,0 +1,139 @@
+"""#471: derive_description extracts a 120-char human-readable summary
+from the first non-trivial user turn in a session.
+
+Edge cases covered:
+
+  - Empty / no-user-turn sessions return "".
+  - Trivial openers ("hi", "thanks", "continue") get skipped — pick
+    the next non-trivial line instead.
+  - Path-noise prefixes (`/Users/x/...`) get stripped before truncation.
+  - Code-fence opens (```) get skipped.
+  - Long lines truncate at a word boundary with "...".
+  - Output is always passed through the Redactor.
+  - The frontmatter field gets emitted by render_session_markdown.
+"""
+from __future__ import annotations
+
+from llmwiki.convert import Redactor, derive_description, render_session_markdown
+from pathlib import Path
+
+
+# ─── helpers ──────────────────────────────────────────────────────────
+
+
+def _u(text: str) -> dict:
+    """Build a minimal user-turn record."""
+    return {"type": "user", "message": {"role": "user", "content": text}}
+
+
+def _u_blocks(blocks: list[dict]) -> dict:
+    return {"type": "user", "message": {"role": "user", "content": blocks}}
+
+
+def _redactor() -> Redactor:
+    return Redactor({"redaction": {"real_username": "", "extra_patterns": []}})
+
+
+# ─── derive_description ───────────────────────────────────────────────
+
+
+def test_returns_first_user_line() -> None:
+    records = [_u("Refactor the auth middleware to use JWT cookies.")]
+    assert derive_description(records, _redactor()) == \
+        "Refactor the auth middleware to use JWT cookies."
+
+
+def test_empty_records_returns_empty_string() -> None:
+    assert derive_description([], _redactor()) == ""
+
+
+def test_no_user_turn_returns_empty_string() -> None:
+    records = [{"type": "assistant", "message": {"content": "ack"}}]
+    assert derive_description(records, _redactor()) == ""
+
+
+def test_skips_trivial_opener_picks_next_line() -> None:
+    records = [_u("hi\nactually, let's debug the failing migration test")]
+    out = derive_description(records, _redactor())
+    assert "debug the failing migration" in out
+    assert out.lower() != "hi"
+
+
+def test_skips_code_fence_opener() -> None:
+    records = [_u("```python\ndef foo():\n    pass\n```\nReview this code.")]
+    # First non-fence non-empty line is `def foo():`. We accept either
+    # that (line-by-line walk pre-fence-open) or "Review this code."
+    out = derive_description(records, _redactor())
+    assert out, "should derive something"
+    assert "```" not in out
+
+
+def test_strips_path_prefix_noise() -> None:
+    records = [_u("/Users/alice/work/proj/src/auth.py needs a JWT cookie path")]
+    out = derive_description(records, _redactor())
+    assert out.startswith("auth.py needs a JWT cookie path") or "JWT cookie" in out
+    assert "/Users/alice" not in out
+
+
+def test_truncates_at_word_boundary_around_120_chars() -> None:
+    long = (
+        "We need to refactor the authentication middleware so that the "
+        "JWT cookie path is configurable per-tenant and survives the "
+        "session-revocation pass without breaking the existing token "
+        "rotation policy that mobile clients depend on."
+    )
+    records = [_u(long)]
+    out = derive_description(records, _redactor())
+    assert len(out) <= 124  # 120 + "..." headroom
+    assert out.endswith("...")
+    # No mid-word truncation (last word should be whole).
+    assert " " in out
+
+
+def test_handles_content_as_block_list() -> None:
+    """Records sometimes carry content as a [{type:text, text:...}] list."""
+    records = [_u_blocks([{"type": "text", "text": "Block-form prompt content"}])]
+    assert derive_description(records, _redactor()) == "Block-form prompt content"
+
+
+def test_passes_output_through_redactor() -> None:
+    """Real_username in the prompt must be redacted in the description."""
+    red = Redactor({"redaction": {"real_username": "alice", "extra_patterns": []}})
+    records = [_u("Run the test suite under /Users/alice/proj")]
+    out = derive_description(records, red)
+    assert "alice" not in out
+
+
+# ─── render_session_markdown emits the field ──────────────────────────
+
+
+def test_render_session_markdown_emits_description_field() -> None:
+    records = [
+        _u("Refactor the auth middleware to use JWT cookies."),
+        {"type": "assistant", "message": {"content": "ok"}},
+    ]
+    md, slug, started = render_session_markdown(
+        records=records,
+        jsonl_path=Path("/tmp/dummy.jsonl"),
+        project_slug="demo",
+        redact=_redactor(),
+        config={},
+        is_subagent_file=False,
+        adapter_name="claude_code",
+    )
+    assert 'description: "' in md
+    assert "Refactor the auth middleware" in md
+
+
+def test_render_session_markdown_emits_empty_description_for_no_user_turn() -> None:
+    records = [{"type": "assistant", "message": {"content": "ack"}}]
+    md, _slug, _started = render_session_markdown(
+        records=records,
+        jsonl_path=Path("/tmp/dummy.jsonl"),
+        project_slug="demo",
+        redact=_redactor(),
+        config={},
+        is_subagent_file=False,
+        adapter_name="claude_code",
+    )
+    assert 'description: ""' in md


### PR DESCRIPTION
Closes #471. See CHANGELOG. Bumps to **1.3.62**.