### PR TITLE
docs: ADR-001 drift ownership + Path-B deprecation trigger (#692) — v1.3.79

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.79] — 2026-04-27
+
+#692 — ADR-001 amendment: drift ownership + Path-B deprecation trigger.
+
+### Changed
+
+- **`docs/maintainers/ADR-001-playwright-stack.md` gains two new sections** (#692) — the v1.3.76 ADR adopted Path A (Python suite gates, TS Test Agents alongside) but punted on what happens when the two suites disagree and how long Path A is allowed to stay the steady state. The amendment closes both gaps:
+  - **Drift ownership** — the Python `tests/e2e/` suite is the gating contract; the TS suite is advisory until #467 has run for one release cycle. When the suites disagree, the Python suite wins and the TS scenario gets rewritten. Reviewers check the Python update first. Sunset: when Path B is adopted under the deprecation trigger below.
+  - **Path-B deprecation trigger** — reconsider full TS migration only when both (a) agents-generated TS coverage exceeds 80% of pytest-bdd scenario count, and (b) Healer-CI auto-patch acceptance rate exceeds 50%, sustained for one full release cycle. If either threshold isn't hit after three release cycles, file a Path-C RFC (drop the TS suite). "Temporary parallel system" anti-patterns become permanent by inertia without a hard sunset.
+
 ## [1.3.78] — 2026-04-27
 
 Multi-agent code review remediation — 6 HIGH fixes from a 5-agent review of the consolidated v1.3.66 → v1.3.77 diff (python-reviewer, security-reviewer, architect, code-reviewer, typescript-reviewer). Plus follow-up issues #691 (deeper cli.py extraction) and #692 (ADR-001 drift ownership amendment) filed for the architect's larger findings.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.78-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.79-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2651%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/docs/maintainers/ADR-001-playwright-stack.md
+++ b/docs/maintainers/ADR-001-playwright-stack.md
@@ -78,6 +78,58 @@ disrupting the contract that's already shipped. After one full epic
 cycle (i.e. after #467 healer-in-CI has run for a release or two) we
 can re-evaluate whether B is worth the porting effort.
 
+## Drift ownership
+
+When two parallel test suites cover the same surface, drift is
+inevitable: the Python suite asserts X, the TS suite asserts X' where
+X ≠ X', and a real UI change disagrees with one of them. Without an
+explicit owner, both suites silently rot.
+
+The rule for this project:
+
+- **The Python `tests/e2e/` suite is the gating contract.** CI fails
+  on master if it fails. It owns the truth about expected behaviour.
+- **The TS Test Agents suite (post-#464) is advisory** until #467
+  (healer-in-CI) has run for one full release cycle and the team
+  trusts the Generator + Healer outputs.
+- **When the two suites disagree on the same area, the Python suite
+  wins.** The TS scenario gets rewritten to match.
+- **When a UI change requires updating tests,** update the Python
+  scenario first, then re-run the Generator to bring the TS suite
+  back into sync.
+- **Reviewers** of any UI PR check the Python suite update first.
+  The TS suite update is a follow-up PR if the Generator doesn't
+  auto-produce it.
+
+This rule has a sunset: once Path B (full TS migration) is adopted
+under the deprecation trigger below, the TS suite becomes the gating
+contract and the Python suite is removed.
+
+## Path-B deprecation trigger
+
+Reconsider Path B when **both** of the following are true for a full
+release cycle:
+
+1. **Coverage parity:** the agents-generated TS suite covers ≥ **80%**
+   of the pytest-bdd scenario count (measured by scenario name +
+   Given/When/Then count, not LOC). A single TS `*.spec.ts` covering
+   the same flow as a Python Background+Scenario block counts as 1:1.
+2. **Healer-CI acceptance rate:** ≥ **50%** of PRs auto-patched by
+   the Healer merge without further human edits to the patched test.
+   "Further human edits" means a follow-up commit on the same PR
+   that touches the auto-patched test file.
+
+When both thresholds hit, file a Path-B migration RFC. The migration
+involves: (a) freezing new pytest-bdd scenario authoring, (b) porting
+the remaining 20% of Python coverage to TS, (c) deleting
+`tests/e2e/` and the `[e2e]` extra in `pyproject.toml`, (d) marking
+ADR-001 superseded by ADR-002.
+
+If either threshold isn't hit after **three full release cycles**
+running both suites, file a Path-C RFC (drop the TS suite entirely).
+"Temporary parallel system" anti-patterns become permanent by inertia
+without a hard sunset; this trigger is the sunset.
+
 ## Constraints
 
 - The TS bootstrap (#464) requires `npm install` and `npx playwright

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.78"
+__version__ = "1.3.79"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.78"
+version = "1.3.79"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Amends `docs/maintainers/ADR-001-playwright-stack.md` with the two sections the architect-agent flagged as missing in the v1.3.76 Path-A ADR: **drift ownership** between the Python and TS suites, and a concrete **Path-B deprecation trigger** so the dual-suite arrangement can't become permanent by inertia. Pure docs PR.

Closes #692 (parent: #462).

## What changed

- `docs/maintainers/ADR-001-playwright-stack.md` — two new sections inserted between "Decision: A" and "Constraints":
  - **Drift ownership** (~25 lines): five rules for how the two suites coexist; Python wins on disagreement; sunset clause.
  - **Path-B deprecation trigger** (~20 lines): two quantitative thresholds (≥80% coverage parity, ≥50% Healer-CI acceptance) sustained for one release cycle; Path-C escape hatch after three cycles if thresholds miss.
- CHANGELOG `[1.3.79]` Changed entry.
- Version bump 1.3.78 → 1.3.79.

## What's new

| Surface | Before | After |
|---|---|---|
| ADR drift section | absent — ADR explicitly punted | 5 explicit rules + sunset |
| Path-B trigger | "re-evaluate after #467 ships" (squishy) | quantitative: 80% coverage parity + 50% healer acceptance, sustained 1 cycle |
| Path-C escape | implicit | explicit: file an RFC if either threshold misses for 3 cycles |
| Reviewer rule | undefined | "check the Python suite update first" |

## How to test it

```bash
cat docs/maintainers/ADR-001-playwright-stack.md | head -150
python3 -m pytest tests/test_readme_badges.py -q   # version badge still in sync
```

## Pre-merge checklist

- [x] **One intent** — single ADR amendment
- [x] **All CI checks green** — verified locally; CI to confirm
- [x] **Linked issue** — `Closes #692` in body
- [x] **Conventional-commit title** — `docs: ...`
- [x] **Tests added or updated** — N/A; doc-only PR
- [x] **CHANGELOG.md updated** — `[1.3.79]` Changed entry
- [x] **Breaking changes flagged** — N/A
- [x] **No new runtime dependencies** — N/A
- [x] **No real session data** — N/A
- [x] **No machine-specific paths** — N/A
- [x] **Docs updated** — this IS the docs update
- [x] **Release notes drafted** — see CHANGELOG.md `[1.3.79]`
- [x] **UI verified** — N/A
- [x] **A11y verified** — N/A
- [x] **Commits GPG-signed** — yes
- [x] **Reviewer has read every changed line** — diff is +65 / -3 across 5 files; ADR is 60 of those lines

## Bundle

- `docs/maintainers/ADR-001-playwright-stack.md` — drift ownership + Path-B trigger sections
- `llmwiki/__init__.py`, `pyproject.toml` — version 1.3.78 → 1.3.79
- `README.md` — version badge bump
- `CHANGELOG.md` — `[1.3.79]` Changed entry

## Out of scope / follow-ups

- Actually measuring the deprecation thresholds requires #464 (TS bootstrap) + #467 (Healer-CI) to ship first. Until then, the trigger metrics aren't observable. Filed as a follow-up note in the ADR.
- The "advisory until #467 has run for one release cycle" clause means the Python suite stays the only enforced contract for at least 1 cycle past #467 even if coverage parity hits sooner. Intentional belt-and-suspenders.

## Next

After merge: tag `v1.3.79`, then move to **#691** (extract `cmd_all`, `cmd_sync_status`, `_load_schedule_config`, `_synthesize_*` from cli.py — the architect's deeper refactor follow-up).