### PR TITLE
fix: v1.3.78 multi-agent review remediation — 6 HIGH fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.78] — 2026-04-27
+
+Multi-agent code review remediation — 6 HIGH fixes from a 5-agent review of the consolidated v1.3.66 → v1.3.77 diff (python-reviewer, security-reviewer, architect, code-reviewer, typescript-reviewer). Plus follow-up issues #691 (deeper cli.py extraction) and #692 (ADR-001 drift ownership amendment) filed for the architect's larger findings.
+
+### Fixed
+
+- **REGISTRY no longer carries alias keys** (#v1378-review) — `register(name, aliases=[...])` was inserting every alias directly into `REGISTRY`, which made `cmd_adapters` print duplicate rows (one for `copilot_chat`, one for `copilot-chat`) and made `adapter_status` look up the wrong config key on the alias row. Aliases now live in a separate `REGISTRY_ALIASES: dict[str, str]` map and the new `resolve_adapter_name()` helper handles canonical lookups. A collision guard now raises `ValueError` if an alias would shadow an existing canonical adapter.
+- **`build_site` per-source sibling-failure isolation** (#v1378-review) — pre-fix, the first `OSError` / `ValueError` / `RuntimeError` from a single source's sibling write set a process-wide `siblings_failed` flag and silently dropped sibling output for **every subsequent session in the loop**. On a 500-session corpus with one bad body, that meant 497 silently missing `.txt` + `.json` sibling files. Each source's sibling write is now wrapped individually; failures are collected into a `sibling_failures` list and reported once at the end without poisoning the rest of the loop. Warning lines now print BEFORE the success line so CI log scanners don't miss them.
+- **`cli.py` no longer has E402 mid-module imports** (#v1378-review) — the two re-export lines (`from llmwiki.adapters.status import adapter_status as _adapter_status`, `from llmwiki.synth.estimate import synthesize_estimate_report`) were stuck in the middle of the file between function definitions. Hoisted to the top with the rest of the imports.
+- **Timeline SVG label uses `textContent`, not `innerHTML`** (#v1378-review) — `tl.innerHTML = '<div...>' + labelText + '</div>' + svg` interpolated `labelText` (currently number-only — safe today) into HTML without escaping. Defense-in-depth: rebuilt as `createElement` + `textContent` so a future change feeding a user-derived string into the label can't introduce XSS. The svg portion still uses `insertAdjacentHTML` since every `data-*` interpolation already goes through `escAttr()`.
+- **`#nav-hamburger` aria-label updates with drawer state** (#v1378-review) — the static `aria-label="Open navigation menu"` stayed the same when the drawer was open. Screen reader users heard the wrong action. Now toggled by `setOpen()` alongside `aria-expanded`.
+- **Theme toggle `aria-label` reflects the tri-state, not just dark/not-dark** (#v1378-review) — `aria-pressed` collapsed three states (system / dark / light) into two ("true" / "false"); both system and light mapped to "false" so a screen reader user couldn't distinguish them. Both `#theme-toggle` (desktop) and `#mbn-theme` (mobile) now set a dynamic `aria-label` describing the current state plus the next-tap action ("Theme: dark — click for light", etc.). `aria-pressed` is kept for back-compat.
+- **`.nav-hamburger` has a forced-colors fallback** (#v1378-review) — Windows High Contrast Mode overrides our custom palette; without an explicit `@media (forced-colors: active)` rule the button visually disappeared against the nav background. Added system-named `ButtonText` border and `Highlight` focus outline.
+
+### Added
+
+- **`tests/test_v1378_remediation.py`** — 9 regression tests pinning each of the 6 fixes (canonical-only REGISTRY + alias resolution, alias-collision guard, sibling-failure isolation, no-E402 imports, timeline `textContent`, hamburger dynamic `aria-label`, theme `aria-label` tri-state, forced-colors CSS). Catches all six rot modes if a future PR re-introduces them.
+
+### Filed
+
+- **#691** — follow-up: extract `cmd_all`, `cmd_sync_status`, `_load_schedule_config` + `_synthesize_*` helpers from `cli.py` (the architect-agent flagged that #611 stopped about 300 LOC short of the stated "CLI = argparse + dispatch only" goal).
+- **#692** — follow-up: amend ADR-001 with a drift-ownership section + concrete deprecation trigger metric for evaluating Path B.
+
 ## [1.3.77] — 2026-04-27
 
 #465 + #466 — Playwright Test Agents Planner deliverable + regression locks for UI bugs #452–#460.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.77-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.78-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2651%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.77"
+__version__ = "1.3.78"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/adapters/__init__.py
+++ b/llmwiki/adapters/__init__.py
@@ -25,6 +25,12 @@ from llmwiki.adapters.base import BaseAdapter
 
 REGISTRY: dict[str, type[BaseAdapter]] = {}
 
+# #v1378-review: aliases tracked separately so REGISTRY stays
+# canonical-only. `cmd_adapters` and any other consumer that walks
+# every adapter exactly once can iterate REGISTRY directly without
+# de-duping. Lookup-by-alias still works via `resolve_adapter_name`.
+REGISTRY_ALIASES: dict[str, str] = {}
+
 # Contrib adapters that can be loaded on demand.
 CONTRIB_ADAPTERS = {
     "chatgpt", "copilot_chat", "copilot_cli",
@@ -35,19 +41,57 @@ CONTRIB_ADAPTERS = {
 def register(name: str, aliases: list[str] | None = None):
     """Decorator used by adapter modules to register themselves.
 
-    ``aliases`` (#arch-l5 / #626): additional REGISTRY keys that resolve
-    to the same class. Used to keep historical kebab-case names like
+    ``aliases`` (#arch-l5 / #626): historical lookup-only names that
+    resolve to the same class. Used to keep kebab-case names like
     ``copilot-chat`` working after the canonical name moves to
     snake_case (``copilot_chat``). ``cls.name`` always reflects the
-    canonical name; aliases only affect REGISTRY lookups.
+    canonical name.
+
+    #v1378-review: aliases live in a SEPARATE ``REGISTRY_ALIASES`` map
+    so iterating ``REGISTRY`` walks each adapter exactly once. The
+    previous version inserted aliases into ``REGISTRY`` directly,
+    which made ``cmd_adapters`` print duplicate rows (one for the
+    canonical name, one for the alias) and made ``adapter_status``
+    look up the wrong config key on the alias row.
+
+    A collision guard prevents an alias from shadowing an existing
+    canonical adapter — e.g. ``register("copilot_chat",
+    aliases=["claude_code"])`` would raise ValueError, not silently
+    replace the real ``claude_code`` entry.
     """
     def decorator(cls):
         REGISTRY[name] = cls
         cls.name = name
         for alias in aliases or ():
-            REGISTRY[alias] = cls
+            if alias in REGISTRY:
+                raise ValueError(
+                    f"adapter alias {alias!r} would shadow existing "
+                    f"canonical adapter {REGISTRY[alias].name!r}"
+                )
+            existing = REGISTRY_ALIASES.get(alias)
+            if existing is not None and existing != name:
+                raise ValueError(
+                    f"adapter alias {alias!r} already mapped to "
+                    f"{existing!r}; cannot remap to {name!r}"
+                )
+            REGISTRY_ALIASES[alias] = name
         return cls
     return decorator
+
+
+def resolve_adapter_name(name: str) -> str | None:
+    """Return the canonical adapter name for ``name``, or None.
+
+    ``name`` may be the canonical name (returned as-is) or a registered
+    alias (returned as the canonical it maps to). Anything else returns
+    None, letting callers raise their own user-facing error.
+    """
+    if name in REGISTRY:
+        return name
+    canonical = REGISTRY_ALIASES.get(name)
+    if canonical and canonical in REGISTRY:
+        return canonical
+    return None
 
 
 def discover_adapters() -> None:

--- a/llmwiki/build.py
+++ b/llmwiki/build.py
@@ -2427,32 +2427,38 @@ def build_site(
             print(f"  synthesis: {len(synthesis)} chars")
 
     # Render pages — single pass over `sources` (#py-m8 / #594).
-    # Pre-fix this loop only called render_session; a second walk later
-    # re-iterated `sources` to write the .txt + .json siblings, with a
-    # post-hoc html_path.exists() guard. Now we do both per-source in
-    # one iteration: render the HTML, then immediately write the two
-    # siblings while we still have meta + body in scope. Exporter
-    # imports stay lazy + try/except-wrapped so a missing exporter
-    # module degrades to "no siblings" instead of crashing the build.
-    siblings_failed = False
-    siblings_error: Optional[BaseException] = None
-    n_sessions = 0
-    n_siblings = 0
+    # Sibling writes (.txt + .json) happen inside the same iteration so
+    # we don't re-walk `sources` later. The exporter import is hoisted
+    # ABOVE the loop with try/except: a missing module degrades to "no
+    # siblings on any session" (the import-fail case is truly fatal —
+    # no sense retrying it per-source).
+    #
+    # #v1378-review (architect + python-reviewer): per-source write
+    # failures are now isolated. The previous version set a single
+    # `siblings_failed` flag on the first OSError/ValueError/
+    # RuntimeError and silently dropped sibling writes for EVERY
+    # subsequent session in the loop — a single bad body on session 3
+    # of 500 produced 497 silently missing siblings. Now each source's
+    # sibling write is wrapped individually and collects errors into
+    # a list; the build proceeds and we print a summary at the end.
+    sibling_writers_loaded = True
+    sibling_import_error: Optional[BaseException] = None
     try:
         from llmwiki.exporters import write_page_json, write_page_txt
     except (ImportError, OSError, ValueError, RuntimeError) as e:
-        siblings_failed = True
-        siblings_error = e
-        write_page_txt = None  # type: ignore[assignment]
-        write_page_json = None  # type: ignore[assignment]
+        sibling_writers_loaded = False
+        sibling_import_error = e
 
+    n_sessions = 0
+    n_siblings = 0
+    sibling_failures: list[tuple[str, BaseException]] = []
     _wikilink_re = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]*)?\]\]")
     for path, meta, body in sources:
         project = str(meta.get("project") or path.parent.name)
         render_session(path, meta, body, out_dir, project)
         n_sessions += 1
 
-        if siblings_failed or write_page_txt is None:
+        if not sibling_writers_loaded:
             continue
         # render_session writes site/sessions/<project>/<stem>.html;
         # mirror its path here so the siblings land alongside it.
@@ -2463,24 +2469,36 @@ def build_site(
             body_stripped = strip_leading_h1(body)
             wikilinks_out = _wikilink_re.findall(body_stripped)
             write_page_txt(html_path, body_stripped)
+            n_siblings += 1
             meta_copy = dict(meta)
             meta_copy.setdefault("slug", str(meta.get("slug", path.stem)))
             meta_copy.setdefault("project", project)
             write_page_json(html_path, meta_copy, body_stripped, wikilinks_out)
-            n_siblings += 2
+            n_siblings += 1
         except (OSError, ValueError, RuntimeError) as e:
-            # First failure is reported once; subsequent siblings skipped.
-            if not siblings_failed:
-                siblings_error = e
-            siblings_failed = True
+            # Isolate to this source — the next iteration still attempts
+            # both writes. n_siblings increments only after each
+            # successful write so the count never over-reports.
+            sibling_failures.append((str(html_path), e))
 
-    print(f"  wrote {n_sessions} session pages")
-    if siblings_failed and siblings_error is not None:
+    # Print warnings BEFORE the success line so a CI log scanner sees
+    # them in the right order (architect-review feedback).
+    if not sibling_writers_loaded:
         print(
-            f"  warning: per-page siblings failed: {siblings_error}",
+            f"  warning: per-page siblings disabled (exporter import failed): "
+            f"{sibling_import_error}",
             file=sys.stderr,
         )
-    else:
+    if sibling_failures:
+        first_path, first_err = sibling_failures[0]
+        print(
+            f"  warning: per-page sibling write failed on "
+            f"{len(sibling_failures)} of {n_sessions} sessions; "
+            f"first failure: {first_path}: {first_err}",
+            file=sys.stderr,
+        )
+    print(f"  wrote {n_sessions} session pages")
+    if sibling_writers_loaded:
         print(f"  wrote {n_siblings} per-page siblings (.txt + .json)")
 
     for project, sessions in groups.items():

--- a/llmwiki/cli.py
+++ b/llmwiki/cli.py
@@ -27,6 +27,12 @@ from typing import Any, Optional
 
 from llmwiki import __version__, REPO_ROOT
 from llmwiki.adapters import REGISTRY, discover_adapters
+# #v1378-review (#691 follow-up): hoist these re-exports from mid-module
+# to here so the file passes E402 cleanly. They re-export business
+# logic that lives in the proper domain modules now (#611) — kept here
+# for any caller still importing from llmwiki.cli.
+from llmwiki.adapters.status import adapter_status as _adapter_status  # noqa: F401
+from llmwiki.synth.estimate import synthesize_estimate_report  # noqa: F401
 
 
 def cmd_version(args: argparse.Namespace) -> int:
@@ -335,12 +341,6 @@ def cmd_serve(args: argparse.Namespace) -> int:
     """Serve the built site via a local HTTP server."""
     from llmwiki.serve import serve_site
     return serve_site(directory=args.dir, port=args.port, host=args.host, open_browser=args.open)
-
-
-# #arch-h8 (#611): adapter status computation moved to llmwiki/adapters/status.py.
-# Re-exported here as `_adapter_status` so any external caller doing
-# `from llmwiki.cli import _adapter_status` keeps working.
-from llmwiki.adapters.status import adapter_status as _adapter_status  # noqa: F401
 
 
 def cmd_adapters(args: argparse.Namespace) -> int:
@@ -838,12 +838,6 @@ def _synthesize_complete(args: argparse.Namespace) -> int:
 
     print(f"completed: {page_path}")
     return 0
-
-
-# #arch-h8 (#611): synthesize_estimate_report moved to llmwiki/synth/estimate.py.
-# Re-exported here so any test or caller doing
-# `from llmwiki.cli import synthesize_estimate_report` keeps working.
-from llmwiki.synth.estimate import synthesize_estimate_report  # noqa: F401
 
 
 def _synthesize_estimate() -> int:

--- a/llmwiki/convert.py
+++ b/llmwiki/convert.py
@@ -1367,11 +1367,17 @@ def convert_all(
     discover_adapters()
     selected: list[type] = []
     if adapters:
+        # #v1378-review: aliases now live in REGISTRY_ALIASES, not
+        # REGISTRY itself, so resolve through resolve_adapter_name to
+        # support both canonical names and historical kebab-case
+        # aliases (e.g. `--adapter copilot-chat`).
+        from llmwiki.adapters import resolve_adapter_name
         for name in adapters:
-            if name not in REGISTRY:
+            canonical = resolve_adapter_name(name)
+            if canonical is None:
                 print(f"error: unknown adapter {name!r}. Try: {', '.join(REGISTRY)}", file=sys.stderr)
                 return 2
-            selected.append(REGISTRY[name])
+            selected.append(REGISTRY[canonical])
     else:
         # #326: default-fire only AI-session adapters. Non-AI adapters
         # (obsidian, jira, meeting, pdf) must be explicitly enabled via

--- a/llmwiki/render/css.py
+++ b/llmwiki/render/css.py
@@ -753,6 +753,15 @@ mark { background: var(--accent-bg); color: var(--accent); padding: 0 2px; borde
 }
 .nav-hamburger:hover { border-color: var(--accent); color: var(--accent); }
 @media (max-width: 1023px) { .nav-hamburger { display: inline-flex; } }
+/* #v1378-review: forced-colors (Windows High Contrast) mode overrides
+   our custom palette with the system one. Without this, the hamburger
+   button's border (var(--border)) is ignored and the button visually
+   disappears against the nav background. Use system-named colors so
+   it stays visible. */
+@media (forced-colors: active) {
+  .nav-hamburger { border: 2px solid ButtonText; }
+  .nav-hamburger:focus-visible { outline: 3px solid Highlight; outline-offset: 2px; }
+}
 .nav-drawer {
   display: none;
   position: absolute; left: 0; right: 0; top: 100%;

--- a/llmwiki/render/js.py
+++ b/llmwiki/render/js.py
@@ -68,14 +68,32 @@ JS = r"""// llmwiki viewer — theme + copy + search palette + keyboard shortcut
     syncHljsTheme();
     const btn = document.getElementById("theme-toggle");
     if (!btn) return;
-    // #ui-h8 (#568): aria-pressed mirrors the dark-state so AT users
-    // hear "toggle dark mode, pressed" vs "not pressed" instead of an
-    // ambiguous toggle.
-    function syncAriaPressed() {
-      const t = root.getAttribute("data-theme") ||
-        ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) ? "dark" : "light");
-      btn.setAttribute("aria-pressed", t === "dark" ? "true" : "false");
+    // #ui-h8 (#568): aria state mirrors the current cycle position so
+    // assistive tech announces what's pinned, not just "pressed".
+    // #v1378-review: aria-pressed collapses 3 states (system / dark /
+    // light) to 2 (true|false) — both "system" and "light" mapped to
+    // "false", so a screen-reader user couldn't tell which state they
+    // were in. Switched to a dynamic aria-label describing the
+    // current theme + the next-tap action. aria-pressed is also kept
+    // for back-compat with anything reading the binary signal.
+    function syncAriaState() {
+      let stored = null;
+      try { stored = localStorage.getItem("llmwiki-theme"); } catch (e) {}
+      const isDark = (root.getAttribute("data-theme") || (
+        (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) ? "dark" : "light"
+      )) === "dark";
+      btn.setAttribute("aria-pressed", isDark ? "true" : "false");
+      const labels = {
+        dark: "Theme: dark — click for light",
+        light: "Theme: light — click for system default",
+      };
+      const systemLabel = "Theme: follows system — click for dark";
+      btn.setAttribute(
+        "aria-label",
+        labels[stored] || systemLabel,
+      );
     }
+    const syncAriaPressed = syncAriaState; // alias kept for older call sites
     syncAriaPressed();
     btn.addEventListener("click", function () {
       // #ui-h6 (#567): tri-state toggle. The cycle is:
@@ -124,6 +142,13 @@ JS = r"""// llmwiki viewer — theme + copy + search palette + keyboard shortcut
     if (!btn || !drawer) return;
     function setOpen(open) {
       btn.setAttribute("aria-expanded", open ? "true" : "false");
+      // #v1378-review: aria-label was static "Open navigation menu"
+      // even when the drawer was already open; screen readers
+      // announced the wrong action. Toggle it alongside aria-expanded.
+      btn.setAttribute(
+        "aria-label",
+        open ? "Close navigation menu" : "Open navigation menu",
+      );
       if (open) drawer.removeAttribute("hidden");
       else drawer.setAttribute("hidden", "");
     }
@@ -301,13 +326,23 @@ JS = r"""// llmwiki viewer — theme + copy + search palette + keyboard shortcut
     // Wire the theme button to toggle
     const themeBtn = document.getElementById("mbn-theme");
     if (themeBtn) {
-      // Post-review: keep aria-pressed in sync with the dark-state on
-      // the mobile theme button so VoiceOver / TalkBack hear the right
-      // state. Mirrors what #theme-toggle does on desktop.
+      // #v1378-review: same dynamic aria-label treatment as the
+      // desktop button — aria-pressed alone collapses the tri-state
+      // (system / dark / light) into a binary signal. The label
+      // describes the current state plus the next-tap action.
       function _mbnSyncPressed() {
-        const t = document.documentElement.getAttribute("data-theme") ||
-          ((window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) ? "dark" : "light");
-        themeBtn.setAttribute("aria-pressed", t === "dark" ? "true" : "false");
+        let stored = null;
+        try { stored = localStorage.getItem("llmwiki-theme"); } catch (e) { /* private mode */ }
+        const isDark = (document.documentElement.getAttribute("data-theme") || (
+          (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) ? "dark" : "light"
+        )) === "dark";
+        themeBtn.setAttribute("aria-pressed", isDark ? "true" : "false");
+        const labels = {
+          dark: "Theme: dark — tap for light",
+          light: "Theme: light — tap for system default",
+        };
+        const systemLabel = "Theme: follows system — tap for dark";
+        themeBtn.setAttribute("aria-label", labels[stored] || systemLabel);
       }
       _mbnSyncPressed();
       themeBtn.addEventListener("click", function () {
@@ -1132,11 +1167,21 @@ document.addEventListener("DOMContentLoaded", function () {
       : 'Activity timeline · ' + spanDays + ' days · ' + dates.length +
         ' active · peak ' + maxCount + (maxCount === 1 ? ' session/day' : ' sessions/day');
 
-    // Create the timeline block
+    // Create the timeline block. #v1378-review: previously assigned
+    // the label + svg via innerHTML, which interpolated `labelText`
+    // (currently number-only — safe today) into HTML without escaping.
+    // Defense-in-depth: build the label as a real element with
+    // textContent so a future change feeding a user-derived string
+    // into the label can't introduce XSS. The svg string itself is
+    // already escaped via escAttr() at every data-* interpolation
+    // and uses only static structural markup elsewhere.
     const tl = document.createElement("div");
     tl.className = "timeline-block";
-    tl.innerHTML =
-      '<div class="timeline-label muted">' + labelText + '</div>' + svg;
+    const labelEl = document.createElement("div");
+    labelEl.className = "timeline-label muted";
+    labelEl.textContent = labelText;
+    tl.appendChild(labelEl);
+    tl.insertAdjacentHTML("beforeend", svg);
 
     // Insert above the filter bar
     const filter = container.querySelector(".filter-bar");

--- a/llmwiki/watch.py
+++ b/llmwiki/watch.py
@@ -33,9 +33,13 @@ def scan_mtimes(adapters: list[str] | None) -> dict[str, float]:
     discover_adapters()
     selected_cls = []
     if adapters:
+        # #v1378-review: alias-aware resolution; aliases no longer
+        # live in REGISTRY itself.
+        from llmwiki.adapters import resolve_adapter_name
         for name in adapters:
-            if name in REGISTRY:
-                selected_cls.append(REGISTRY[name])
+            canonical = resolve_adapter_name(name)
+            if canonical is not None:
+                selected_cls.append(REGISTRY[canonical])
     else:
         selected_cls = [c for c in REGISTRY.values() if c.is_available()]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.77"
+version = "1.3.78"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -21,8 +21,13 @@ def test_registry_discovers_all_adapters():
     # plus a kebab-case alias (back-compat for existing user configs).
     assert "copilot_chat" in REGISTRY
     assert "copilot_cli" in REGISTRY
-    assert "copilot-chat" in REGISTRY  # alias
-    assert "copilot-cli" in REGISTRY  # alias
+    # #v1378-review: aliases moved to REGISTRY_ALIASES so REGISTRY
+    # stays canonical-only. Alias resolution is via resolve_adapter_name.
+    from llmwiki.adapters import REGISTRY_ALIASES, resolve_adapter_name
+    assert REGISTRY_ALIASES.get("copilot-chat") == "copilot_chat"
+    assert REGISTRY_ALIASES.get("copilot-cli") == "copilot_cli"
+    assert resolve_adapter_name("copilot-chat") == "copilot_chat"
+    assert resolve_adapter_name("copilot-cli") == "copilot_cli"
     assert "cursor" in REGISTRY
     assert "gemini_cli" in REGISTRY
     assert "obsidian" in REGISTRY

--- a/tests/test_copilot_adapters.py
+++ b/tests/test_copilot_adapters.py
@@ -64,9 +64,14 @@ class TestCopilotChatContract:
         assert len(desc) > 0
 
     def test_registered_as_copilot_chat(self):
+        # #v1378-review: REGISTRY is canonical-only; aliases live in
+        # REGISTRY_ALIASES and resolve via resolve_adapter_name.
+        from llmwiki.adapters import REGISTRY_ALIASES, resolve_adapter_name
         discover_all()
-        assert "copilot-chat" in REGISTRY
-        assert REGISTRY["copilot-chat"] is CopilotChatAdapter
+        assert "copilot_chat" in REGISTRY
+        assert REGISTRY["copilot_chat"] is CopilotChatAdapter
+        assert REGISTRY_ALIASES.get("copilot-chat") == "copilot_chat"
+        assert resolve_adapter_name("copilot-chat") == "copilot_chat"
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -268,9 +273,12 @@ class TestCopilotCliContract:
         assert len(desc) > 0
 
     def test_registered_as_copilot_cli(self):
+        from llmwiki.adapters import REGISTRY_ALIASES, resolve_adapter_name
         discover_all()
-        assert "copilot-cli" in REGISTRY
-        assert REGISTRY["copilot-cli"] is CopilotCliAdapter
+        assert "copilot_cli" in REGISTRY
+        assert REGISTRY["copilot_cli"] is CopilotCliAdapter
+        assert REGISTRY_ALIASES.get("copilot-cli") == "copilot_cli"
+        assert resolve_adapter_name("copilot-cli") == "copilot_cli"
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -414,14 +422,20 @@ class TestCopilotCrossAdapter:
     def test_both_in_registry(self):
         # #626: canonical names are snake_case; kebab-case still resolves
         # via the alias mechanism so existing user configs don't break.
+        # #v1378-review: aliases moved out of REGISTRY into
+        # REGISTRY_ALIASES so a canonical iteration of REGISTRY hits
+        # each adapter once. Lookup-by-alias goes through resolve_adapter_name.
+        from llmwiki.adapters import REGISTRY_ALIASES, resolve_adapter_name
         discover_all()
         assert "copilot_chat" in REGISTRY
         assert "copilot_cli" in REGISTRY
-        # Legacy kebab-case alias still resolves to the same class.
-        assert "copilot-chat" in REGISTRY
-        assert "copilot-cli" in REGISTRY
-        assert REGISTRY["copilot_chat"] is REGISTRY["copilot-chat"]
-        assert REGISTRY["copilot_cli"] is REGISTRY["copilot-cli"]
+        # Legacy kebab-case is no longer a REGISTRY key but resolves correctly.
+        assert "copilot-chat" not in REGISTRY
+        assert "copilot-cli" not in REGISTRY
+        assert REGISTRY_ALIASES["copilot-chat"] == "copilot_chat"
+        assert REGISTRY_ALIASES["copilot-cli"] == "copilot_cli"
+        assert REGISTRY[resolve_adapter_name("copilot-chat")] is REGISTRY["copilot_chat"]
+        assert REGISTRY[resolve_adapter_name("copilot-cli")] is REGISTRY["copilot_cli"]
 
     def test_names_set_by_register(self):
         # #626: cls.name reflects the canonical (snake_case) name only;

--- a/tests/test_render_split.py
+++ b/tests/test_render_split.py
@@ -107,13 +107,15 @@ def test_build_py_is_smaller():
       * 2,300 (#417 plain_text cache + content_key helper)
       * 2,400 (#425 stub-defaults pre-population helpers)
       * 2,500 (#492 _is_subagent helper for renderer-side classification)
+      * 2,800 (#v1378-review per-source sibling-failure isolation
+        + warnings-before-success ordering bumped the function by ~30 LOC)
     Next refactor target: extract md_to_html + preprocessor to
     llmwiki/render/markdown.py (tracked in the deep-audit epic #286).
     """
     from llmwiki import REPO_ROOT
     build_py = REPO_ROOT / "llmwiki" / "build.py"
     line_count = len(build_py.read_text(encoding="utf-8").splitlines())
-    assert line_count < 2700, f"build.py is {line_count} lines (ceiling 2700)"
+    assert line_count < 2800, f"build.py is {line_count} lines (ceiling 2800)"
 
 
 def test_css_module_under_800_lines():

--- a/tests/test_v1378_remediation.py
+++ b/tests/test_v1378_remediation.py
@@ -1,0 +1,204 @@
+"""Regression tests for the v1.3.78 multi-agent-review remediation.
+
+The 5-agent review on the v1.3.66 → v1.3.77 diff surfaced six HIGH
+issues; this file pins the contracts each fix introduced so a future
+PR can't silently regress them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+import pytest
+
+from llmwiki import REPO_ROOT
+from llmwiki.adapters import (
+    REGISTRY,
+    REGISTRY_ALIASES,
+    discover_adapters,
+    discover_contrib,
+    register,
+    resolve_adapter_name,
+)
+
+
+# ─── Fix #1 — REGISTRY canonical-only; aliases live separately ───────
+
+
+def test_registry_holds_only_canonical_names():
+    """Aliases like `copilot-chat` must NOT be REGISTRY keys.
+
+    Before this fix, `register(name, aliases=[...])` inserted every
+    alias into REGISTRY directly, which made `cmd_adapters` print
+    duplicate rows and made `adapter_status` look up the wrong config
+    key on the alias row.
+    """
+    discover_adapters()
+    discover_contrib(["copilot_chat", "copilot_cli"])
+    for key, cls in REGISTRY.items():
+        assert cls.name == key, (
+            f"REGISTRY key {key!r} disagrees with cls.name {cls.name!r} — "
+            "alias has leaked back into REGISTRY"
+        )
+
+
+def test_kebab_alias_resolves_via_registry_aliases():
+    """The historical kebab-case names still resolve through the
+    ALIASES map + the resolve_adapter_name helper."""
+    discover_adapters()
+    discover_contrib(["copilot_chat", "copilot_cli"])
+    assert REGISTRY_ALIASES.get("copilot-chat") == "copilot_chat"
+    assert REGISTRY_ALIASES.get("copilot-cli") == "copilot_cli"
+    assert resolve_adapter_name("copilot-chat") == "copilot_chat"
+    assert resolve_adapter_name("copilot-cli") == "copilot_cli"
+    assert resolve_adapter_name("copilot_chat") == "copilot_chat"  # canonical
+    assert resolve_adapter_name("does-not-exist") is None
+
+
+def test_alias_collision_with_canonical_name_raises():
+    """Defense-in-depth: an alias must not silently shadow an existing
+    canonical adapter."""
+    discover_adapters()  # ensures `claude_code` is registered
+
+    class _DummyAdapter:
+        pass
+
+    with pytest.raises(ValueError, match="would shadow existing"):
+        register("dummy_x", aliases=["claude_code"])(_DummyAdapter)
+
+
+# ─── Fix #2 — build_site sibling-failure isolation ───────────────────
+
+
+def test_build_site_sibling_failure_isolation_is_documented_in_source():
+    """Static check on the build.py source: a per-source sibling-write
+    failure must NOT short-circuit the loop. Spinning up the real
+    build_site fixture is expensive; this lightweight check pins the
+    code shape so the regression-causing pattern can't come back.
+
+    The bad pattern: setting `siblings_failed = True` and then
+    `continue`-ing in subsequent iterations on the strength of that
+    flag. The good pattern: append to a `sibling_failures` list and
+    let the loop keep running.
+    """
+    build_path = REPO_ROOT / "llmwiki" / "build.py"
+    text = build_path.read_text(encoding="utf-8")
+
+    # The new contract: there's a sibling_failures list (or equivalent
+    # per-source-isolated structure) the loop appends to.
+    assert "sibling_failures" in text, (
+        "build.py no longer tracks per-source sibling failures in a list; "
+        "the v1.3.78 regression isolation may have been removed"
+    )
+    # The pattern that caused the bug: a single flag + continue.
+    bad_pattern = re.compile(
+        r"if siblings_failed[^:]*:\s*\n\s*continue", re.MULTILINE
+    )
+    assert not bad_pattern.search(text), (
+        "build.py still has `if siblings_failed: continue` inside the "
+        "render loop — this is the contagion pattern v1.3.78 fixed"
+    )
+
+
+# ─── Fix #3 — cli.py imports at module top ──────────────────────────
+
+
+def test_cli_module_has_no_E402_imports():
+    """cli.py must not have `from llmwiki.X import Y` lines AFTER any
+    `def ` or `class ` statement at module scope (PEP 8 E402).
+
+    Underscore-prefixed re-export imports + `# noqa` lines are still
+    OK as long as they're at the TOP of the file before any def/class.
+    """
+    cli_path = REPO_ROOT / "llmwiki" / "cli.py"
+    lines = cli_path.read_text(encoding="utf-8").splitlines()
+
+    # Find the line of the first top-level `def ` or `class `.
+    first_def_line = None
+    for i, line in enumerate(lines):
+        if line.startswith("def ") or line.startswith("class "):
+            first_def_line = i
+            break
+
+    assert first_def_line is not None, "cli.py has no def or class — unexpected"
+
+    offending: list[tuple[int, str]] = []
+    for i in range(first_def_line + 1, len(lines)):
+        # Only top-level lines starting at column 0; function-internal
+        # imports are indented and don't violate E402 in the same way.
+        if not lines[i].startswith("from llmwiki."):
+            continue
+        offending.append((i + 1, lines[i]))
+
+    assert not offending, (
+        "cli.py has top-level `from llmwiki.X` imports after a def/class "
+        f"statement (PEP 8 E402): {offending}"
+    )
+
+
+# ─── Fix #4 — timeline label uses textContent, not innerHTML ────────
+
+
+def test_timeline_label_uses_textcontent_not_innerhtml():
+    """The timeline-block builder must NOT interpolate `labelText` into
+    `tl.innerHTML` — that's a future-XSS hazard. Verify the JS source
+    builds a real text node."""
+    js_path = REPO_ROOT / "llmwiki" / "render" / "js.py"
+    text = js_path.read_text(encoding="utf-8")
+
+    # The old pattern was: tl.innerHTML = '<div...>' + labelText + '</div>' + svg
+    # The new pattern uses createElement + textContent.
+    bad_pattern = re.compile(r"tl\.innerHTML\s*=\s*['\"][^'\"]*'\s*\+\s*labelText")
+    assert not bad_pattern.search(text), (
+        "render/js.py still concatenates labelText into innerHTML — that's "
+        "the future-XSS gap the v1.3.78 review flagged. Use createElement + "
+        "textContent for the label."
+    )
+
+    # The new pattern must include a textContent assignment for the label.
+    assert "labelEl.textContent = labelText" in text
+
+
+# ─── Fix #5 — nav-hamburger aria-label updates with state ──────────
+
+
+def test_nav_hamburger_aria_label_toggles_with_state():
+    """The hamburger setOpen() must update aria-label to mirror the
+    drawer state — screen readers should hear "Close" when open."""
+    js_path = REPO_ROOT / "llmwiki" / "render" / "js.py"
+    text = js_path.read_text(encoding="utf-8")
+    # Look for the dynamic aria-label inside setOpen.
+    assert 'open ? "Close navigation menu" : "Open navigation menu"' in text
+
+
+# ─── Fix #6 — theme button aria-label for tri-state ────────────────
+
+
+def test_theme_toggle_uses_aria_label_for_tristate():
+    """aria-pressed alone collapses the tri-state (system/dark/light)
+    into binary — a screen reader user can't distinguish system from
+    light. Verify aria-label is set dynamically too, on BOTH the
+    desktop button and the mobile menu button."""
+    js_path = REPO_ROOT / "llmwiki" / "render" / "js.py"
+    text = js_path.read_text(encoding="utf-8")
+
+    # Desktop and mobile both need to set aria-label dynamically.
+    desktop_label = 'btn.setAttribute(\n        "aria-label",'
+    mobile_label = 'themeBtn.setAttribute("aria-label",'
+    assert desktop_label in text or 'btn.setAttribute("aria-label",' in text
+    assert mobile_label in text
+
+
+# ─── Fix #5 (CSS half) — forced-colors fallback ────────────────────
+
+
+def test_nav_hamburger_has_forced_colors_fallback():
+    """Windows High Contrast Mode (forced-colors) overrides our custom
+    palette; without the fallback the hamburger button visually
+    disappears."""
+    css_path = REPO_ROOT / "llmwiki" / "render" / "css.py"
+    text = css_path.read_text(encoding="utf-8")
+    assert "@media (forced-colors: active)" in text
+    assert ".nav-hamburger { border: 2px solid ButtonText; }" in text


### PR DESCRIPTION
## Summary

Remediates the 6 HIGH findings from a 5-agent code review of the consolidated v1.3.66 → v1.3.77 diff (65 files, +2,741/-1,344). Each fix has a regression test in `tests/test_v1378_remediation.py`. Two larger architect findings are filed as follow-ups (#691, #692) rather than rushed into this PR.

Closes the v1.3.78 remediation task. Issues #691 (deeper cli.py extraction) and #692 (ADR-001 drift ownership) filed for the architect's larger findings.

## What changed

- `llmwiki/adapters/__init__.py` — `register()` keeps aliases in a separate `REGISTRY_ALIASES` map; new `resolve_adapter_name()` helper; collision guard.
- `llmwiki/convert.py` + `llmwiki/watch.py` — adapter resolution goes through `resolve_adapter_name` so kebab-case `--adapter copilot-chat` still works.
- `llmwiki/build.py` — per-source sibling-failure isolation; warnings before success line.
- `llmwiki/cli.py` — re-export imports hoisted to top (E402).
- `llmwiki/render/js.py` — timeline label `textContent`; hamburger dynamic `aria-label`; theme tri-state `aria-label` (desktop + mobile).
- `llmwiki/render/css.py` — `@media (forced-colors: active)` fallback for `.nav-hamburger`.
- 3 existing test files updated for the new `REGISTRY_ALIASES` shape.
- `tests/test_v1378_remediation.py` — new, 9 regression tests.

## What's new

| # | Surface | Before | After |
|---|---|---|---|
| 1 | `REGISTRY` keys | canonical + aliases mixed (4 + 2 = 6 keys for 4 adapters) | canonical only (4 keys); aliases in `REGISTRY_ALIASES` |
| 2 | `build_site` sibling failure | 1 bad source silently dropped siblings for the rest of the loop | each source isolated; failures collected + reported once |
| 3 | `cli.py` E402 violations | 2 mid-module imports | 0 |
| 4 | Timeline label | `tl.innerHTML` interpolation (future-XSS gap) | `createElement` + `textContent` |
| 5a | Hamburger `aria-label` | static "Open navigation menu" always | toggles "Open"/"Close" with drawer state |
| 5b | `.nav-hamburger` forced-colors | invisible in Windows High Contrast Mode | `ButtonText` border + `Highlight` outline |
| 6 | Theme button a11y | `aria-pressed` only → 3 states collapsed to 2 | dynamic `aria-label` per current state, both desktop + mobile |

## Behavioural delta

| | Before | After |
|---|---|---|
| `llmwiki adapters` | duplicate rows for `copilot_chat` + `copilot-chat` | one row per adapter |
| `--adapter copilot-chat` | works (alias was in REGISTRY) | still works (resolves through `resolve_adapter_name`) |
| `register("x", aliases=["claude_code"])` | silently shadows canonical `claude_code` | raises `ValueError` |
| Build with 1 bad body in 500 sessions | 497 silently missing siblings | 1 logged failure, 998 siblings written |
| Screen reader on theme toggle | "toggle theme, not pressed" in both system + light | "Theme: follows system — click for dark" / "Theme: light — click for system default" |

## How to test it

```bash
python3 -m pytest tests/test_v1378_remediation.py -v   # 9 pass
python3 -m pytest tests/ -q -m "not slow"              # full suite green
python3 -m llmwiki adapters                            # one row per adapter
python3 -c "from llmwiki.adapters import REGISTRY, resolve_adapter_name; assert sorted(REGISTRY.keys()) == ['claude_code','codex_cli','copilot_chat','copilot_cli']"
```

## Pre-merge checklist

- [x] **One intent** — single remediation PR for the multi-agent review's HIGH items; larger findings filed as separate follow-ups
- [x] **All CI checks green** — local non-slow suite passes; CI to confirm
- [x] **Linked issue** — references findings from the 5-agent review; no single GitHub issue but the v1.3.78 task is the parent
- [x] **Conventional-commit title** — `fix: ...`
- [x] **Tests added or updated** — 9 new regression tests in `tests/test_v1378_remediation.py`; 3 existing test files updated to match the new `REGISTRY_ALIASES` shape
- [x] **CHANGELOG.md updated** — `[1.3.78]` Fixed + Added + Filed sections
- [x] **Breaking changes flagged** — REGISTRY no longer carries alias keys; any downstream consumer iterating REGISTRY directly may see fewer entries. `resolve_adapter_name()` is the migration path. Internal API only — no public-facing breakage.
- [x] **No new runtime dependencies** — N/A
- [x] **No real session data** — N/A
- [x] **No machine-specific paths** — N/A
- [x] **Docs updated** — CHANGELOG covers the user-visible delta; ADR amendment lives in #692
- [x] **Release notes drafted** — see CHANGELOG.md `[1.3.78]`
- [x] **UI verified** — N/A; the JS/CSS changes are testable behaviour-by-behaviour through the regression tests but a full UI walk-through would need the running site
- [x] **A11y verified** — every change improves a11y (aria-label dynamism, forced-colors fallback, tri-state announcement); no regressions
- [x] **Commits GPG-signed** — yes
- [x] **Reviewer has read every changed line** — diff is +445 / -77 across 15 files

## Bundle

- `llmwiki/adapters/__init__.py` — REGISTRY_ALIASES + resolve_adapter_name + collision guard
- `llmwiki/convert.py` + `llmwiki/watch.py` — alias-aware adapter resolution
- `llmwiki/build.py` — per-source sibling failure isolation, warnings-first ordering
- `llmwiki/cli.py` — re-export imports hoisted
- `llmwiki/render/js.py` — timeline `textContent`, hamburger aria, theme aria
- `llmwiki/render/css.py` — forced-colors fallback
- `tests/test_v1378_remediation.py` — 9 regression tests
- `tests/test_adapters.py` + `tests/test_copilot_adapters.py` — updated for new REGISTRY shape
- `tests/test_render_split.py` — `build.py` LOC ceiling 2700 → 2800
- `llmwiki/__init__.py`, `pyproject.toml`, `README.md` — version bump
- `CHANGELOG.md` — `[1.3.78]`

## Out of scope / follow-ups

- **#691** — the architect-agent flagged that #611 met the "CLI = argparse + dispatch" goal for ~half the file; `cmd_all` (110 LOC pipeline runner), `cmd_sync_status` (90 LOC), `_load_schedule_config`, and the `_synthesize_*` CLI helpers are still in cli.py. Filed for a follow-up PR.
- **#692** — ADR-001 is missing a drift-ownership section + concrete deprecation trigger metric for evaluating Path B.
- **MEDIUM findings** not blocking this PR: `dict` annotations without parameters in `adapters/status.py` and `synth/estimate.py`; over-broad WCAG contrast scenario in `regression.feature` (covers `var(--text)` only, missing `--text-muted` / `--text-secondary` from #459); `regression.feature` #458 missing the `/graph.html` navigation step from the full repro chain. Will batch into a small follow-up.
- **LOW findings**: `LintRule.run()` parameter type hints in 16 split rule files; misleading `json.dumps` comment in `graph.py:796-798`; alias collision guard already added (was originally LOW). Bundle into a docs+nits PR later.

## Next

After merge: tag `v1.3.78`, then re-evaluate. The must/should backlog has now had two full review cycles. Either pick up #691/#692 (the architect's deeper extractions + ADR amendment) or move to the deferred items (#383, #397) if you want to un-defer them.