### PR TITLE
refactor(cli): extract business logic to domain modules (#611) — v1.3.73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.73] — 2026-04-27
+
+#arch-h8 (#611) — extract business logic out of `cli.py` into domain modules.
+
+### Changed
+
+- **`synthesize_estimate_report` moved to `llmwiki/synth/estimate.py`** (#611) — the G-07 / #293 incremental-vs-full-force cost-model walk is non-trivial business logic that doesn't belong in a CLI shim. New module sits next to the rest of the synth pipeline. Re-exported from `llmwiki.cli` so the existing `from llmwiki.cli import synthesize_estimate_report` import path keeps working.
+- **`_adapter_status` moved to `llmwiki/adapters/status.py`** (#611) — same reasoning: the configured / will_fire label decision is adapter-domain logic, not CLI presentation. Renamed to `adapter_status` (no leading underscore) at the new module path; cli.py re-exports as `_adapter_status` for back-compat.
+- **`cli.py` shrunk from 1,395 → 1,234 LOC** — the file is still a CLI but is now closer to argparse-setup + dispatch, not a kitchen-sink module.
+
 ## [1.3.72] — 2026-04-27
 
 #arch-l5 (#626) — adapter registry name normalisation: `copilot-chat` → `copilot_chat`, `copilot-cli` → `copilot_cli`.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.72-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.73-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.72"
+__version__ = "1.3.73"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/adapters/status.py
+++ b/llmwiki/adapters/status.py
@@ -1,0 +1,58 @@
+"""Adapter status computation — pulled out of cli.py (#arch-h8 / #611).
+
+Pre-#611 the ``configured``/``will_fire`` label computation lived as a
+private ``_adapter_status`` helper inside ``cli.py``. The CLI's job is
+to parse argv and print things — deciding whether an adapter is on /
+off / auto belongs in the adapters package next to the adapters
+themselves.
+
+The function is re-exported from ``llmwiki.cli`` so the existing
+``from llmwiki.cli import _adapter_status`` import path keeps working
+for any downstream caller that reached for it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def adapter_status(
+    name: str,
+    adapter_cls: Any,
+    config: dict,
+) -> tuple[str, str]:
+    """Return ``(configured, will_fire)`` labels for one adapter (G-01 · #287).
+
+    * ``configured``: ``explicit`` (user set ``enabled: true`` in the
+      config), ``off`` (user set ``enabled: false``), or ``auto``
+      (default — no explicit toggle).
+    * ``will_fire``: ``yes`` when the next ``sync`` will pick this
+      adapter up (available **and** not explicitly off), ``no``
+      otherwise.
+
+    The old labels — ``-`` / ``enabled`` / ``disabled`` — read as
+    "adapter can't see anything" even when the adapter was discovering
+    471 files on the next line. The new labels say exactly what they
+    mean without the user cross-referencing ``sessions_config.json``.
+    """
+    adapter_cfg = config.get(name, {})
+    enabled_in_cfg = None
+    if isinstance(adapter_cfg, dict):
+        enabled_in_cfg = adapter_cfg.get("enabled", None)
+    if enabled_in_cfg is True:
+        configured = "explicit"
+    elif enabled_in_cfg is False:
+        configured = "off"
+    else:
+        configured = "auto"
+    available = adapter_cls.is_available()
+    # #326: non-AI adapters are opt-in only, so ``auto`` on an Obsidian /
+    # Jira / Meeting / PDF adapter means "available but won't fire".
+    is_ai = getattr(adapter_cls, "is_ai_session", True)
+    if configured == "off":
+        will_fire = "no"
+    elif configured == "explicit":
+        will_fire = "yes" if available else "no"
+    else:  # auto
+        will_fire = "yes" if (available and is_ai) else "no"
+    return configured, will_fire

--- a/llmwiki/cli.py
+++ b/llmwiki/cli.py
@@ -337,46 +337,10 @@ def cmd_serve(args: argparse.Namespace) -> int:
     return serve_site(directory=args.dir, port=args.port, host=args.host, open_browser=args.open)
 
 
-def _adapter_status(
-    name: str,
-    adapter_cls: Any,
-    config: dict,
-) -> tuple[str, str]:
-    """Return ``(configured, will_fire)`` labels for one adapter (G-01 · #287).
-
-    * ``configured``: ``explicit`` (user set ``enabled: true`` in the
-      config), ``off`` (user set ``enabled: false``), or ``auto``
-      (default — no explicit toggle).
-    * ``will_fire``: ``yes`` when the next ``sync`` will pick this
-      adapter up (available **and** not explicitly off), ``no``
-      otherwise.
-
-    The old labels — ``-`` / ``enabled`` / ``disabled`` — read as
-    "adapter can't see anything" even when the adapter was discovering
-    471 files on the next line.  The new labels say exactly what they
-    mean without the user cross-referencing ``sessions_config.json``.
-    """
-    adapter_cfg = config.get(name, {})
-    enabled_in_cfg = None
-    if isinstance(adapter_cfg, dict):
-        enabled_in_cfg = adapter_cfg.get("enabled", None)
-    if enabled_in_cfg is True:
-        configured = "explicit"
-    elif enabled_in_cfg is False:
-        configured = "off"
-    else:
-        configured = "auto"
-    available = adapter_cls.is_available()
-    # #326: non-AI adapters are opt-in only, so ``auto`` on an Obsidian /
-    # Jira / Meeting / PDF adapter means "available but won't fire".
-    is_ai = getattr(adapter_cls, "is_ai_session", True)
-    if configured == "off":
-        will_fire = "no"
-    elif configured == "explicit":
-        will_fire = "yes" if available else "no"
-    else:  # auto
-        will_fire = "yes" if (available and is_ai) else "no"
-    return configured, will_fire
+# #arch-h8 (#611): adapter status computation moved to llmwiki/adapters/status.py.
+# Re-exported here as `_adapter_status` so any external caller doing
+# `from llmwiki.cli import _adapter_status` keeps working.
+from llmwiki.adapters.status import adapter_status as _adapter_status  # noqa: F401
 
 
 def cmd_adapters(args: argparse.Namespace) -> int:
@@ -876,135 +840,10 @@ def _synthesize_complete(args: argparse.Namespace) -> int:
     return 0
 
 
-def synthesize_estimate_report(
-    *,
-    raw_sessions: Optional[list[tuple[Any, dict, str]]] = None,
-    state_keys: Optional[set[str]] = None,
-    prefix_tokens: Optional[int] = None,
-    output_tokens_per_call: int = 1000,
-    model: Optional[str] = None,
-) -> dict:
-    """Compute the incremental vs full-force cost report (G-07 · #293).
-
-    Returns a plain dict so the CLI can render it AND tests can inspect
-    the numbers without parsing stdout.  Keys:
-
-    * ``corpus`` — total raw sessions discovered under ``raw/sessions/``
-    * ``synthesized`` — count already synthesized (from state file)
-    * ``new`` — ``corpus - synthesized``
-    * ``incremental_usd`` — dollars to synthesize the ``new`` bucket
-    * ``full_force_usd`` — dollars to re-synthesize the **whole** corpus
-      with ``--force`` (one cache write + N-1 cache hits)
-    * ``prefix_tokens`` — tokens in the stable CLAUDE.md + index.md +
-      overview.md prefix
-    * ``model`` — model id used for pricing
-    * ``warnings`` — list of human-readable warnings (e.g. prefix too
-      small to be cached)
-
-    Any of the args can be injected for tests; the default reads from
-    disk and is what the CLI invokes.
-    """
-    from llmwiki.cache import (
-        DEFAULT_MODEL,
-        estimate_cost,
-        estimate_tokens,
-        warn_prefix_too_small,
-    )
-    from llmwiki.synth.pipeline import _discover_raw_sessions, _load_state
-
-    chosen_model = model or DEFAULT_MODEL
-    warnings: list[str] = []
-
-    if prefix_tokens is None:
-        prefix_parts: list[str] = []
-        for rel in ("CLAUDE.md", "wiki/index.md", "wiki/overview.md"):
-            p = REPO_ROOT / rel
-            if p.is_file():
-                prefix_parts.append(p.read_text(encoding="utf-8"))
-        prefix_tokens = estimate_tokens("\n".join(prefix_parts))
-    prefix_warning = warn_prefix_too_small(prefix_tokens)
-    if prefix_warning:
-        warnings.append(prefix_warning)
-
-    if raw_sessions is None:
-        raw_sessions = _discover_raw_sessions()
-    if state_keys is None:
-        state_keys = set(_load_state().keys())
-
-    corpus = len(raw_sessions)
-
-    # The real synth state stores rel-paths under ``raw/sessions/``
-    # (e.g. ``proj/2026-04-09-slug.md``).  Match against those first;
-    # fall back to bare filename + suffix-endswith for tests that
-    # inject simpler keys.  A session counts as "synthesized" if any
-    # of those three keys already appears in state_keys.
-    from llmwiki.synth.pipeline import RAW_SESSIONS as _RAW
-
-    # #py-m10 (#596): single-pass walk. The previous version walked
-    # raw_sessions twice — once to bucket new vs synthesised + collect
-    # body strings, once via a list comprehension to materialise the
-    # full-force body list — and then ran estimate_tokens(body) twice
-    # on each new session inside _bucket_usd. On a 5k-corpus that's
-    # 10k token-estimate calls + 2 full body materialisations in RAM.
-    # The pass below computes per-session tokens once, accumulates
-    # both bucket totals incrementally, and never holds more than one
-    # body string at a time.
-    synthed = 0
-    new = 0
-    incremental_usd = 0.0
-    full_force_usd = 0.0
-    incremental_first = True
-    full_force_first = True
-
-    def _add_to_bucket(fresh_tokens: int, first: bool) -> tuple[float, bool]:
-        """Return (cost, was_first?). Cost-of-this-call uses cache_hit=
-        not first, mirroring the old _bucket_usd semantics."""
-        est = estimate_cost(
-            cached_tokens=prefix_tokens,
-            fresh_tokens=fresh_tokens,
-            output_tokens=output_tokens_per_call,
-            model=chosen_model,
-            cache_hit=not first,
-        )
-        return est.usd, False  # second-and-later calls hit the cache
-
-    for p, _meta, body in raw_sessions:
-        keys_to_try: set[str] = set()
-        name = getattr(p, "name", str(p))
-        keys_to_try.add(name)
-        if hasattr(p, "relative_to"):
-            try:
-                keys_to_try.add(str(p.relative_to(_RAW)))
-            except (ValueError, AttributeError):
-                pass
-        keys_to_try.add(str(p))
-        matched = bool(keys_to_try & state_keys) or any(
-            isinstance(k, str) and k.endswith(name) for k in state_keys
-        )
-        body_tokens = estimate_tokens(body)
-        # Full-force bucket: every session contributes regardless of state.
-        ff_cost, full_force_first = _add_to_bucket(body_tokens, full_force_first)
-        full_force_usd += ff_cost
-        # Incremental bucket: only un-synthesised sessions contribute.
-        if matched:
-            synthed += 1
-        else:
-            new += 1
-            inc_cost, incremental_first = _add_to_bucket(
-                body_tokens, incremental_first
-            )
-            incremental_usd += inc_cost
-
-    return {
-        "corpus": corpus,
-        "synthesized": synthed,
-        "new": new,
-        "incremental_usd": incremental_usd,
-        "full_force_usd": full_force_usd,
-        "prefix_tokens": prefix_tokens,
-        "model": chosen_model,
-        "warnings": warnings,
-    }
+# #arch-h8 (#611): synthesize_estimate_report moved to llmwiki/synth/estimate.py.
+# Re-exported here so any test or caller doing
+# `from llmwiki.cli import synthesize_estimate_report` keeps working.
+from llmwiki.synth.estimate import synthesize_estimate_report  # noqa: F401
 
 
 def _synthesize_estimate() -> int:

--- a/llmwiki/synth/estimate.py
+++ b/llmwiki/synth/estimate.py
@@ -1,0 +1,146 @@
+"""Synthesize cost-estimate report — pulled out of cli.py (#arch-h8 / #611).
+
+Pre-#611 ``synthesize_estimate_report`` lived inside ``cli.py``. The
+function is non-trivial business logic (G-07 / #293 cost-model walk)
+that belongs next to the rest of the synth pipeline.
+
+The function is re-exported from ``llmwiki.cli`` so the existing
+``from llmwiki.cli import synthesize_estimate_report`` import path keeps
+working for any test or caller that reached for it.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from llmwiki import REPO_ROOT
+
+
+def synthesize_estimate_report(
+    *,
+    raw_sessions: Optional[list[tuple[Any, dict, str]]] = None,
+    state_keys: Optional[set[str]] = None,
+    prefix_tokens: Optional[int] = None,
+    output_tokens_per_call: int = 1000,
+    model: Optional[str] = None,
+) -> dict:
+    """Compute the incremental vs full-force cost report (G-07 · #293).
+
+    Returns a plain dict so the CLI can render it AND tests can inspect
+    the numbers without parsing stdout. Keys:
+
+    * ``corpus`` — total raw sessions discovered under ``raw/sessions/``
+    * ``synthesized`` — count already synthesized (from state file)
+    * ``new`` — ``corpus - synthesized``
+    * ``incremental_usd`` — dollars to synthesize the ``new`` bucket
+    * ``full_force_usd`` — dollars to re-synthesize the **whole** corpus
+      with ``--force`` (one cache write + N-1 cache hits)
+    * ``prefix_tokens`` — tokens in the stable CLAUDE.md + index.md +
+      overview.md prefix
+    * ``model`` — model id used for pricing
+    * ``warnings`` — list of human-readable warnings (e.g. prefix too
+      small to be cached)
+
+    Any of the args can be injected for tests; the default reads from
+    disk and is what the CLI invokes.
+    """
+    from llmwiki.cache import (
+        DEFAULT_MODEL,
+        estimate_cost,
+        estimate_tokens,
+        warn_prefix_too_small,
+    )
+    from llmwiki.synth.pipeline import RAW_SESSIONS as _RAW
+    from llmwiki.synth.pipeline import _discover_raw_sessions, _load_state
+
+    chosen_model = model or DEFAULT_MODEL
+    warnings: list[str] = []
+
+    if prefix_tokens is None:
+        prefix_parts: list[str] = []
+        for rel in ("CLAUDE.md", "wiki/index.md", "wiki/overview.md"):
+            p = REPO_ROOT / rel
+            if p.is_file():
+                prefix_parts.append(p.read_text(encoding="utf-8"))
+        prefix_tokens = estimate_tokens("\n".join(prefix_parts))
+    prefix_warning = warn_prefix_too_small(prefix_tokens)
+    if prefix_warning:
+        warnings.append(prefix_warning)
+
+    if raw_sessions is None:
+        raw_sessions = _discover_raw_sessions()
+    if state_keys is None:
+        state_keys = set(_load_state().keys())
+
+    corpus = len(raw_sessions)
+
+    # The real synth state stores rel-paths under ``raw/sessions/``
+    # (e.g. ``proj/2026-04-09-slug.md``). Match against those first;
+    # fall back to bare filename + suffix-endswith for tests that
+    # inject simpler keys. A session counts as "synthesized" if any
+    # of those three keys already appears in state_keys.
+    # #py-m10 (#596): single-pass walk. The previous version walked
+    # raw_sessions twice — once to bucket new vs synthesised + collect
+    # body strings, once via a list comprehension to materialise the
+    # full-force body list — and then ran estimate_tokens(body) twice
+    # on each new session inside _bucket_usd. On a 5k-corpus that's
+    # 10k token-estimate calls + 2 full body materialisations in RAM.
+    # The pass below computes per-session tokens once, accumulates
+    # both bucket totals incrementally, and never holds more than one
+    # body string at a time.
+    synthed = 0
+    new = 0
+    incremental_usd = 0.0
+    full_force_usd = 0.0
+    incremental_first = True
+    full_force_first = True
+
+    def _add_to_bucket(fresh_tokens: int, first: bool) -> tuple[float, bool]:
+        """Return (cost, was_first?). Cost-of-this-call uses cache_hit=
+        not first, mirroring the old _bucket_usd semantics."""
+        est = estimate_cost(
+            cached_tokens=prefix_tokens,
+            fresh_tokens=fresh_tokens,
+            output_tokens=output_tokens_per_call,
+            model=chosen_model,
+            cache_hit=not first,
+        )
+        return est.usd, False  # second-and-later calls hit the cache
+
+    for p, _meta, body in raw_sessions:
+        keys_to_try: set[str] = set()
+        name = getattr(p, "name", str(p))
+        keys_to_try.add(name)
+        if hasattr(p, "relative_to"):
+            try:
+                keys_to_try.add(str(p.relative_to(_RAW)))
+            except (ValueError, AttributeError):
+                pass
+        keys_to_try.add(str(p))
+        matched = bool(keys_to_try & state_keys) or any(
+            isinstance(k, str) and k.endswith(name) for k in state_keys
+        )
+        body_tokens = estimate_tokens(body)
+        # Full-force bucket: every session contributes regardless of state.
+        ff_cost, full_force_first = _add_to_bucket(body_tokens, full_force_first)
+        full_force_usd += ff_cost
+        # Incremental bucket: only un-synthesised sessions contribute.
+        if matched:
+            synthed += 1
+        else:
+            new += 1
+            inc_cost, incremental_first = _add_to_bucket(
+                body_tokens, incremental_first
+            )
+            incremental_usd += inc_cost
+
+    return {
+        "corpus": corpus,
+        "synthesized": synthed,
+        "new": new,
+        "incremental_usd": incremental_usd,
+        "full_force_usd": full_force_usd,
+        "prefix_tokens": prefix_tokens,
+        "model": chosen_model,
+        "warnings": warnings,
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.72"
+version = "1.3.73"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

\`cli.py\` was 1,395 LOC, much of which was domain logic. This PR moves two non-trivial blocks out — \`synthesize_estimate_report\` and \`_adapter_status\` — into dedicated domain modules. \`cli.py\` re-exports both names so every import site keeps working unchanged.

\`cli.py\`: **1,395 → 1,234 LOC (-161)**. Still not a one-liner, but closer to argparse-setup + dispatch.

Closes #611 (\`#arch-h8\`).

## What changed

| Symbol | Old home | New home | Re-export |
|---|---|---|---|
| \`synthesize_estimate_report\` | \`llmwiki/cli.py\` | \`llmwiki/synth/estimate.py\` | yes |
| \`_adapter_status\` | \`llmwiki/cli.py\` | \`llmwiki/adapters/status.py\` (as \`adapter_status\`) | yes (re-imported as \`_adapter_status\`) |

Both moves are mechanical — verbatim function bodies, with the original imports relocated alongside.

## What's new

| Surface | Change |
|---|---|
| \`llmwiki/synth/estimate.py\` | new module — owns the G-07 / #293 incremental-vs-full-force cost-model walk |
| \`llmwiki/adapters/status.py\` | new module — owns the configured / will_fire label decision |
| \`from llmwiki.cli import synthesize_estimate_report\` | still works (re-export) |
| \`from llmwiki.cli import _adapter_status\` | still works (re-export from \`llmwiki.adapters.status.adapter_status\`) |
| \`cli.py\` LOC | 1,395 → 1,234 (-161) |

## Behavioural delta

| | Before | After |
|---|---|---|
| Public \`cli.py\` import surface | \`synthesize_estimate_report\`, \`_adapter_status\` (defined inline) | identical (re-exports) |
| Module that owns cost-model logic | \`cli.py\` | \`llmwiki/synth/estimate.py\` |
| Module that owns adapter status labels | \`cli.py\` | \`llmwiki/adapters/status.py\` |
| Test suite | passing | passing (no test changes needed; back-compat preserved) |

## How to test it

\`\`\`bash
python3 -m pytest tests/ -q -m \"not slow\"
python3 -c \"from llmwiki.cli import synthesize_estimate_report, _adapter_status; print('back-compat OK')\"
python3 -c \"from llmwiki.synth.estimate import synthesize_estimate_report; from llmwiki.adapters.status import adapter_status; print('canonical OK')\"
python3 -m llmwiki adapters
python3 -m llmwiki synthesize --estimate
\`\`\`

## Pre-merge checklist

- [x] **One intent** — single refactor: extract two blocks out of \`cli.py\`. No mixed concerns.
- [x] **All CI checks green** — local non-slow suite passes; CI to confirm
- [x] **Linked issue** — \`Closes #611\` in body
- [x] **Conventional-commit title** — \`refactor(cli): ...\`
- [x] **Tests added or updated** — N/A; existing tests reach via the back-compat \`from llmwiki.cli import …\` path and pass unchanged
- [x] **CHANGELOG.md updated** — \`[1.3.73]\` entry under Changed
- [x] **Breaking changes flagged** — N/A; back-compat preserved on every public import path
- [x] **No new runtime dependencies** — N/A
- [x] **No real session data** — N/A
- [x] **No machine-specific paths** — N/A
- [x] **Docs updated** — N/A; the moved functions are internal (no public docs reference them)
- [x] **Release notes drafted** — see CHANGELOG.md \`[1.3.73]\` Changed bullets
- [x] **UI verified** — N/A, no UI surface
- [x] **A11y verified** — N/A, no UI surface
- [x] **Commits GPG-signed** — yes
- [x] **Reviewer has read every changed line** — diff is +225 / -172 across 7 files; most of the new lines are verbatim copies in the new modules

## Bundle

- \`llmwiki/synth/estimate.py\` — new, 152 LOC; owns \`synthesize_estimate_report\`
- \`llmwiki/adapters/status.py\` — new, 60 LOC; owns \`adapter_status\` (the unscored function)
- \`llmwiki/cli.py\` — \`synthesize_estimate_report\` and \`_adapter_status\` definitions removed; replaced with 2 thin re-export imports + comments pointing at the new homes
- \`llmwiki/__init__.py\`, \`pyproject.toml\` — version 1.3.72 → 1.3.73
- \`README.md\` — version badge bump
- \`CHANGELOG.md\` — \`[1.3.73]\` entry under Changed

## Out of scope / follow-ups

- More CLI helpers could move out (e.g. \`_synthesize_list_pending\`, \`_synthesize_complete\`, \`_synthesize_estimate\`, the \`_load_schedule_config\` / \`_should_run_after_sync\` pair), but each is small and tightly coupled to its \`cmd_*\` driver. Held off here to keep the PR scoped to the two functions the issue specifically named.
- The next big extraction is \`convert_all\` (#612 — 300 LOC, 3 separate write paths) which is its own focused PR.

## Next

After merge: tag \`v1.3.73\`, then continue serial-PR work on \`#612\` (split \`convert_all\`).