### PR TITLE
docs: README claim audit + badge-drift regression test (#682) — v1.3.75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.75] — 2026-04-27
+
+#682 — README claim audit + regression test for badge drift.
+
+### Fixed
+
+- **README test-count badge corrected** (#682) — read `tests-2363 passing` while pytest actually collects 2,651. Bumped to the real number.
+- **`pip install -e '.[pdf]'` reference removed** (#682) — the `[pdf]` extra was deleted in the simplification sweep but the install table still advertised it. Replaced with the real extras (`[graph]`, `[dev]`, `[e2e]`, `[all]`).
+- **`pypdf` claim removed from "Stdlib first" design principle** (#682) — same root cause; the line now mentions the real optional extras (`graph`, `dev`, `e2e`).
+- **"472 tests" inline mention bumped to 2,651** (#682) — the E2E section claimed 472, contradicting the badge.
+- **Tutorial heading "every command in 60 seconds" → "90 seconds"** (#682) — the new VHS recording at `docs/videos/cli-tutorial.gif` runs 31 seconds against an 8-session sandbox; "90 seconds" is the realistic narration time. Also added a link to the recording + tape source so readers can re-render it.
+- **Demo GIF re-embedded** (#682) — `<!-- TODO: re-record demo GIF for v1.3 (#248) -->` was leftover from before v1.3.67 shipped the recording. The README now displays `docs/demo.gif` directly.
+- **Chromium download size claim softened** (#682) — "~300 MB for Chromium" was a stale snapshot; the actual size shifts every Playwright release. Now reads "several hundred MB for the Chromium binary".
+
+### Added
+
+- **`test_test_count_badge_within_window_of_actual`** (#682) — runs `pytest --collect-only` inside the existing `tests/test_readme_badges.py` and fails when the badge drifts more than ±15% from the actually-collected count. Catches the exact rot mode that triggered this audit (badge silently ~290 tests behind reality through several PR cycles).
+
 ## [1.3.74] — 2026-04-27
 
 #arch-h9 (#612) — `convert_all` no longer calls `derive_project_slug` on every session before the mtime check.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.74-10B981.svg)](CHANGELOG.md)
-[![Tests](https://img.shields.io/badge/tests-2363%20passing-10B981.svg)](tests/)
+[![Version](https://img.shields.io/badge/version-v1.3.75-10B981.svg)](CHANGELOG.md)
+[![Tests](https://img.shields.io/badge/tests-2651%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)
 [![Wiki checks](https://github.com/Pratiyush/llm-wiki/actions/workflows/wiki-checks.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/wiki-checks.yml)
@@ -33,7 +33,7 @@ Every Claude Code, Codex CLI, Copilot, Cursor, and Gemini CLI session writes a f
 ./build.sh && ./serve.sh           # build + serve at http://127.0.0.1:8765
 ```
 
-<!-- TODO: re-record demo GIF for v1.3 (#248). Removed broken ref to docs/demo.gif. -->
+![llmwiki — 70-second demo](docs/demo.gif)
 
 
 **Contributing in one line:** read [`CONTRIBUTING.md`](CONTRIBUTING.md), keep PRs focused (one concern each), use `feat:` / `fix:` / `docs:` / `chore:` / `test:` commit prefixes, never commit real session data (`raw/` is gitignored), no new runtime deps. CI must be green to merge.
@@ -159,9 +159,11 @@ The full script is **stdlib-only** at [`examples/scripts/tree_from_graph.py`](ex
 - **Pending ingest queue** — SessionStart hook converts + queues; `/wiki-sync` processes queue
 - **No servers, no database, no npm** — Python stdlib + `markdown`. Syntax highlighting loads from a highlight.js CDN at view time.
 
-## Tutorial — every command in 60 seconds
+## Tutorial — every command in 90 seconds
 
 A guided tour. Run these in order and you'll have a fully working wiki at `http://127.0.0.1:8765/` by the end. Each command is idempotent and prints what it did.
+
+A scripted recording of the same flow ships at [`docs/videos/cli-tutorial.gif`](docs/videos/cli-tutorial.gif) (31 seconds against an 8-session sandbox). The reproducible source is [`docs/videos/cli-tutorial.tape`](docs/videos/cli-tutorial.tape) — re-render anytime with `vhs docs/videos/cli-tutorial.tape`.
 
 ```bash
 # 1. One-time scaffold (≈1 sec). Creates raw/, wiki/, site/, seed nav files.
@@ -297,9 +299,10 @@ setup.bat
 
 ```bash
 pip install -e .                # basic — everything you need
-pip install -e '.[pdf]'         # + PDF ingestion
+pip install -e '.[graph]'       # + graphifyy AI-powered graph engine
 pip install -e '.[dev]'         # + pytest + ruff
-pip install -e '.[all]'         # all of the above
+pip install -e '.[e2e]'         # + Playwright + pytest-bdd + pytest-html (E2E)
+pip install -e '.[all]'         # graph + everything
 ```
 
 Syntax highlighting is now powered by [highlight.js](https://highlightjs.org/), loaded from a CDN at view time — no optional deps required.
@@ -337,7 +340,7 @@ Four Claude Code slash commands automate the common ops:
 
 ## Running E2E tests
 
-The unit suite (`pytest tests/` — 472 tests) runs in milliseconds and
+The unit suite (`pytest tests/` — 2,651 tests) runs in seconds and
 covers every module. The **end-to-end suite** under `tests/e2e/` is
 separate: it builds a minimal demo site, serves it on a random port,
 drives a real browser via [Playwright](https://playwright.dev/python),
@@ -348,7 +351,7 @@ Why both? Unit tests lock the contract at the module boundary;
 E2E locks the contract at the **user's browser**. A diff that passes
 unit tests but breaks the Cmd+K palette will fail E2E.
 
-Install the extras (one-time, ~300 MB for Chromium):
+Install the extras (one-time, several hundred MB for the Chromium binary):
 
 ```bash
 pip install -e '.[e2e]'
@@ -536,7 +539,7 @@ See [docs/architecture.md](docs/architecture.md) for the full breakdown and how 
 
 ## Design principles
 
-- **Stdlib first** — only mandatory runtime dep is `markdown`. `pypdf` is an optional extra for PDF ingestion.
+- **Stdlib first** — only mandatory runtime dep is `markdown`. Optional extras (`graph`, `dev`, `e2e`) layer in graph engines, lint/test tooling, and Playwright on top.
 - **Works offline** — no Google fonts, no external CSS. Syntax highlighting loads from a highlight.js CDN but degrades gracefully without it.
 - **Redact by default** — username, API keys, tokens, emails all get redacted before entering the wiki.
 - **Idempotent everything** — re-running any command is safe and cheap.

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.74"
+__version__ = "1.3.75"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.74"
+version = "1.3.75"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_readme_badges.py
+++ b/tests/test_readme_badges.py
@@ -121,6 +121,47 @@ def test_test_count_badge_is_a_reasonable_number(readme_text: str):
     )
 
 
+# #682: pin the badge within ±15% of the actually-collected test count
+# so it can't silently drift hundreds of tests behind reality (the bug
+# this audit caught: badge said 2363, real count was 2651).
+def test_test_count_badge_within_window_of_actual():
+    """Run pytest --collect-only and compare to the badge number.
+
+    Tolerance ±15% — we don't expect every PR to bump the badge, but a
+    drift of more than 15% means the badge has been stale through
+    multiple PR cycles. Refresh it.
+    """
+    import subprocess
+    import sys
+
+    badge_match = TEST_COUNT_RE.search(README.read_text(encoding="utf-8"))
+    assert badge_match is not None
+    badge_count = int(badge_match.group(1))
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", "tests/", "--collect-only"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    # Output contains a line like "<N> tests collected in <T>s"
+    text = proc.stdout + proc.stderr
+    m = re.search(r"(\d+) tests collected", text)
+    if m is None:
+        pytest.skip(f"could not parse pytest --collect-only output: {text[-200:]!r}")
+    actual = int(m.group(1))
+
+    # Allow ±15% drift before failing.
+    lower = int(actual * 0.85)
+    upper = int(actual * 1.15)
+    assert lower <= badge_count <= upper, (
+        f"test-count badge says {badge_count} but pytest currently "
+        f"collects {actual}; outside the ±15% drift window "
+        f"[{lower}, {upper}]. Refresh the badge."
+    )
+
+
 # ─── #271: no hard-coded "11 lint rules" references in user-facing docs ─
 
 


### PR DESCRIPTION
## Summary

Walks every numeric/factual claim in \`README.md\` against the current code + data and fixes the seven that drifted. Pairs the audit with a regression test that fails CI when the test-count badge silently rots more than ±15% behind reality.

Closes #682.

## What changed

| # | Where | Claim before | Verdict | Fix |
|---|---|---|---|---|
| 1 | README badge L13 | \`tests-2363 passing\` | **stale** — \`pytest --collect-only\` reports 2,651 | bump badge to 2,651 |
| 2 | README L300 | \`pip install -e '.[pdf]'\` | **wrong** — \`[pdf]\` extra was removed in the simplification sweep (memory: PDF adapter pruned deliberately) | replace with the real extras (\`[graph]\`, \`[dev]\`, \`[e2e]\`, \`[all]\`) |
| 3 | README L539 | \`pypdf is an optional extra for PDF ingestion\` | **wrong** — same root cause | rewrite the line to mention the real extras |
| 4 | README L340 | \`the unit suite (pytest tests/ — 472 tests)\` | **stale** — same reason as the badge; off by ~2,200 | bump inline mention to 2,651 |
| 5 | README L162 | \`Tutorial — every command in 60 seconds\` | **stale** — the v1.3.67 VHS recording at \`docs/videos/cli-tutorial.gif\` runs 31 seconds against an 8-session sandbox; "90 seconds" is the realistic narration time on a real corpus | rename to "90 seconds" + link to the recording + tape source |
| 6 | README L36 | \`<!-- TODO: re-record demo GIF for v1.3 (#248) -->\` | **stale** — the demo gif shipped in v1.3.67 (#248 closed) | embed \`docs/demo.gif\` directly |
| 7 | README L351 | \`~300 MB for Chromium\` | **unprovable** — Playwright re-pins Chromium every release; the snapshot rots quickly | soften to "several hundred MB" |

Verified, no change needed:
- \`16 lint rules\` (\`len(REGISTRY) == 16\`)
- \`12 production tools\` (12 unique \`name="wiki_..."\` entries in \`mcp/server.py\`)
- \`8 sessions across 3 projects\` for the demo data (8 \`.md\` files under \`examples/demo-sessions/\`)
- \`161 features across 16 categories\` (\`docs/feature-matrix.md\` totals row)
- \`Adapters\` table in the "Works with" section (cross-checked against \`llmwiki/adapters/REGISTRY\`)
- \`Releases\` table (cross-checked against \`gh release list\`)

## What's new

| Surface | Change |
|---|---|
| README badge accuracy | drifted ~290 tests behind reality (\`2363 → 2651\`) |
| Install table | references real extras only — no phantom \`[pdf]\` |
| Tutorial section | links to the v1.3.67 VHS recording + tape source |
| Design principles | "Stdlib first" no longer mentions deleted \`pypdf\` extra |
| Demo gif | re-embedded from \`docs/demo.gif\` (shipped 1.3.67) |
| Tests | new regression test pins badge ≤ ±15% drift |

## Behavioural delta

| | Before | After |
|---|---|---|
| Badge accuracy on \`master\` | drifted 2,363 vs 2,651 actual | within ±15% always |
| Install copy-paste | \`pip install -e '.[pdf]'\` errors with "no such extra" | every advertised extra is real |
| Demo gif visibility | hidden behind a TODO comment | inline at the top of the README |
| Future drift detection | none — manual re-check | CI fails when badge drifts >15% |

## How to test it

\`\`\`bash
python3 -m pytest tests/test_readme_badges.py -v   # 10 pass, including the new test
python3 -m pytest tests/ -q -m "not slow"          # full suite green
python3 -m pytest tests/ --collect-only 2>&1 | grep "tests collected"
\`\`\`

## Pre-merge checklist

- [x] **One intent** — single doc audit + corresponding regression test, no scope mixing
- [x] **All CI checks green** — verified locally; CI to confirm
- [x] **Linked issue** — \`Closes #682\` in body
- [x] **Conventional-commit title** — \`docs: ...\`
- [x] **Tests added or updated** — new \`test_test_count_badge_within_window_of_actual\` pins the contract; full existing badge suite still passes
- [x] **CHANGELOG.md updated** — \`[1.3.75]\` entry under Fixed + Added
- [x] **Breaking changes flagged** — N/A; doc-only PR
- [x] **No new runtime dependencies** — N/A
- [x] **No real session data** — N/A
- [x] **No machine-specific paths** — N/A
- [x] **Docs updated** — this PR is the docs update
- [x] **Release notes drafted** — see CHANGELOG.md \`[1.3.75]\`
- [x] **UI verified** — N/A; no UI surface changes
- [x] **A11y verified** — N/A
- [x] **Commits GPG-signed** — yes
- [x] **Reviewer has read every changed line** — diff is +73 / -11 across 5 files

## Bundle

- \`README.md\` — 7 textual fixes (badge, install table, design principles, tutorial heading, demo gif, E2E section, Chromium size)
- \`tests/test_readme_badges.py\` — new \`test_test_count_badge_within_window_of_actual\` runs \`pytest --collect-only\` in a subprocess and compares to the badge with ±15% tolerance
- \`llmwiki/__init__.py\`, \`pyproject.toml\` — version 1.3.74 → 1.3.75
- \`CHANGELOG.md\` — \`[1.3.75]\` entry under Fixed + Added

## Out of scope / follow-ups

- \`docs/benchmarks.md\` numbers (M2 MacBook Air, "337 sessions (real wiki)") are old but they correctly call themselves "representative" with a "100 sessions = 8.3 s total" budget. The numbers fluctuate per machine + Python version, so re-measuring them every PR is overkill. Held off here.
- \`docs/feature-matrix.md\` "Total: 161" is current but the rating columns ("⭐⭐⭐⭐⭐") are subjective and fall outside this audit's scope.
- The \`Google Fonts\` line in \`docs/benchmarks.md\` ("CDN fonts — Inter and JetBrains Mono load from Google Fonts") technically conflicts with the README "Works offline — no Google fonts" line. Could be a separate small PR; it's adjacent rather than central to the README claim audit.

## Next

After merge: tag \`v1.3.75\`, then move to the Playwright Test Agents epic (#462–#467). Per memory: open #462 with a phased plan first, then #463 (decide pytest-playwright vs \`npx @playwright/test\`) before any code PRs in the family.