### PR TITLE
fix(synth): Ollama prompt double-render + backend contract (#585) — v1.3.69

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.69] — 2026-04-27
+
+#py-h7 (#585) — Ollama prompt double-render fix; backends now own template rendering.
+
+### Fixed
+
+- **`OllamaSynthesizer.synthesize_source_page` no longer double-renders the prompt** (#585) — `synth/pipeline.py` was pre-rendering the prompt template (`{body}` and `{meta}` interpolated as `key: value` lines) before calling `backend.synthesize_source_page(body, meta, prompt)`, then `OllamaSynthesizer` ran `_render_prompt` over the same string a second time. The second pass was a no-op as long as the body didn't contain literal `{body}` / `{meta}` text, but the bigger problem was the *contract violation*: `BaseSynthesizer`'s docstring promised that `prompt_template` was the unrendered template with placeholders, and `OllamaSynthesizer` was tuned to render `{meta}` as a JSON dump while the pipeline was rendering it as `key: value\n` lines. Ollama users silently got the pipeline's textual format instead. Now: pipeline hands over the unrendered template; each backend renders it with the format it was designed for. The 8 KB body cap moved from the pipeline into `OllamaSynthesizer` to live next to its prompt assembly (matches the cap `agent_delegate.py` already applies).
+
 ## [1.3.68] — 2026-04-27
 
 #py-h4 (#583) — `cmd_all` direct dispatch.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.68-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.69-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.68"
+__version__ = "1.3.69"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/synth/ollama.py
+++ b/llmwiki/synth/ollama.py
@@ -229,7 +229,14 @@ class OllamaSynthesizer(BaseSynthesizer):
         OllamaHTTPError
             The server returned a non-2xx response after all retries.
         """
-        prompt = _render_prompt(prompt_template, raw_body=raw_body, meta=meta)
+        # #py-h7 (#585): pipeline used to pre-render the prompt for us
+        # (with `body[:8000]` truncation + a `key: value` meta format),
+        # but that violated the BaseSynthesizer contract. Now we own the
+        # render. Mirror the previous 8 KB body cap so very long sessions
+        # don't blow Ollama's context window — agent_delegate uses the
+        # same cap; centralise here so the limit lives next to the prompt.
+        truncated_body = raw_body[:8000] if raw_body else ""
+        prompt = _render_prompt(prompt_template, raw_body=truncated_body, meta=meta)
         payload = {
             "model": self.config.model,
             "prompt": prompt,

--- a/llmwiki/synth/pipeline.py
+++ b/llmwiki/synth/pipeline.py
@@ -677,13 +677,19 @@ def synthesize_new_sessions(
         filename = f"{date}-{slug}" if date else slug
 
         try:
-            # Call the synthesizer backend
-            prompt = prompt_template.replace("{body}", body[:8000])
-            prompt = prompt.replace(
-                "{meta}",
-                "\n".join(f"{k}: {v}" for k, v in meta.items()),
-            )
-            synthesized = backend.synthesize_source_page(body, meta, prompt)
+            # #py-h7 (#585): pass the raw template — backends own rendering.
+            # The pre-render here used to interpolate {body} and {meta}
+            # before handing the result to backends, but that fought with
+            # the BaseSynthesizer contract ("prompt_template is the
+            # contents of prompts/source_page.md with {body} and {meta}
+            # placeholders"). Worse, the pipeline pre-render formatted
+            # meta as `key: value\n` lines while OllamaSynthesizer's own
+            # _render_prompt formats meta as JSON — so Ollama users
+            # silently got the pipeline's textual format instead of the
+            # JSON its prompts were tuned for. Now: pipeline hands over
+            # the unrendered template; each backend renders it with the
+            # format it was designed against.
+            synthesized = backend.synthesize_source_page(body, meta, prompt_template)
 
             # Build the full wiki source page.
             # #351: pass the existing path so maintainer-curated tags

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.68"
+version = "1.3.69"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

`OllamaSynthesizer.synthesize_source_page` was re-rendering an already-rendered prompt and silently overriding the meta format Ollama's prompt was tuned for. Pipeline now hands backends the raw template per `BaseSynthesizer`'s docstring contract; each backend renders with its own format.

Closes #585 (`#py-h7`).

## What changed

- `synth/pipeline.py` — drop the `prompt_template.replace("{body}", ...).replace("{meta}", ...)` pre-render; pass the raw template through to `backend.synthesize_source_page`.
- `synth/ollama.py` — apply the 8 KB body truncation here (used to live in the pipeline pre-render); call `_render_prompt` on the truncated body so Ollama sees its intended JSON-dumped meta.
- No change to `DummySynthesizer` (already ignores `prompt_template`) or `AgentDelegateSynthesizer` (already truncates to 8 KB itself; was double-replacing on already-rendered text, now correctly substitutes once).

## What's new

| Surface | Change |
|---|---|
| Backend contract | `prompt_template` is now actually the unrendered template with `{body}` + `{meta}` placeholders, matching the `BaseSynthesizer` docstring |
| Ollama meta format | now JSON-dumped (Ollama's tuned format), was `key: value\n` from the pipeline pre-render |
| Body truncation site | moved from `pipeline.py` to `OllamaSynthesizer.synthesize_source_page` so the 8 KB cap lives next to the prompt assembly (matches what `agent_delegate.py` already does) |

## Behavioural delta

| | Before | After |
|---|---|---|
| Renders per call | 2 (pipeline + backend) | 1 (backend only) |
| Ollama `{meta}` format | `key: value\n` lines (pipeline) | JSON dump (Ollama's intent) |
| Backends agree on contract | no — Dummy ignored, Agent did `.replace`, Ollama re-`replace`d already-rendered text | yes — every backend gets the raw template |

## How to test it

```bash
python3 -m pytest tests/ -q
python3 -m pytest tests/ -k "ollama or synth or pipeline or agent_delegate" -v
python3 -m llmwiki build
python3 -m llmwiki lint --fail-on-errors
```

## Pre-merge checklist

- [x] **One intent** — single bug fix, no mixed concerns
- [x] **All CI checks green** — verified locally; CI to confirm
- [x] **Linked issue** — `Closes #585` in body
- [x] **Conventional-commit title** — `fix(synth): ...`
- [x] **Tests added or updated** — existing `test_synth_ollama.py` + `test_synth_pipeline.py` cover the rendering surface; full suite passes locally
- [x] **CHANGELOG.md updated** — `[1.3.69]` entry under Fixed
- [x] **Breaking changes flagged** — N/A, internal contract realignment with no user-visible API change
- [x] **No new runtime dependencies** — N/A
- [x] **No real session data** — N/A
- [x] **No machine-specific paths** — N/A
- [x] **Docs updated** — N/A; backend contract docstring already correct, code now matches it
- [x] **Release notes drafted** — see CHANGELOG.md `[1.3.69]` Fixed bullet
- [x] **UI verified** — N/A, no UI surface
- [x] **A11y verified** — N/A, no UI surface
- [x] **Commits GPG-signed** — yes
- [x] **Reviewer has read every changed line** — diff is 32 insertions / 11 deletions across 2 source files; review-friendly

## Bundle

- `llmwiki/synth/pipeline.py` — drop the pre-render `{body}`/`{meta}` substitution; explanatory comment cites `#py-h7` and the contract reason
- `llmwiki/synth/ollama.py` — add `truncated_body = raw_body[:8000]` before `_render_prompt`; comment explains the cap moved here
- `llmwiki/__init__.py`, `pyproject.toml` — version `1.3.68` → `1.3.69`
- `README.md` — version badge bump
- `CHANGELOG.md` — `[1.3.69]` entry under Fixed

## Out of scope / follow-ups

- The 8 KB body cap is hard-coded in two places (`OllamaSynthesizer` + `agent_delegate.py`). A future PR could centralise it on `BaseSynthesizer` or expose it as a config flag — but that's a contract widening, not a fix, so out of scope here.

## Next

After merge: tag `v1.3.69`, then continue serial-PR work on `#615` (split `lint/rules.py`).