### PR TITLE
fix(convert): mtime check before derive_project_slug (#612) — v1.3.74

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.74] — 2026-04-27
+
+#arch-h9 (#612) — `convert_all` no longer calls `derive_project_slug` on every session before the mtime check.
+
+### Fixed
+
+- **No-op `llmwiki sync` is O(0) file opens, not O(N)** (#612) — `convert_all`'s per-session loop used to call `adapter.derive_project_slug(path)` BEFORE the mtime check. On Codex CLI that helper opens every `.jsonl` to read the `session_meta` `cwd` field, so a no-op sync of a 5k-session corpus paid 5k needless file opens. Reordered the loop: `path.stat()` (cheap) and the state-mtime comparison run first; slug derivation, project filter, and ignore filter only run for sessions that actually need conversion. New regression test `test_no_op_sync_does_not_call_derive_project_slug` asserts the helper is not called when state already matches mtime.
+
 ## [1.3.73] — 2026-04-27
 
 #arch-h8 (#611) — extract business logic out of `cli.py` into domain modules.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.73-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.74-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.73"
+__version__ = "1.3.74"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/convert.py
+++ b/llmwiki/convert.py
@@ -1425,15 +1425,14 @@ def convert_all(
         })
         counters[cls.name]["discovered"] = len(sessions)
         for path in sessions:
-            project_slug = adapter.derive_project_slug(path)
-            if project and project not in project_slug:
-                filtered += 1
-                _bump(cls.name, "filtered")
-                continue
-            if ignore and ignore.is_ignored(project=project_slug, filename=path.name):
-                ignored_count += 1
-                _bump(cls.name, "ignored")
-                continue
+            # #arch-h9 (#612): mtime check FIRST. The previous order
+            # called `adapter.derive_project_slug(path)` before the
+            # mtime check, which on Codex CLI opens every .jsonl to
+            # read the session_meta cwd field. On a 5k-session corpus
+            # that's 5k needless file opens per no-op sync (~10x scale
+            # projection). Stat is cheap; slug derivation can be
+            # expensive — so check mtime first and skip the expensive
+            # slug + ignore + project-filter work when nothing changed.
             try:
                 mtime = path.stat().st_mtime
             except OSError as e:
@@ -1445,6 +1444,20 @@ def convert_all(
             if state.get(key) == mtime:
                 unchanged += 1
                 _bump(cls.name, "unchanged")
+                continue
+
+            # Now we know we have to look at the file content — derive
+            # slug + run filters. Anything that bails after this point
+            # has had to pay the slug cost, but that's true for every
+            # session that actually gets converted.
+            project_slug = adapter.derive_project_slug(path)
+            if project and project not in project_slug:
+                filtered += 1
+                _bump(cls.name, "filtered")
+                continue
+            if ignore and ignore.is_ignored(project=project_slug, filename=path.name):
+                ignored_count += 1
+                _bump(cls.name, "ignored")
                 continue
 
             # Markdown-source adapters (e.g. Obsidian) route through a simple

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.73"
+version = "1.3.74"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_convert_no_op_perf.py
+++ b/tests/test_convert_no_op_perf.py
@@ -1,0 +1,143 @@
+"""Regression tests for #arch-h9 / #612 — no-op sync skips derive_project_slug.
+
+Pre-fix, ``convert_all`` called ``adapter.derive_project_slug(path)``
+BEFORE the mtime check, which on Codex CLI opens every .jsonl to read
+the session_meta cwd field. On a 5k-session corpus that's 5k needless
+file opens per no-op sync. The fix reordered the per-session loop so
+mtime is checked first; slug derivation only runs when the file
+actually needs conversion.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from llmwiki.adapters import REGISTRY
+from llmwiki.adapters.base import BaseAdapter
+from llmwiki.convert import convert_all
+
+
+class _CountingAdapter(BaseAdapter):
+    """Test adapter that counts how often derive_project_slug is called."""
+
+    name = "counting_adapter"
+    is_ai_session = True
+
+    derive_count = 0
+    fixture_dir: Path
+
+    def __init__(self, config: dict[str, Any] | None = None):
+        super().__init__(config)
+
+    @classmethod
+    def is_available(cls) -> bool:
+        return True
+
+    @property
+    def session_store_path(self) -> list[Path]:
+        return [self.__class__.fixture_dir]
+
+    def discover_sessions(self) -> list[Path]:
+        return sorted(self.__class__.fixture_dir.rglob("*.jsonl"))
+
+    def derive_project_slug(self, path: Path) -> str:
+        # Track every call so the test can assert no-op syncs don't trigger this.
+        type(self).derive_count += 1
+        # Pretend this is expensive (mirroring CodexCliAdapter's open()).
+        with open(path, encoding="utf-8") as f:
+            f.read(1)
+        return path.parent.name
+
+
+def _write_jsonl(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _make_session(path: Path, slug: str) -> None:
+    """Write a tiny but valid Claude-Code-shaped jsonl that survives parse_jsonl."""
+    rec = {
+        "type": "user",
+        "uuid": "u-1",
+        "timestamp": "2026-04-27T00:00:00Z",
+        "message": {"content": [{"type": "text", "text": f"hello {slug}"}]},
+    }
+    _write_jsonl(path, json.dumps(rec) + "\n")
+
+
+@pytest.fixture
+def counting_adapter_registered(tmp_path, monkeypatch):
+    """Register _CountingAdapter into REGISTRY for the duration of the test."""
+    fixture_dir = tmp_path / "sessions" / "demo-project"
+    fixture_dir.parent.mkdir(parents=True, exist_ok=True)
+    fixture_dir.mkdir()
+    _CountingAdapter.fixture_dir = fixture_dir
+    _CountingAdapter.derive_count = 0
+
+    # Insert into REGISTRY without affecting other tests.
+    REGISTRY[_CountingAdapter.name] = _CountingAdapter
+    yield fixture_dir
+    REGISTRY.pop(_CountingAdapter.name, None)
+
+
+def test_no_op_sync_does_not_call_derive_project_slug(
+    counting_adapter_registered, tmp_path
+):
+    """#612: a no-op sync (state matches mtime) skips derive_project_slug.
+
+    Steps:
+      1. Create 3 sessions
+      2. Run convert_all once → counts go up (3 conversions)
+      3. Reset derive_count
+      4. Run convert_all again with the SAME state file → all 3 should
+         skip via the mtime check, derive_project_slug must NOT run.
+    """
+    fixture_dir = counting_adapter_registered
+    out_dir = tmp_path / "raw" / "sessions"
+    state_file = tmp_path / ".llmwiki-state.json"
+    config_file = tmp_path / "sessions_config.json"
+    ignore_file = tmp_path / ".llmwikiignore"
+
+    _make_session(fixture_dir / "a.jsonl", "a")
+    _make_session(fixture_dir / "b.jsonl", "b")
+    _make_session(fixture_dir / "c.jsonl", "c")
+
+    # First run — converts all 3.
+    rc = convert_all(
+        adapters=[_CountingAdapter.name],
+        out_dir=out_dir,
+        state_file=state_file,
+        config_file=config_file,
+        ignore_file=ignore_file,
+        include_current=True,  # don't filter "live" recent sessions
+    )
+    assert rc == 0
+    first_run_calls = _CountingAdapter.derive_count
+    # During the first run derive_project_slug runs once per session
+    # (only when mtime changed — which it has, all 3 are new).
+    assert first_run_calls >= 3
+
+    # Reset the counter and run again. State + mtimes unchanged.
+    _CountingAdapter.derive_count = 0
+    rc = convert_all(
+        adapters=[_CountingAdapter.name],
+        out_dir=out_dir,
+        state_file=state_file,
+        config_file=config_file,
+        ignore_file=ignore_file,
+        include_current=True,
+    )
+    assert rc == 0
+
+    # The whole point of the fix: no-op sync MUST NOT call
+    # derive_project_slug. On a 5k-session corpus this is the
+    # difference between 5k file opens and 0.
+    assert _CountingAdapter.derive_count == 0, (
+        f"no-op sync called derive_project_slug "
+        f"{_CountingAdapter.derive_count} times — should have skipped "
+        f"via the mtime check (#612 / #arch-h9)"
+    )


### PR DESCRIPTION
## Summary

\`convert_all\` no longer calls \`adapter.derive_project_slug(path)\` on every session before the mtime check. On Codex CLI that helper opens every \`.jsonl\` to read the \`session_meta\` \`cwd\` field — so a no-op sync of a 5k-session corpus paid 5k needless file opens. The fix reorders the per-session loop so the cheap mtime check runs first; slug derivation, project filter, and ignore filter only run for sessions that actually need conversion.

Closes #612 (\`#arch-h9\`).

## What changed

- \`llmwiki/convert.py\` — moved \`path.stat()\` + state-mtime check above the \`derive_project_slug\` call inside the per-session loop. No behavior change for sessions that DO get converted; the work is just reordered.
- \`tests/test_convert_no_op_perf.py\` — new regression test exercising a counting adapter that fails CI if a future change re-introduces the early-derive pattern.

## What's new

| Surface | Change |
|---|---|
| File opens per no-op Codex sync (5k corpus) | 5,000 → 0 |
| Mtime check ordering | \`derive_project_slug → filters → mtime\` | \`mtime → derive_project_slug → filters\` |
| Test coverage | new \`test_no_op_sync_does_not_call_derive_project_slug\` |

## Behavioural delta

| | Before | After |
|---|---|---|
| Per-session work for \`state[key] == mtime\` (unchanged) | \`stat\` + \`derive_project_slug\` (file open on Codex) + project filter + ignore | \`stat\` only |
| Per-session work for sessions that DO need conversion | identical (slug + filters + write) | identical (slug + filters + write) |
| Behavior change visible from outside | none | none |
| 5k-session no-op sync wall-clock | (dominated by 5k file opens) | (dominated by stat() — negligible) |

## How to test it

\`\`\`bash
python3 -m pytest tests/test_convert_no_op_perf.py -v
python3 -m pytest tests/ -q -m \"not slow\"

# Manual perf sniff on a real Codex corpus:
python3 -m llmwiki sync   # first run — converts everything
python3 -m llmwiki sync   # second run — should print all-unchanged in <1s
\`\`\`

## Pre-merge checklist

- [x] **One intent** — single perf-fix + corresponding regression test
- [x] **All CI checks green** — local non-slow suite passes; CI to confirm
- [x] **Linked issue** — \`Closes #612\` in body
- [x] **Conventional-commit title** — \`fix(convert): ...\`
- [x] **Tests added or updated** — new \`tests/test_convert_no_op_perf.py\` asserts the contract; full existing suite passes
- [x] **CHANGELOG.md updated** — \`[1.3.74]\` entry under Fixed
- [x] **Breaking changes flagged** — N/A; no public surface change
- [x] **No new runtime dependencies** — N/A
- [x] **No real session data** — N/A; test uses an in-memory counting adapter
- [x] **No machine-specific paths** — N/A
- [x] **Docs updated** — N/A; the change is internal to the sync loop
- [x] **Release notes drafted** — see CHANGELOG.md \`[1.3.74]\` Fixed bullet
- [x] **UI verified** — N/A, no UI surface
- [x] **A11y verified** — N/A, no UI surface
- [x] **Commits GPG-signed** — yes
- [x] **Reviewer has read every changed line** — diff is +176 / -12 across 6 files; most of the new lines are the regression test scaffold

## Bundle

- \`llmwiki/convert.py\` — per-session loop reorder; \`stat()\`/mtime first, slug+filters second
- \`tests/test_convert_no_op_perf.py\` — new test using \`_CountingAdapter\` that registers temporarily, runs \`convert_all\` twice, and asserts \`derive_project_slug\` was not called on the second (no-op) run
- \`llmwiki/__init__.py\`, \`pyproject.toml\` — version 1.3.73 → 1.3.74
- \`README.md\` — version badge bump
- \`CHANGELOG.md\` — \`[1.3.74]\` entry under Fixed

## Out of scope / follow-ups

- The issue title also called \`convert_all\` a "300-line monstrosity with 3 separate write paths". The two real write paths (markdown-source copy at the start of the loop, and parsed-jsonl render at the bottom) could be extracted into helpers in a future PR — held off here to keep this PR scoped to the perf bug. The reorder above is the part that was actually breaking on real corpora.

## Next

After merge: tag \`v1.3.74\`, then run the README-claim audit (#682) or move directly to a final consolidated PyPI release (will need PyPI trusted-publisher to be configured first per the v1.2.0 plan; flagging that as the only remaining blocker).