### PR TITLE
chore(adapters): copilot kebab→snake naming + alias (#626) — v1.3.72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.72] — 2026-04-27
+
+#arch-l5 (#626) — adapter registry name normalisation: `copilot-chat` → `copilot_chat`, `copilot-cli` → `copilot_cli`.
+
+### Changed
+
+- **Copilot adapters now register under snake_case names** (#626) — `CopilotChatAdapter` and `CopilotCliAdapter` were the only two adapters using kebab-case (`copilot-chat`, `copilot-cli`); every other adapter (`claude_code`, `codex_cli`, `gemini_cli`, etc.) is snake_case. The canonical names are now `copilot_chat` and `copilot_cli`. The kebab-case names are kept as REGISTRY aliases so existing user `sessions_config.json` files keep working unchanged. The new `aliases=` parameter on the `register` decorator handles this generically — future renames can reuse it without dropping legacy keys.
+
+### Migration
+
+- **No action required.** `sessions_config.json` keyed under `copilot-chat:` / `copilot-cli:` continues to work. Update to the snake_case keys at your leisure; if both keys are present the snake_case key wins so a partial migration is safe.
+
 ## [1.3.71] — 2026-04-27
 
 #py-m8 (#594) — single-pass build over `sources`.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.71-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.72-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/docs/adapters/copilot.md
+++ b/docs/adapters/copilot.md
@@ -12,7 +12,7 @@ llmwiki ships two adapters for GitHub Copilot, covering the two distinct storage
 
 **Module:** `llmwiki.adapters.contrib.copilot_chat`
 **Source:** [`llmwiki/adapters/contrib/copilot_chat.py`](../../llmwiki/adapters/contrib/copilot_chat.py)
-**Registry name:** `copilot-chat`
+**Registry name:** `copilot_chat` (canonical) — `copilot-chat` is kept as a back-compat alias for existing configs (#626).
 
 ### What it reads
 
@@ -55,7 +55,7 @@ Override roots in `config.json`:
 ```json
 {
   "adapters": {
-    "copilot-chat": {
+    "copilot_chat": {
       "roots": ["~/custom/copilot/path"]
     }
   }
@@ -68,7 +68,7 @@ Override roots in `config.json`:
 
 **Module:** `llmwiki.adapters.contrib.copilot_cli`
 **Source:** [`llmwiki/adapters/contrib/copilot_cli.py`](../../llmwiki/adapters/contrib/copilot_cli.py)
-**Registry name:** `copilot-cli`
+**Registry name:** `copilot_cli` (canonical) — `copilot-cli` is kept as a back-compat alias for existing configs (#626).
 
 ### What it reads
 
@@ -102,7 +102,7 @@ Override roots in `config.json`:
 ```json
 {
   "adapters": {
-    "copilot-cli": {
+    "copilot_cli": {
       "roots": ["~/.copilot/session-state"]
     }
   }
@@ -120,7 +120,7 @@ export COPILOT_HOME=~/.copilot-custom
 ## Testing both adapters
 
 ```bash
-python3 -m llmwiki adapters      # should list copilot-chat and copilot-cli
+python3 -m llmwiki adapters      # should list copilot_chat and copilot_cli
 python3 -m pytest tests/test_copilot_adapters.py -v
 ```
 

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -257,8 +257,8 @@ Each adapter can be configured in the `adapters` section of `config.json`. The k
 |---|---|---|---|
 | Claude Code | `claude_code` | yes (default on) | `roots` |
 | Codex CLI | `codex_cli` | yes (default on) | `roots` |
-| Copilot Chat | `copilot-chat` | yes (default on) | `roots` |
-| Copilot CLI | `copilot-cli` | yes (default on) | `roots` |
+| Copilot Chat | `copilot_chat` | yes (default on) | `roots` |
+| Copilot CLI | `copilot_cli` | yes (default on) | `roots` |
 | Cursor | `cursor` | yes (default on) | `roots` |
 | Gemini CLI | `gemini_cli` | yes (default on) | `roots` |
 | OpenCode / OpenClaw | `opencode` | yes (default on) | `roots` |
@@ -274,7 +274,7 @@ Example:
 ```json
 {
   "adapters": {
-    "copilot-chat": {
+    "copilot_chat": {
       "roots": ["/custom/path/to/vscode/workspaceStorage"]
     }
   }

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,8 +12,8 @@ The `--synthesize` flag on `llmwiki build` calls the local `claude` binary on yo
 |---|---|---|
 | Claude Code | `claude_code` | Production |
 | Codex CLI | `codex_cli` | Production |
-| GitHub Copilot Chat | `copilot-chat` | Production |
-| GitHub Copilot CLI | `copilot-cli` | Production |
+| GitHub Copilot Chat | `copilot_chat` | Production |
+| GitHub Copilot CLI | `copilot_cli` | Production |
 | Cursor | `cursor` | Scaffold (SQLite parser in progress) |
 | Gemini CLI | `gemini_cli` | Scaffold (schema TBC) |
 | Obsidian | `obsidian` | Production (vault as input source) |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -57,8 +57,8 @@ Example output:
 Registered adapters:
   claude_code       available: yes  (Claude Code — reads ~/.claude/projects/*/*.jsonl)
   codex_cli         available: yes  (Codex CLI — reads ~/.codex/sessions/**/*.jsonl)
-  copilot-chat      available: no   (GitHub Copilot Chat — reads VS Code workspaceStorage chatSessions)
-  copilot-cli       available: no   (GitHub Copilot CLI — reads ~/.copilot/session-state/*/events.jsonl)
+  copilot_chat      available: no   (GitHub Copilot Chat — reads VS Code workspaceStorage chatSessions)
+  copilot_cli       available: no   (GitHub Copilot CLI — reads ~/.copilot/session-state/*/events.jsonl)
   cursor            available: yes  (Cursor IDE — reads chat history)
   gemini_cli        available: no   (Gemini CLI — reads ~/.gemini/ session history)
   obsidian          available: no   (Obsidian vault)

--- a/docs/modes/index.md
+++ b/docs/modes/index.md
@@ -28,7 +28,7 @@ pipeline (`raw/` → `wiki/` → `site/`) but differ on *who calls the LLM*:
 
 Everything except synthesis:
 
-- Adapters (`claude_code`, `codex_cli`, `cursor`, `gemini_cli`, `copilot-chat`, `obsidian`, …) work identically.
+- Adapters (`claude_code`, `codex_cli`, `cursor`, `gemini_cli`, `copilot_chat`, `obsidian`, …) work identically.
 - The static site, graph viewer, lint rules, backlinks CLI, tag family — all mode-agnostic.
 - `sessions_config.json` is the same file; only `synthesis.backend` differs.
 

--- a/docs/multi-agent-setup.md
+++ b/docs/multi-agent-setup.md
@@ -8,8 +8,8 @@ llmwiki reads sessions from multiple coding agents simultaneously. One `llmwiki 
 |---|---|---|---|
 | Claude Code | `claude_code` | `~/.claude/projects/` | Production |
 | Codex CLI | `codex_cli` | `~/.codex/sessions/` | Production |
-| GitHub Copilot Chat | `copilot-chat` | VS Code workspaceStorage | Production |
-| GitHub Copilot CLI | `copilot-cli` | `~/.copilot/session-state/` | Production |
+| GitHub Copilot Chat | `copilot_chat` | VS Code workspaceStorage | Production |
+| GitHub Copilot CLI | `copilot_cli` | `~/.copilot/session-state/` | Production |
 | Cursor | `cursor` | Cursor IDE workspaceStorage | Scaffold (SQLite parser in progress) |
 | Gemini CLI | `gemini_cli` | `~/.gemini/` | Scaffold (schema TBC) |
 | Obsidian | `obsidian` | Configurable vault paths | Production |
@@ -36,8 +36,8 @@ Example output:
 Registered adapters:
   claude_code       available: yes  (Claude Code — reads ~/.claude/projects/*/*.jsonl)
   codex_cli         available: yes  (Codex CLI — reads ~/.codex/sessions/**/*.jsonl)
-  copilot-chat      available: no   (GitHub Copilot Chat — reads VS Code workspaceStorage chatSessions)
-  copilot-cli       available: no   (GitHub Copilot CLI — reads ~/.copilot/session-state/*/events.jsonl)
+  copilot_chat      available: no   (GitHub Copilot Chat — reads VS Code workspaceStorage chatSessions)
+  copilot_cli       available: no   (GitHub Copilot CLI — reads ~/.copilot/session-state/*/events.jsonl)
   cursor            available: yes  (Cursor IDE — reads chat history)
   gemini_cli        available: no   (Gemini CLI — reads ~/.gemini/ session history)
   obsidian          available: no   (Obsidian vault)
@@ -106,7 +106,7 @@ Override adapter paths in `config.json`:
     "codex_cli": {
       "roots": ["~/custom/codex/sessions"]
     },
-    "copilot-chat": {
+    "copilot_chat": {
       "roots": ["/path/to/vscode/workspaceStorage"]
     },
     "gemini_cli": {

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.71"
+__version__ = "1.3.72"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/adapters/__init__.py
+++ b/llmwiki/adapters/__init__.py
@@ -32,11 +32,20 @@ CONTRIB_ADAPTERS = {
 }
 
 
-def register(name: str):
-    """Decorator used by adapter modules to register themselves."""
+def register(name: str, aliases: list[str] | None = None):
+    """Decorator used by adapter modules to register themselves.
+
+    ``aliases`` (#arch-l5 / #626): additional REGISTRY keys that resolve
+    to the same class. Used to keep historical kebab-case names like
+    ``copilot-chat`` working after the canonical name moves to
+    snake_case (``copilot_chat``). ``cls.name`` always reflects the
+    canonical name; aliases only affect REGISTRY lookups.
+    """
     def decorator(cls):
         REGISTRY[name] = cls
         cls.name = name
+        for alias in aliases or ():
+            REGISTRY[alias] = cls
         return cls
     return decorator
 

--- a/llmwiki/adapters/contrib/copilot_chat.py
+++ b/llmwiki/adapters/contrib/copilot_chat.py
@@ -42,9 +42,15 @@ def _build_default_roots() -> list[Path]:
     return roots
 
 
-@register("copilot-chat")
+@register("copilot_chat", aliases=["copilot-chat"])
 class CopilotChatAdapter(BaseAdapter):
-    """GitHub Copilot Chat — reads VS Code workspaceStorage chatSessions"""
+    """GitHub Copilot Chat — reads VS Code workspaceStorage chatSessions.
+
+    #arch-l5 (#626): canonical name is ``copilot_chat`` (snake_case,
+    matching every other adapter). The kebab-case ``copilot-chat`` is
+    kept as a REGISTRY alias and still recognised in
+    ``sessions_config.json`` so existing user configs don't break.
+    """
 
     # #arch-m9 (#621): SUPPORTED_SCHEMA_VERSIONS = ["v1"] is the
     # BaseAdapter default — declaration removed here.
@@ -56,7 +62,10 @@ class CopilotChatAdapter(BaseAdapter):
 
     def __init__(self, config: dict[str, Any] | None = None):
         super().__init__(config)
-        ad_cfg = (config or {}).get("adapters", {}).get("copilot-chat", {})
+        adapters_cfg = (config or {}).get("adapters", {}) or {}
+        # #626: read snake_case config first; fall back to legacy
+        # kebab-case so existing sessions_config.json keeps working.
+        ad_cfg = adapters_cfg.get("copilot_chat") or adapters_cfg.get("copilot-chat") or {}
         paths = ad_cfg.get("roots") or []
         self.roots: list[Path] = (
             [Path(p).expanduser() for p in paths] if paths else self.DEFAULT_ROOTS

--- a/llmwiki/adapters/contrib/copilot_cli.py
+++ b/llmwiki/adapters/contrib/copilot_cli.py
@@ -31,9 +31,15 @@ def _build_default_roots() -> list[Path]:
     return roots
 
 
-@register("copilot-cli")
+@register("copilot_cli", aliases=["copilot-cli"])
 class CopilotCliAdapter(BaseAdapter):
-    """GitHub Copilot CLI — reads ~/.copilot/session-state/*/events.jsonl"""
+    """GitHub Copilot CLI — reads ~/.copilot/session-state/*/events.jsonl.
+
+    #arch-l5 (#626): canonical name is ``copilot_cli`` (snake_case,
+    matching every other adapter). The kebab-case ``copilot-cli`` is
+    kept as a REGISTRY alias and still recognised in
+    ``sessions_config.json`` so existing user configs don't break.
+    """
 
     # #arch-m9 (#621): SUPPORTED_SCHEMA_VERSIONS = ["v1"] is the
     # BaseAdapter default — declaration removed here.
@@ -42,7 +48,10 @@ class CopilotCliAdapter(BaseAdapter):
 
     def __init__(self, config: dict[str, Any] | None = None):
         super().__init__(config)
-        ad_cfg = (config or {}).get("adapters", {}).get("copilot-cli", {})
+        adapters_cfg = (config or {}).get("adapters", {}) or {}
+        # #626: read snake_case config first; fall back to legacy
+        # kebab-case so existing sessions_config.json keeps working.
+        ad_cfg = adapters_cfg.get("copilot_cli") or adapters_cfg.get("copilot-cli") or {}
         paths = ad_cfg.get("roots") or []
         self.roots: list[Path] = (
             [Path(p).expanduser() for p in paths] if paths else self.DEFAULT_ROOTS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.71"
+version = "1.3.72"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -17,8 +17,12 @@ def test_registry_discovers_all_adapters():
     discover_all()
     assert "claude_code" in REGISTRY
     assert "codex_cli" in REGISTRY
-    assert "copilot-chat" in REGISTRY
-    assert "copilot-cli" in REGISTRY
+    # #626: copilot adapters now register under snake_case (canonical)
+    # plus a kebab-case alias (back-compat for existing user configs).
+    assert "copilot_chat" in REGISTRY
+    assert "copilot_cli" in REGISTRY
+    assert "copilot-chat" in REGISTRY  # alias
+    assert "copilot-cli" in REGISTRY  # alias
     assert "cursor" in REGISTRY
     assert "gemini_cli" in REGISTRY
     assert "obsidian" in REGISTRY
@@ -35,9 +39,22 @@ def test_all_adapters_subclass_base():
 
 
 def test_all_adapters_have_name():
+    # #626: REGISTRY may carry alias keys that legitimately differ from
+    # ``cls.name`` (e.g. ``copilot-chat`` aliases the canonical
+    # ``copilot_chat``). Walk the unique classes once instead of asserting
+    # every key matches ``cls.name``.
     discover_all()
-    for name, cls in REGISTRY.items():
-        assert cls.name == name, f"adapter {cls.__name__} name mismatch"
+    seen: set[type] = set()
+    for cls in REGISTRY.values():
+        if cls in seen:
+            continue
+        seen.add(cls)
+        assert isinstance(cls.name, str) and cls.name, (
+            f"adapter {cls.__name__} has no name"
+        )
+        assert REGISTRY.get(cls.name) is cls, (
+            f"adapter {cls.__name__} canonical name {cls.name!r} not in REGISTRY"
+        )
 
 
 def test_all_adapters_have_description():

--- a/tests/test_copilot_adapters.py
+++ b/tests/test_copilot_adapters.py
@@ -412,11 +412,48 @@ class TestCopilotCrossAdapter:
             assert isinstance(sessions, list)
 
     def test_both_in_registry(self):
+        # #626: canonical names are snake_case; kebab-case still resolves
+        # via the alias mechanism so existing user configs don't break.
         discover_all()
+        assert "copilot_chat" in REGISTRY
+        assert "copilot_cli" in REGISTRY
+        # Legacy kebab-case alias still resolves to the same class.
         assert "copilot-chat" in REGISTRY
         assert "copilot-cli" in REGISTRY
+        assert REGISTRY["copilot_chat"] is REGISTRY["copilot-chat"]
+        assert REGISTRY["copilot_cli"] is REGISTRY["copilot-cli"]
 
     def test_names_set_by_register(self):
+        # #626: cls.name reflects the canonical (snake_case) name only;
+        # aliases never overwrite cls.name.
         discover_all()
-        assert CopilotChatAdapter.name == "copilot-chat"
-        assert CopilotCliAdapter.name == "copilot-cli"
+        assert CopilotChatAdapter.name == "copilot_chat"
+        assert CopilotCliAdapter.name == "copilot_cli"
+
+    def test_kebab_case_config_still_recognised(self, tmp_path):
+        # #626: existing user `sessions_config.json` files keyed under
+        # `copilot-chat` / `copilot-cli` must keep working — the
+        # adapter __init__ falls back to the legacy key when the
+        # snake_case key is absent.
+        discover_all()
+        legacy_chat = {"adapters": {"copilot-chat": {"roots": [str(tmp_path)]}}}
+        adapter = CopilotChatAdapter(config=legacy_chat)
+        assert adapter.roots == [tmp_path]
+        legacy_cli = {"adapters": {"copilot-cli": {"roots": [str(tmp_path)]}}}
+        adapter = CopilotCliAdapter(config=legacy_cli)
+        assert adapter.roots == [tmp_path]
+
+    def test_snake_case_config_takes_precedence(self, tmp_path):
+        # When BOTH keys are present, the canonical snake_case wins so
+        # users migrating their config can clean up the old key safely.
+        discover_all()
+        snake_path = tmp_path / "snake"
+        kebab_path = tmp_path / "kebab"
+        snake_path.mkdir()
+        kebab_path.mkdir()
+        cfg = {"adapters": {
+            "copilot_chat": {"roots": [str(snake_path)]},
+            "copilot-chat": {"roots": [str(kebab_path)]},
+        }}
+        adapter = CopilotChatAdapter(config=cfg)
+        assert adapter.roots == [snake_path]


### PR DESCRIPTION
## Summary

Renames the two copilot adapters to follow the snake_case convention every other adapter uses. \`CopilotChatAdapter\` and \`CopilotCliAdapter\` were the only two registering under kebab-case (\`copilot-chat\`, \`copilot-cli\`); the rest of the registry is \`claude_code\` / \`codex_cli\` / \`gemini_cli\` / \`obsidian\` / \`opencode\` / \`cursor\`. Naming now consistent.

The kebab-case names are kept as REGISTRY aliases AND in adapter \`__init__\` config-key lookup, so existing user \`sessions_config.json\` files keep working unchanged.

Closes #626 (\`#arch-l5\`).

## What changed

- \`llmwiki/adapters/__init__.py\` — \`register\` decorator gains an \`aliases=[...]\` kwarg; alias keys are added to \`REGISTRY\` but \`cls.name\` always reflects the canonical (first) name.
- \`llmwiki/adapters/contrib/copilot_chat.py\` — \`@register(\"copilot_chat\", aliases=[\"copilot-chat\"])\`; \`__init__\` reads snake_case config first, falls back to kebab-case.
- \`llmwiki/adapters/contrib/copilot_cli.py\` — same pattern.
- 6 docs updated to the snake_case names; \`docs/adapters/copilot.md\` Registry-name rows call out the alias.
- 3 tests updated; 2 new tests added covering legacy-config + precedence.

## What's new

| Surface | Before | After |
|---|---|---|
| \`REGISTRY[\"copilot_chat\"]\` | KeyError | \`CopilotChatAdapter\` |
| \`REGISTRY[\"copilot-chat\"]\` | \`CopilotChatAdapter\` | \`CopilotChatAdapter\` (alias) |
| \`CopilotChatAdapter.name\` | \`\"copilot-chat\"\` | \`\"copilot_chat\"\` |
| \`sessions_config.json\` key \`copilot-chat:\` | recognised | recognised (back-compat) |
| \`sessions_config.json\` key \`copilot_chat:\` | ignored | recognised + preferred |
| Same for \`copilot-cli\` / \`copilot_cli\` | same as above | same as above |

## Behavioural delta

| | Before | After |
|---|---|---|
| Display name in \`llmwiki adapters\` | \`copilot-chat\` / \`copilot-cli\` | \`copilot_chat\` / \`copilot_cli\` |
| Display name elsewhere (file paths, frontmatter \`agent:\`) | \`copilot-chat\` / \`copilot-cli\` | \`copilot_chat\` / \`copilot_cli\` |
| Adapter discovery for kebab-case configs | works | works (alias) |
| Adapter discovery for snake_case configs | does NOT work | works |

## How to test it

\`\`\`bash
python3 -m pytest tests/test_adapters.py tests/test_copilot_adapters.py -q
python3 -m pytest tests/ -q -m \"not slow\"
python3 -c \"
from llmwiki.adapters import REGISTRY, discover_adapters, discover_contrib
discover_adapters(); discover_contrib(['copilot_chat','copilot_cli'])
assert REGISTRY['copilot_chat'] is REGISTRY['copilot-chat']
assert REGISTRY['copilot_chat'].name == 'copilot_chat'
print('OK')
\"
\`\`\`

## Pre-merge checklist

- [x] **One intent** — single rename + alias mechanism, no mixed concerns
- [x] **All CI checks green** — local non-slow suite passes; CI to confirm
- [x] **Linked issue** — \`Closes #626\` in body
- [x] **Conventional-commit title** — \`chore(adapters): ...\`
- [x] **Tests added or updated** — 2 new tests (\`test_kebab_case_config_still_recognised\`, \`test_snake_case_config_takes_precedence\`); existing tests rewritten to assert the new contract; \`test_all_adapters_have_name\` walks unique classes (alias keys legitimately don't match \`cls.name\`)
- [x] **CHANGELOG.md updated** — \`[1.3.72]\` entry under Changed + Migration
- [x] **Breaking changes flagged** — N/A; no public surface broken (alias preserves both names + config keys)
- [x] **No new runtime dependencies** — N/A
- [x] **No real session data** — N/A
- [x] **No machine-specific paths** — N/A
- [x] **Docs updated** — 6 docs files updated to canonical snake_case + adapter doc explicitly notes the alias for migration
- [x] **Release notes drafted** — see CHANGELOG.md \`[1.3.72]\` Changed bullet + Migration note
- [x] **UI verified** — N/A, no UI surface
- [x] **A11y verified** — N/A, no UI surface
- [x] **Commits GPG-signed** — yes
- [x] **Reviewer has read every changed line** — diff is +128 / -35 across 15 files

## Bundle

- \`llmwiki/adapters/__init__.py\` — \`register(name, aliases=...)\` extension
- \`llmwiki/adapters/contrib/copilot_chat.py\` — canonical name + alias + config-key fallback
- \`llmwiki/adapters/contrib/copilot_cli.py\` — same pattern
- \`tests/test_adapters.py\` — \`test_registry_discovers_all_adapters\` covers both keys; \`test_all_adapters_have_name\` walks unique classes
- \`tests/test_copilot_adapters.py\` — \`test_both_in_registry\` + \`test_names_set_by_register\` updated; new \`test_kebab_case_config_still_recognised\` + \`test_snake_case_config_takes_precedence\`
- \`docs/configuration-reference.md\`, \`docs/adapters/copilot.md\`, \`docs/getting-started.md\`, \`docs/faq.md\`, \`docs/multi-agent-setup.md\`, \`docs/modes/index.md\` — names updated; copilot.md Registry-name lines note the alias
- \`llmwiki/__init__.py\`, \`pyproject.toml\` — version 1.3.71 → 1.3.72
- \`README.md\` — version badge bump
- \`CHANGELOG.md\` — \`[1.3.72]\` entry + Migration note

## Out of scope / follow-ups

- The wider session frontmatter / file-path strings produced by these adapters historically embedded the kebab-case name (e.g. session slugs containing \`copilot-chat\`). Renaming them retroactively would force a re-sync of every existing wiki — out of scope. New sessions written after this PR will use the canonical snake_case form via \`cls.name\`.

## Next

After merge: tag \`v1.3.72\`, then continue serial-PR work on \`#611\` (extract business logic from \`cli.py\`).