### PR TITLE
fix: cmd_all direct-dispatch (#583) — v1.3.68

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.68] — 2026-04-27
+
+#py-h4 (#583) — `cmd_all` direct dispatch.
+
+### Fixed
+
+- **`cmd_all` no longer round-trips through the global parser** — the post-#422 version called `build_parser()` once per invocation and re-parsed argv lists like `["build", "--out", "..."]` for each step. Semantically correct but the global parser still leaked into `cmd_all`'s contract: adding a flag to any unrelated subcommand could regress `cmd_all` if defaults shifted. Now constructs each step's `Namespace` directly with the defaults the relevant `cmd_*` expects and dispatches via a `{name: cmd_*}` map. Zero `build_parser()` calls.
+
 ## [1.3.67] — 2026-04-27
 
 Post-final-review remediation — 7 HIGH findings from the multi-agent code review (python-reviewer, security-reviewer, architect, code-reviewer, typescript-reviewer). Plus the long-deferred CLI tutorial recording (#248) and a fresh full-site UI walkthrough.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.67-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.68-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.67"
+__version__ = "1.3.68"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/cli.py
+++ b/llmwiki/cli.py
@@ -46,35 +46,70 @@ def cmd_all(args: argparse.Namespace) -> int:
       1  at least one step returned a non-zero exit status.
       2  ``--strict`` was passed and lint reported any error or warning.
     """
-    import shlex
+    # #py-h4 (#583): direct dispatch instead of round-tripping through
+    # argparse. The old version built ``["build", "--out", "..."]`` argv
+    # lists and re-parsed them via the global ``build_parser()``, which
+    # meant every flag #422 then optimised away the *per-step* re-parse,
+    # but ``cmd_all`` still depended on the global parser's full grammar
+    # — adding a flag to any unrelated subcommand could regress
+    # ``cmd_all`` if defaults shifted. Now we construct each step's
+    # Namespace directly with the defaults the relevant cmd_* expects,
+    # which is also what ``cmd_all`` was *supposed* to do per its
+    # docstring (avoid global-parser coupling).
+    def _ns(**kw: Any) -> argparse.Namespace:
+        return argparse.Namespace(**kw)
 
-    steps: list[tuple[str, list[str]]] = []
-    build_args = ["build", "--out", str(args.out)]
-    if args.search_mode:
-        build_args.extend(["--search-mode", args.search_mode])
-    steps.append(("build", build_args))
-
+    steps: list[tuple[str, str, argparse.Namespace]] = []
+    steps.append((
+        "build",
+        f"build --out {args.out} --search-mode {args.search_mode}",
+        _ns(
+            out=args.out,
+            synthesize=False,
+            claude="",
+            search_mode=args.search_mode or "auto",
+            seed_project_stubs=False,
+            vault=None,
+        ),
+    ))
     if not args.skip_graph:
-        steps.append(("graph", ["graph", "--format", "both", "--engine", args.graph_engine]))
-
-    steps.append(("export", ["export", "all", "--out", str(args.out)]))
+        steps.append((
+            "graph",
+            f"graph --format both --engine {args.graph_engine}",
+            _ns(format="both", engine=args.graph_engine),
+        ))
+    steps.append((
+        "export",
+        f"export all --out {args.out}",
+        _ns(format="all", out=args.out, topic=""),
+    ))
     # ``lint --fail-on-errors`` so error-severity issues already fail the step;
     # ``--strict`` additionally escalates warnings (checked below).
-    lint_argv = ["lint", "--fail-on-errors"] if args.strict else ["lint"]
-    steps.append(("lint", lint_argv))
+    lint_label = "lint --fail-on-errors" if args.strict else "lint"
+    steps.append((
+        "lint",
+        lint_label,
+        _ns(
+            wiki_dir=None,
+            rules=None,
+            include_llm=False,
+            json=False,
+            fail_on_errors=args.strict,
+        ),
+    ))
+
+    dispatch = {
+        "build": cmd_build,
+        "graph": cmd_graph,
+        "export": cmd_export,
+        "lint": cmd_lint,
+    }
 
     overall_rc = 0
     lint_rc: Optional[int] = None
-    # #422: build the parser ONCE and re-use for all steps. The previous
-    # version called ``build_parser()`` per step (4× per ``llmwiki all``)
-    # which (a) was wasteful argparse-tree work and (b) made every
-    # subcommand's flag set part of the global build_parser() contract
-    # — exactly the coupling cmd_all was supposed to avoid.
-    parser = build_parser()
-    for name, argv in steps:
-        print(f"\n==> llmwiki {' '.join(shlex.quote(a) for a in argv)}")
-        sub_args = parser.parse_args(argv)
-        rc = sub_args.func(sub_args)
+    for name, label, sub_args in steps:
+        print(f"\n==> llmwiki {label}")
+        rc = dispatch[name](sub_args)
         if name == "lint":
             lint_rc = rc
             continue  # lint's own exit policy is handled below

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.67"
+version = "1.3.68"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_cmd_all_parser.py
+++ b/tests/test_cmd_all_parser.py
@@ -1,10 +1,14 @@
-"""Tests for the `llmwiki all` orchestrator (closes #422).
+"""Tests for the `llmwiki all` orchestrator (closes #422 and #583).
 
-Pre-fix, `cmd_all` called `build_parser()` once *per step*, rebuilding
-the entire argparse tree four times for a single invocation. That was
-wasteful argparse work AND a coupling smell — each subcommand's flag
-set leaked into the cmd_all contract via the shared parser. Build the
-parser once and re-use the parsed namespace.
+#422: `cmd_all` was calling `build_parser()` once *per step* (4× per
+invocation). Wasteful argparse work AND a coupling smell.
+
+#py-h4 (#583): `cmd_all` then re-parsed argv lists via the global
+parser — semantically correct but the global parser still leaked into
+`cmd_all`'s contract. Rewritten to direct-dispatch: each step gets a
+Namespace constructed in-place with the defaults that subcommand
+expects, and we call `cmd_build` / `cmd_graph` / `cmd_export` /
+`cmd_lint` directly. No global parser involvement.
 """
 
 from __future__ import annotations
@@ -31,9 +35,15 @@ def _mk_args(**overrides) -> argparse.Namespace:
 # ─── Parser-build call counter ───────────────────────────────────────
 
 
-def test_cmd_all_builds_parser_once_only():
-    """Regression for #422: cmd_all must call build_parser() exactly
-    once across all steps. Previously called 4× (once per step)."""
+def test_cmd_all_does_not_use_global_parser():
+    """#py-h4 (#583): cmd_all must NOT call build_parser() at all.
+
+    Previously: 4× (#422 era), then 1× (post-#422). Now: 0× — direct
+    dispatch via cmd_* function references. Calling build_parser inside
+    cmd_all means the global parser's grammar leaks into cmd_all's
+    contract; adding a flag to any unrelated subcommand could regress
+    cmd_all if defaults shifted.
+    """
     from llmwiki import cli
 
     call_count = {"n": 0}
@@ -43,19 +53,16 @@ def test_cmd_all_builds_parser_once_only():
         call_count["n"] += 1
         return original_build_parser()
 
-    # Stub each command function so we don't actually execute build/etc.
     stub = MagicMock(return_value=0)
-
     with patch.object(cli, "build_parser", side_effect=counting_build_parser):
         with patch.object(cli, "cmd_build", stub):
             with patch.object(cli, "cmd_lint", stub):
-                with patch("llmwiki.exporters.export_all", stub):
-                    with patch.object(cli, "cmd_export", stub):
-                        cli.cmd_all(_mk_args())
+                with patch.object(cli, "cmd_export", stub):
+                    cli.cmd_all(_mk_args())
 
-    assert call_count["n"] == 1, (
+    assert call_count["n"] == 0, (
         f"cmd_all called build_parser() {call_count['n']} times "
-        f"(expected exactly 1 — see #422)"
+        f"(expected 0 — see #583)"
     )
 
 
@@ -139,89 +146,64 @@ def test_cmd_all_includes_graph_step_when_not_skipped():
     assert graph_stub.call_count == 1
 
 
-def test_cmd_all_strict_propagates_to_lint_argv():
-    """--strict adds --fail-on-errors to the lint step's argv."""
+def test_cmd_all_strict_propagates_fail_on_errors_to_lint():
+    """#py-h4 (#583): --strict sets fail_on_errors=True on the lint step."""
     from llmwiki import cli
 
-    received_argvs: list[list[str]] = []
-    original = cli.build_parser
+    lint_stub = MagicMock(return_value=0)
+    other = MagicMock(return_value=0)
+    with patch.object(cli, "cmd_build", other):
+        with patch.object(cli, "cmd_export", other):
+            with patch.object(cli, "cmd_lint", lint_stub):
+                cli.cmd_all(_mk_args(strict=True))
 
-    class WrapParser:
-        def __init__(self, real):
-            self._real = real
-        def parse_args(self, argv):
-            received_argvs.append(list(argv))
-            return self._real.parse_args(argv)
-
-    def fake_build_parser():
-        return WrapParser(original())
-
-    stub = MagicMock(return_value=0)
-    with patch.object(cli, "build_parser", side_effect=fake_build_parser):
-        with patch.object(cli, "cmd_build", stub):
-            with patch.object(cli, "cmd_export", stub):
-                with patch.object(cli, "cmd_lint", stub):
-                    cli.cmd_all(_mk_args(strict=True))
-
-    lint_argv = next((a for a in received_argvs if a and a[0] == "lint"), None)
-    assert lint_argv is not None
-    assert "--fail-on-errors" in lint_argv
+    assert lint_stub.call_count == 1
+    lint_ns = lint_stub.call_args[0][0]
+    assert lint_ns.fail_on_errors is True
 
 
-def test_cmd_all_out_dir_propagates_to_steps():
-    """--out flows through to build's --out argv."""
+def test_cmd_all_strict_false_keeps_lint_permissive():
+    """Without --strict, lint runs without fail_on_errors."""
     from llmwiki import cli
 
-    received_argvs: list[list[str]] = []
-    original = cli.build_parser
+    lint_stub = MagicMock(return_value=0)
+    other = MagicMock(return_value=0)
+    with patch.object(cli, "cmd_build", other):
+        with patch.object(cli, "cmd_export", other):
+            with patch.object(cli, "cmd_lint", lint_stub):
+                cli.cmd_all(_mk_args(strict=False))
 
-    class WrapParser:
-        def __init__(self, real):
-            self._real = real
-        def parse_args(self, argv):
-            received_argvs.append(list(argv))
-            return self._real.parse_args(argv)
+    lint_ns = lint_stub.call_args[0][0]
+    assert lint_ns.fail_on_errors is False
 
-    stub = MagicMock(return_value=0)
-    with patch.object(cli, "build_parser", side_effect=lambda: WrapParser(original())):
-        with patch.object(cli, "cmd_build", stub):
-            with patch.object(cli, "cmd_export", stub):
-                with patch.object(cli, "cmd_lint", stub):
-                    cli.cmd_all(_mk_args(out=Path("/custom/out")))
 
-    build_argv = next((a for a in received_argvs if a and a[0] == "build"), None)
-    assert build_argv is not None
-    assert "--out" in build_argv
-    out_idx = build_argv.index("--out")
-    assert build_argv[out_idx + 1] == "/custom/out"
+def test_cmd_all_out_dir_propagates_to_build_and_export():
+    """#py-h4 (#583): --out flows through to both build and export Namespaces."""
+    from llmwiki import cli
+
+    build_stub = MagicMock(return_value=0)
+    export_stub = MagicMock(return_value=0)
+    with patch.object(cli, "cmd_build", build_stub):
+        with patch.object(cli, "cmd_export", export_stub):
+            with patch.object(cli, "cmd_lint", MagicMock(return_value=0)):
+                cli.cmd_all(_mk_args(out=Path("/custom/out")))
+
+    assert build_stub.call_args[0][0].out == Path("/custom/out")
+    assert export_stub.call_args[0][0].out == Path("/custom/out")
 
 
 def test_cmd_all_search_mode_propagates_to_build():
-    """--search-mode flows through to build's argv."""
+    """#py-h4 (#583): --search-mode flows through to build's Namespace."""
     from llmwiki import cli
 
-    received_argvs: list[list[str]] = []
-    original = cli.build_parser
+    build_stub = MagicMock(return_value=0)
+    other = MagicMock(return_value=0)
+    with patch.object(cli, "cmd_build", build_stub):
+        with patch.object(cli, "cmd_export", other):
+            with patch.object(cli, "cmd_lint", other):
+                cli.cmd_all(_mk_args(search_mode="tree"))
 
-    class WrapParser:
-        def __init__(self, real):
-            self._real = real
-        def parse_args(self, argv):
-            received_argvs.append(list(argv))
-            return self._real.parse_args(argv)
-
-    stub = MagicMock(return_value=0)
-    with patch.object(cli, "build_parser", side_effect=lambda: WrapParser(original())):
-        with patch.object(cli, "cmd_build", stub):
-            with patch.object(cli, "cmd_export", stub):
-                with patch.object(cli, "cmd_lint", stub):
-                    cli.cmd_all(_mk_args(search_mode="tree"))
-
-    build_argv = next((a for a in received_argvs if a and a[0] == "build"), None)
-    assert build_argv is not None
-    assert "--search-mode" in build_argv
-    sm_idx = build_argv.index("--search-mode")
-    assert build_argv[sm_idx + 1] == "tree"
+    assert build_stub.call_args[0][0].search_mode == "tree"
 
 
 def test_cmd_all_runs_all_four_steps_by_default():


### PR DESCRIPTION
Closes #583 (`#py-h4`).

## Summary

Direct-dispatch refactor of `cmd_all`. Each pipeline step (`build` → `graph` → `export` → `lint`) now constructs its own `argparse.Namespace` inline and calls the `cmd_*` function directly via a `{name: fn}` map. The global `build_parser()` is no longer involved at all — 0 calls per `llmwiki all` (was 1 post-#422, was 4 pre-#422).

Pre-fix, even after #422 collapsed the per-step parser rebuild, `cmd_all` still re-parsed argv lists like `["build", "--out", "..."]` through the global parser. That meant every subcommand's argparse grammar was part of `cmd_all`'s implicit contract: adding a flag to any unrelated subcommand could regress `cmd_all` if defaults shifted.

## What's new

| Surface | Change |
|---|---|
| CLI | `cmd_all` no longer imports / depends on `build_parser` |
| CLI | Internal `_ns(**kw)` helper builds per-step Namespaces with the defaults each `cmd_*` expects |
| CLI | Step dispatch via `{"build": cmd_build, "graph": cmd_graph, ...}` map (data, not control flow) |
| Tests | `test_cmd_all_parser.py` assertions migrated from captured-argv inspection to Namespace-attribute inspection on patched `cmd_*` |

## Behavioural delta

| Surface | Before | After |
|---|---|---|
| `build_parser()` calls per `llmwiki all` | 1 | 0 |
| Failure mode if a sibling subcommand's default shifts | `cmd_all` could silently drift | unaffected |
| Step `Namespace` source | argparse re-parse of synthesised argv | direct construction with explicit defaults |
| Step `Namespace` shape | exactly what argparse produces | exactly what each `cmd_*` reads (verified by inspection) |

## Test plan

- [x] `pytest tests/test_cmd_all_parser.py` — 11/11 pass
- [x] Full `pytest tests/` — all pass (no regressions)
- [x] `test_cmd_all_does_not_use_global_parser` asserts 0 `build_parser()` calls (renamed from `_builds_parser_once_only`, the post-#422 invariant)
- [x] `test_cmd_all_strict_propagates_fail_on_errors_to_lint` asserts `lint` Namespace receives `fail_on_errors=True` when `--strict`
- [x] `test_cmd_all_strict_false_keeps_lint_permissive` covers the inverse
- [x] `test_cmd_all_out_dir_propagates_to_build_and_export` asserts `--out` flows to BOTH steps' Namespaces
- [x] `test_cmd_all_search_mode_propagates_to_build` asserts `--search-mode` lands on the build step
- [x] `test_cmd_all_runs_all_four_steps_by_default` asserts ordering
- [x] `test_cmd_all_skip_graph_omits_graph_step` and `test_cmd_all_includes_graph_step_when_not_skipped` cover both branches
- [x] `test_cmd_all_fail_fast_aborts_on_first_failure` and `test_cmd_all_propagates_failure_when_not_fail_fast` cover error paths
- [ ] CI green

## Bundle

- `llmwiki/cli.py` — `cmd_all` rewritten (~50 LOC); old argv-build + `parser.parse_args` loop replaced with `_ns()` helper + dispatch map
- `tests/test_cmd_all_parser.py` — 4 tests rewritten to inspect Namespaces instead of captured argvs (intent preserved, implementation-specific assertions removed)
- `llmwiki/__init__.py`, `pyproject.toml` — version `1.3.67` → `1.3.68`
- `README.md` — version badge bump
- `CHANGELOG.md` — `[1.3.68]` entry under Fixed

## Next

After merge: tag `v1.3.68`, then continue serial-PR work on `#py-h7` (#585 — Ollama prompt double-render).