### PR TITLE
perf: synthesize_estimate_report single-walk (#596) — v1.3.66

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.66] — 2026-04-26
+
+Phase 3 (a) — synthesize-estimate single-walk perf (#596).
+
+### Fixed
+
+- **`synthesize_estimate_report` walks `raw_sessions` once, not twice** (#596, #py-m10) — the previous version walked the iterator first to bucket new vs synthesised sessions and collect the new-bucket bodies, then again via a list comprehension to materialise the full-force body list, then ran `estimate_tokens(body)` twice on each new session inside `_bucket_usd`. On a 5k-corpus that was 10k token-estimate calls + 2 full body materialisations in RAM. Single-pass version computes per-session tokens once, accumulates both bucket totals incrementally, and never holds more than one body string at a time. Cost semantics preserved (first call in each bucket pays cache_write, the rest hit the cache).
+
 ## [1.3.65] — 2026-04-26
 
 Phase 2 (d) — docs hub auto-versioning (#457 partial).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.65-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.66-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.65"
+__version__ = "1.3.66"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/cli.py
+++ b/llmwiki/cli.py
@@ -900,8 +900,35 @@ def synthesize_estimate_report(
     # inject simpler keys.  A session counts as "synthesized" if any
     # of those three keys already appears in state_keys.
     from llmwiki.synth.pipeline import RAW_SESSIONS as _RAW
+
+    # #py-m10 (#596): single-pass walk. The previous version walked
+    # raw_sessions twice — once to bucket new vs synthesised + collect
+    # body strings, once via a list comprehension to materialise the
+    # full-force body list — and then ran estimate_tokens(body) twice
+    # on each new session inside _bucket_usd. On a 5k-corpus that's
+    # 10k token-estimate calls + 2 full body materialisations in RAM.
+    # The pass below computes per-session tokens once, accumulates
+    # both bucket totals incrementally, and never holds more than one
+    # body string at a time.
     synthed = 0
-    new_bodies: list[str] = []
+    new = 0
+    incremental_usd = 0.0
+    full_force_usd = 0.0
+    incremental_first = True
+    full_force_first = True
+
+    def _add_to_bucket(fresh_tokens: int, first: bool) -> tuple[float, bool]:
+        """Return (cost, was_first?). Cost-of-this-call uses cache_hit=
+        not first, mirroring the old _bucket_usd semantics."""
+        est = estimate_cost(
+            cached_tokens=prefix_tokens,
+            fresh_tokens=fresh_tokens,
+            output_tokens=output_tokens_per_call,
+            model=chosen_model,
+            cache_hit=not first,
+        )
+        return est.usd, False  # second-and-later calls hit the cache
+
     for p, _meta, body in raw_sessions:
         keys_to_try: set[str] = set()
         name = getattr(p, "name", str(p))
@@ -915,37 +942,19 @@ def synthesize_estimate_report(
         matched = bool(keys_to_try & state_keys) or any(
             isinstance(k, str) and k.endswith(name) for k in state_keys
         )
+        body_tokens = estimate_tokens(body)
+        # Full-force bucket: every session contributes regardless of state.
+        ff_cost, full_force_first = _add_to_bucket(body_tokens, full_force_first)
+        full_force_usd += ff_cost
+        # Incremental bucket: only un-synthesised sessions contribute.
         if matched:
             synthed += 1
         else:
-            new_bodies.append(body)
-    new = corpus - synthed
-
-    def _bucket_usd(bodies: list[str]) -> float:
-        if not bodies:
-            return 0.0
-        first = estimate_cost(
-            cached_tokens=prefix_tokens,
-            fresh_tokens=estimate_tokens(bodies[0]),
-            output_tokens=output_tokens_per_call,
-            model=chosen_model,
-            cache_hit=False,
-        )
-        total = first.usd
-        for body in bodies[1:]:
-            est = estimate_cost(
-                cached_tokens=prefix_tokens,
-                fresh_tokens=estimate_tokens(body),
-                output_tokens=output_tokens_per_call,
-                model=chosen_model,
-                cache_hit=True,
+            new += 1
+            inc_cost, incremental_first = _add_to_bucket(
+                body_tokens, incremental_first
             )
-            total += est.usd
-        return total
-
-    incremental_usd = _bucket_usd(new_bodies)
-    full_force_bodies = [body for _p, _m, body in raw_sessions]
-    full_force_usd = _bucket_usd(full_force_bodies)
+            incremental_usd += inc_cost
 
     return {
         "corpus": corpus,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.65"
+version = "1.3.66"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Closes #596. See CHANGELOG. Bumps to **1.3.66**.