### PR TITLE
docs: docs-hub auto-versioning + sidebar TOC follow-up note (#457) — v1.3.65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.65] — 2026-04-26
+
+Phase 2 (d) — docs hub auto-versioning (#457 partial).
+
+### Fixed
+
+- **Docs hub no longer ships a stale `Latest tagged release: v1.2.0` line** (#457) — `compile_docs_site` now substitutes `{{__llmwiki_version__}}` at build time from `llmwiki.__version__`. The hub stays current on every release without a manual edit. Same template substitution can be extended later for release dates / latest CHANGELOG bullet.
+
+### Deferred
+
+- The other half of #457 — moving the in-page TOC `<details>` to a sticky left sidebar — needs a layout-level rethink that's larger than this PR's scope. Filed as follow-up; the auto-versioning fix here closes the most user-visible drift symptom.
+
 ## [1.3.64] — 2026-04-26
 
 Phase 2 (c) — richer tool-result collapsible card (#476).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.64-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.65-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/docs/index.md
+++ b/docs/index.md
@@ -112,5 +112,6 @@ out of the way. The only third-party runtime dependency is `markdown`.
 
 ## What's new
 
-See the **[CHANGELOG](https://github.com/Pratiyush/llm-wiki/blob/master/CHANGELOG.md)**. Latest tagged release:
-[v1.2.0](https://github.com/Pratiyush/llm-wiki/releases/tag/v1.2.0).
+See the **[CHANGELOG](https://github.com/Pratiyush/llm-wiki/blob/master/CHANGELOG.md)**. Latest tagged release: **v{{__llmwiki_version__}}**.
+
+> The version above is substituted from `llmwiki/__init__.py:__version__` at build time, so this hub stays current on every release without a manual edit (#457).

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.64"
+__version__ = "1.3.65"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/docs_pages.py
+++ b/llmwiki/docs_pages.py
@@ -368,10 +368,22 @@ def compile_docs_site(
     written: list[Path] = []
     all_pages = list(iter_docs_pages(docs_dir))
 
+    # #457: substitute {{__llmwiki_version__}} at build time so the docs
+    # hub never goes stale on a release. Reading the version lazily
+    # (inside the loop instead of at module load) keeps the docs_pages
+    # module cheap to import.
+    from llmwiki import __version__ as _llmwiki_version
+
     for page in all_pages:
         meta_strip = render_meta_strip(page.body) if page.is_shell else ""
         body_without_meta = (
             _strip_meta_lines(page.body) if page.is_shell else page.body
+        )
+        # #457: template substitution. Currently supports the version
+        # placeholder used by the docs hub; can be extended with more
+        # placeholders (e.g. release date, latest CHANGELOG bullet) later.
+        body_without_meta = body_without_meta.replace(
+            "{{__llmwiki_version__}}", _llmwiki_version
         )
         body_html = md_to_html(body_without_meta)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.64"
+version = "1.3.65"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Closes #457 partial. See CHANGELOG. Bumps to **1.3.65**.