### PR TITLE
refactor(cli): extract pipeline + sync.status + helpers (#691) — v1.3.80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ Versions below 1.0 are pre-production — API and file formats may change.
 
 ## [Unreleased]
 
+## [1.3.80] — 2026-04-27
+
+#691 / #arch-h8 — second pass extracting business logic from `cli.py`. Builds on #611 (which moved `synthesize_estimate_report` + `_adapter_status`).
+
+### Changed
+
+- **`cmd_all` moved to `llmwiki/pipeline.py:run_pipeline`** (#691) — the 110-LOC pipeline orchestrator was domain logic, not CLI glue. `cli.py:cmd_all` is now a one-liner that calls `_run_pipeline(args)`. The `cmd_*` step targets are lazy-imported inside `run_pipeline` to avoid a circular import.
+- **`cmd_sync_status` + `_resolve_key_exists` moved to `llmwiki/sync/status.py`** (#691) — sync observability (state-file parsing, quarantine counts, orphan detection) belongs in the sync subpackage. New `llmwiki/sync/` package with `__init__.py` re-exporting both. Renamed to `cmd_sync_status` + `resolve_key_exists` (no leading underscore at the new home; `cli.py` re-exports under the underscored name for back-compat).
+- **`_load_schedule_config` + `_should_run_after_sync` moved to `llmwiki/config_schedule.py`** (#691) — config-policy concerns. Renamed without underscores at the new home; `cli.py` re-exports.
+- **`_synthesize_list_pending` + `_synthesize_complete` moved to `llmwiki/synth/cli_helpers.py`** (#691) — these were inconsistently extracted: `synthesize_estimate_report` already lived in `synth/estimate.py` but its two siblings stayed in `cli.py`. Now consistent.
+- **`cli.py` shrunk from 1,228 → 942 LOC (-286)** — closing in on the architect-flagged "<900 LOC" target. Closer to argparse-setup + dispatch only; the remaining LOC is mostly the parser definition + small `cmd_*` wrappers.
+
+### Filed
+
+- The `synth/estimate.py` private-API reach (`_discover_raw_sessions`, `_load_state`) flagged in the same review is **out of scope** for this PR; promoting those to public is a follow-up that touches synth/pipeline.py's public surface.
+
 ## [1.3.79] — 2026-04-27
 
 #692 — ADR-001 amendment: drift ownership + Path-B deprecation trigger.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rebuilt on every `master` push from the synthetic sessions in [`examples/demo-se
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/)
-[![Version](https://img.shields.io/badge/version-v1.3.79-10B981.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-v1.3.80-10B981.svg)](CHANGELOG.md)
 [![Tests](https://img.shields.io/badge/tests-2651%20passing-10B981.svg)](tests/)
 [![CI](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/ci.yml)
 [![Link check](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml/badge.svg?branch=master)](https://github.com/Pratiyush/llm-wiki/actions/workflows/link-check.yml)

--- a/llmwiki/__init__.py
+++ b/llmwiki/__init__.py
@@ -15,7 +15,7 @@ Public API:
     - llmwiki.mcp.server.main()       — MCP server (stdio)
 """
 
-__version__ = "1.3.79"
+__version__ = "1.3.80"
 __author__ = "Pratiyush"
 __license__ = "MIT"
 

--- a/llmwiki/cli.py
+++ b/llmwiki/cli.py
@@ -33,6 +33,22 @@ from llmwiki.adapters import REGISTRY, discover_adapters
 # for any caller still importing from llmwiki.cli.
 from llmwiki.adapters.status import adapter_status as _adapter_status  # noqa: F401
 from llmwiki.synth.estimate import synthesize_estimate_report  # noqa: F401
+# #691 / #arch-h8: extracted business logic moves out of cli.py.
+# cli.py keeps thin re-export wrappers for back-compat with anyone
+# doing `from llmwiki.cli import cmd_all, cmd_sync_status, ...`.
+from llmwiki.config_schedule import (  # noqa: F401
+    load_schedule_config as _load_schedule_config,
+    should_run_after_sync as _should_run_after_sync,
+)
+from llmwiki.pipeline import run_pipeline as _run_pipeline
+from llmwiki.sync.status import (  # noqa: F401
+    cmd_sync_status,
+    resolve_key_exists as _resolve_key_exists,
+)
+from llmwiki.synth.cli_helpers import (  # noqa: F401
+    complete as _synthesize_complete,
+    list_pending as _synthesize_list_pending,
+)
 
 
 def cmd_version(args: argparse.Namespace) -> int:
@@ -43,113 +59,9 @@ def cmd_version(args: argparse.Namespace) -> int:
 def cmd_all(args: argparse.Namespace) -> int:
     """Run the full wiki pipeline end-to-end: build → graph → export all → lint.
 
-    This is the convenience entry point advertised as ``wiki-all`` in docs and
-    slash commands. It executes the usual post-sync steps in the canonical
-    order so a single command reproduces a CI-ready site.
-
-    Exit codes:
-      0  every step succeeded (lint warnings are informational).
-      1  at least one step returned a non-zero exit status.
-      2  ``--strict`` was passed and lint reported any error or warning.
+    Thin shim — the implementation lives in ``llmwiki.pipeline`` (#691).
     """
-    # #py-h4 (#583): direct dispatch instead of round-tripping through
-    # argparse. The old version built ``["build", "--out", "..."]`` argv
-    # lists and re-parsed them via the global ``build_parser()``, which
-    # meant every flag #422 then optimised away the *per-step* re-parse,
-    # but ``cmd_all`` still depended on the global parser's full grammar
-    # — adding a flag to any unrelated subcommand could regress
-    # ``cmd_all`` if defaults shifted. Now we construct each step's
-    # Namespace directly with the defaults the relevant cmd_* expects,
-    # which is also what ``cmd_all`` was *supposed* to do per its
-    # docstring (avoid global-parser coupling).
-    def _ns(**kw: Any) -> argparse.Namespace:
-        return argparse.Namespace(**kw)
-
-    steps: list[tuple[str, str, argparse.Namespace]] = []
-    steps.append((
-        "build",
-        f"build --out {args.out} --search-mode {args.search_mode}",
-        _ns(
-            out=args.out,
-            synthesize=False,
-            claude="",
-            search_mode=args.search_mode or "auto",
-            seed_project_stubs=False,
-            vault=None,
-        ),
-    ))
-    if not args.skip_graph:
-        steps.append((
-            "graph",
-            f"graph --format both --engine {args.graph_engine}",
-            _ns(format="both", engine=args.graph_engine),
-        ))
-    steps.append((
-        "export",
-        f"export all --out {args.out}",
-        _ns(format="all", out=args.out, topic=""),
-    ))
-    # ``lint --fail-on-errors`` so error-severity issues already fail the step;
-    # ``--strict`` additionally escalates warnings (checked below).
-    lint_label = "lint --fail-on-errors" if args.strict else "lint"
-    steps.append((
-        "lint",
-        lint_label,
-        _ns(
-            wiki_dir=None,
-            rules=None,
-            include_llm=False,
-            json=False,
-            fail_on_errors=args.strict,
-        ),
-    ))
-
-    dispatch = {
-        "build": cmd_build,
-        "graph": cmd_graph,
-        "export": cmd_export,
-        "lint": cmd_lint,
-    }
-
-    overall_rc = 0
-    lint_rc: Optional[int] = None
-    for name, label, sub_args in steps:
-        print(f"\n==> llmwiki {label}")
-        rc = dispatch[name](sub_args)
-        if name == "lint":
-            lint_rc = rc
-            continue  # lint's own exit policy is handled below
-        if rc != 0:
-            overall_rc = rc if overall_rc == 0 else overall_rc
-            if args.fail_fast:
-                print(f"error: step '{name}' exited {rc}; stopping (--fail-fast).", file=sys.stderr)
-                return rc
-
-    if args.strict:
-        # ``--strict`` escalates *any* lint signal — errors OR warnings —
-        # into a pipeline failure. Re-read the lint report directly so we
-        # don't depend on lint's own exit code, which by design only fires
-        # on error-severity issues.
-        from llmwiki.lint import load_pages, run_all, summarize
-        wiki_dir = REPO_ROOT / "wiki"
-        if wiki_dir.is_dir():
-            pages = load_pages(wiki_dir)
-            issues = run_all(pages)
-            counts = summarize(issues) if issues else {}
-            errors = counts.get("error", 0)
-            warnings = counts.get("warning", 0)
-            if errors or warnings:
-                print(
-                    f"error: --strict: lint reported "
-                    f"{errors} error(s) + {warnings} warning(s).",
-                    file=sys.stderr,
-                )
-                return 2
-
-    if lint_rc not in (None, 0) and overall_rc == 0:
-        overall_rc = lint_rc
-
-    return overall_rc
+    return _run_pipeline(args)
 
 
 def cmd_init(args: argparse.Namespace) -> int:
@@ -285,32 +197,8 @@ def cmd_sync(args: argparse.Namespace) -> int:
     return rc
 
 
-def _load_schedule_config() -> dict[str, str]:
-    """Load build/lint schedule config from sessions_config.json."""
-    import json as _json
-    from llmwiki import REPO_ROOT
-    config_path = REPO_ROOT / "examples" / "sessions_config.json"
-    if not config_path.is_file():
-        return {"build": "on-sync", "lint": "manual"}
-    try:
-        data = _json.loads(config_path.read_text(encoding="utf-8"))
-    except (ValueError, OSError):
-        return {"build": "on-sync", "lint": "manual"}
-    schedule = data.get("schedule", {})
-    return {
-        "build": schedule.get("build", "on-sync"),
-        "lint": schedule.get("lint", "manual"),
-    }
-
-
-def _should_run_after_sync(schedule: str) -> bool:
-    """Return True if the schedule value indicates running after sync.
-
-    Accepted values: "on-sync", "daily", "weekly", "manual", "never".
-    Only "on-sync" triggers from cmd_sync. "daily"/"weekly" run from a
-    scheduled task; "manual" and "never" never auto-run.
-    """
-    return schedule.lower() == "on-sync"
+# _load_schedule_config + _should_run_after_sync moved to
+# llmwiki/config_schedule.py and re-exported at top of file (#691).
 
 
 def cmd_build(args: argparse.Namespace) -> int:
@@ -470,106 +358,8 @@ def cmd_graph(args: argparse.Namespace) -> int:
     return build_and_report(write_json_flag=write_json, write_html_flag=write_html)
 
 
-def cmd_sync_status(args: argparse.Namespace) -> int:
-    """Report sync observability — last run, per-adapter counters, quarantined sources.
-
-    G-03 (#289): emits a one-screen status report so operators can see
-    *what synced / what didn't / why*.  Reads ``.llmwiki-state.json``
-    for the last-sync timestamp + per-adapter counters (written there
-    by ``convert_all``) and ``.llmwiki-quarantine.json`` for the failing
-    sources.
-    """
-    # #py-l10 (#608): Path is already imported at module top (line 25 as
-    # `from pathlib import Path`); re-importing as `_Path` here was
-    # legacy from an earlier rename. Just reuse the module-level name.
-    import json as _json
-    from datetime import datetime, timezone
-
-    from llmwiki import quarantine as _q
-    from llmwiki.convert import DEFAULT_STATE_FILE
-
-    state: dict = {}
-    if DEFAULT_STATE_FILE.is_file():
-        try:
-            state = _json.loads(DEFAULT_STATE_FILE.read_text(encoding="utf-8"))
-        except (ValueError, OSError):
-            state = {}
-
-    meta = state.pop("_meta", {}) if isinstance(state, dict) else {}
-    counters = state.pop("_counters", {}) if isinstance(state, dict) else {}
-
-    last_sync = meta.get("last_sync")
-    if last_sync:
-        try:
-            ts = datetime.fromisoformat(last_sync.replace("Z", "+00:00"))
-            delta = datetime.now(timezone.utc) - ts
-            human = f"{int(delta.total_seconds() // 3600)}h ago"
-            print(f"Last sync: {last_sync} ({human})")
-        except ValueError:
-            print(f"Last sync: {last_sync}")
-    else:
-        print("Last sync: never (or pre-upgrade state file)")
-
-    print()
-    if counters:
-        print("Adapters:")
-        header = (
-            f"  {'adapter':<16}  {'discovered':>10}  {'converted':>9}  "
-            f"{'unchanged':>9}  {'live':>5}  {'filtered':>8}  {'errored':>7}"
-        )
-        print(header)
-        print("  " + "-" * (len(header) - 2))
-        for name, c in sorted(counters.items()):
-            print(
-                f"  {name:<16}  {c.get('discovered', 0):>10}  "
-                f"{c.get('converted', 0):>9}  "
-                f"{c.get('unchanged', 0):>9}  "
-                f"{c.get('live', 0):>5}  "
-                f"{c.get('filtered', 0):>8}  "
-                f"{c.get('errored', 0):>7}"
-            )
-    else:
-        print("No per-adapter counters recorded (run `llmwiki sync` first).")
-
-    print()
-    orphans = [
-        k for k in state.keys()
-        if isinstance(k, str) and k.startswith(tuple(f"{n}::" for n in counters))
-        and not _resolve_key_exists(k)
-    ]
-    if orphans:
-        print(f"Orphan state entries: {len(orphans)} (source path no longer on disk)")
-
-    # Read the module-level default at call time so monkeypatches take effect.
-    quar_counts = _q.count_by_adapter(_q.DEFAULT_QUARANTINE_FILE)
-    if quar_counts:
-        total = sum(quar_counts.values())
-        print(f"Quarantined sources: {total} "
-              f"({', '.join(f'{k}:{v}' for k, v in sorted(quar_counts.items()))})")
-    else:
-        print("Quarantined sources: 0")
-
-    if args.recent:
-        from llmwiki.log_reader import recent_events
-        log_path = REPO_ROOT / "wiki" / "log.md"
-        events = recent_events(log_path, limit=args.recent, operations={"sync", "synthesize"})
-        if events:
-            print()
-            print(f"Recent activity (last {len(events)}):")
-            for e in events:
-                print(f"  [{e.date.isoformat()}] {e.operation:<12} {e.title}")
-
-    return 0
-
-
-def _resolve_key_exists(key: str) -> bool:
-    """Check whether a portable state-file key points at an extant file."""
-    # #py-l10 (#608): Path is already imported at module top.
-    if "::" not in key:
-        return Path(key).exists()
-    _, rel = key.split("::", 1)
-    candidate = Path.home() / rel
-    return candidate.exists() or Path(rel).exists()
+# cmd_sync_status + _resolve_key_exists moved to llmwiki/sync/status.py
+# and re-exported at top of file (#691).
 
 
 def cmd_export(args: argparse.Namespace) -> int:
@@ -760,84 +550,8 @@ def cmd_synthesize(args: argparse.Namespace) -> int:
 
 
 # ─── #316 agent-delegate CLI helpers ─────────────────────────────────
-
-
-def _synthesize_list_pending() -> int:
-    """Print the pending-prompts table for ``--list-pending``.
-
-    Two-column layout: uuid │ slug · project · date · prompt-path.
-    Exit 0 even when empty — the slash-command layer treats "nothing
-    pending" as a success signal.
-    """
-    from llmwiki.synth.agent_delegate import list_pending
-
-    rows = list_pending()
-    if not rows:
-        print("No pending prompts.")
-        return 0
-    # Max-width uuid column for alignment.
-    uuid_w = max(len(r["uuid"]) for r in rows)
-    print(f"{'UUID':<{uuid_w}}  SLUG · PROJECT · DATE")
-    print(f"{'-' * uuid_w}  " + "-" * 40)
-    for r in rows:
-        meta = " · ".join(
-            part for part in (r["slug"], r["project"], r["date"]) if part
-        )
-        print(f"{r['uuid']:<{uuid_w}}  {meta}")
-    print(f"\n{len(rows)} pending prompt(s).")
-    return 0
-
-
-def _synthesize_complete(args: argparse.Namespace) -> int:
-    """Rewrite a placeholder wiki page with the agent's synthesis.
-
-    Reads the synthesized body from ``args.body`` (file) or stdin, calls
-    :func:`llmwiki.synth.agent_delegate.complete_pending` to replace the
-    sentinel + prompt-file pair with the real content.  Exit codes:
-
-    * ``0`` — success
-    * ``1`` — missing --page, uuid mismatch, missing sentinel, or I/O
-      error
-    """
-    from llmwiki.synth.agent_delegate import complete_pending
-
-    if not args.page:
-        print("error: --complete requires --page <path>", file=sys.stderr)
-        return 1
-
-    page_path = Path(args.page)
-    if not page_path.is_absolute():
-        page_path = REPO_ROOT / page_path
-
-    if args.body:
-        body_path = Path(args.body)
-        if not body_path.is_absolute():
-            body_path = REPO_ROOT / body_path
-        try:
-            body = body_path.read_text(encoding="utf-8")
-        except OSError as e:
-            print(f"error: reading --body {body_path}: {e}", file=sys.stderr)
-            return 1
-    else:
-        body = sys.stdin.read()
-        if not body:
-            print(
-                "error: --complete expects a body on stdin or via --body",
-                file=sys.stderr,
-            )
-            return 1
-
-    try:
-        complete_pending(args.complete, body, page_path)
-    except FileNotFoundError as e:
-        print(f"error: {e}", file=sys.stderr)
-        return 1
-    except ValueError as e:
-        print(f"error: {e}", file=sys.stderr)
-        return 1
-
-    print(f"completed: {page_path}")
-    return 0
+# _synthesize_list_pending + _synthesize_complete moved to
+# llmwiki/synth/cli_helpers.py and re-exported at top of file (#691).
 
 
 def _synthesize_estimate() -> int:

--- a/llmwiki/config_schedule.py
+++ b/llmwiki/config_schedule.py
@@ -1,0 +1,46 @@
+"""Schedule-config helpers extracted from cli.py (#691 / #arch-h8).
+
+The "should this step run automatically after sync?" decision is a
+config-policy concern, not a CLI concern. Moved out of ``cli.py``
+into this module; ``cli.py`` re-exports under the original
+underscored names for back-compat.
+"""
+
+from __future__ import annotations
+
+import json as _json
+
+from llmwiki import REPO_ROOT
+
+
+def load_schedule_config() -> dict[str, str]:
+    """Load build/lint schedule config from sessions_config.json.
+
+    Returns a dict with at minimum ``build`` and ``lint`` keys, each
+    one of ``on-sync``, ``daily``, ``weekly``, ``manual``, or ``never``.
+    Defaults are ``build: on-sync, lint: manual`` when the config file
+    is missing or malformed.
+    """
+    config_path = REPO_ROOT / "examples" / "sessions_config.json"
+    if not config_path.is_file():
+        return {"build": "on-sync", "lint": "manual"}
+    try:
+        data = _json.loads(config_path.read_text(encoding="utf-8"))
+    except (ValueError, OSError):
+        return {"build": "on-sync", "lint": "manual"}
+    schedule = data.get("schedule", {})
+    return {
+        "build": schedule.get("build", "on-sync"),
+        "lint": schedule.get("lint", "manual"),
+    }
+
+
+def should_run_after_sync(schedule: str) -> bool:
+    """Return True if the schedule value indicates running after sync.
+
+    Accepted values: ``on-sync``, ``daily``, ``weekly``, ``manual``,
+    ``never``. Only ``on-sync`` triggers from cmd_sync. ``daily`` /
+    ``weekly`` run from a scheduled task; ``manual`` and ``never``
+    never auto-run.
+    """
+    return schedule.lower() == "on-sync"

--- a/llmwiki/pipeline.py
+++ b/llmwiki/pipeline.py
@@ -1,0 +1,131 @@
+"""End-to-end build pipeline orchestrator (#691 / #arch-h8).
+
+Pre-#691 ``cmd_all`` lived inside ``cli.py`` and was a 110-LOC
+pipeline runner that constructed argparse Namespaces by hand and
+dispatched to the cmd_* functions. The architect-agent flagged it as
+domain logic that didn't belong in a CLI shim.
+
+The function moves here. ``cli.py`` re-exports it as ``cmd_all`` so
+existing callers and the argparse `func=` set_defaults continue to
+work unchanged. The cmd_* dispatch targets are imported lazily
+inside the function to avoid a circular import (cli.py imports this
+module at top, this module would otherwise import cli.py).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any, Optional
+
+from llmwiki import REPO_ROOT
+
+
+def run_pipeline(args: argparse.Namespace) -> int:
+    """Run the full wiki pipeline end-to-end: build → graph → export all → lint.
+
+    This is the convenience entry point advertised as ``wiki-all`` in
+    docs and slash commands. It executes the usual post-sync steps in
+    the canonical order so a single command reproduces a CI-ready
+    site.
+
+    Exit codes:
+      0  every step succeeded (lint warnings are informational).
+      1  at least one step returned a non-zero exit status.
+      2  ``--strict`` was passed and lint reported any error or warning.
+    """
+    # #py-h4 (#583): direct dispatch instead of round-tripping through
+    # argparse. Each step's Namespace is constructed with the defaults
+    # the relevant cmd_* expects; no global parser involvement.
+    # cmd_* are lazy-imported here to avoid a circular import — cli.py
+    # imports run_pipeline at module top.
+    from llmwiki.cli import cmd_build, cmd_export, cmd_graph, cmd_lint
+
+    def _ns(**kw: Any) -> argparse.Namespace:
+        return argparse.Namespace(**kw)
+
+    steps: list[tuple[str, str, argparse.Namespace]] = []
+    steps.append((
+        "build",
+        f"build --out {args.out} --search-mode {args.search_mode}",
+        _ns(
+            out=args.out,
+            synthesize=False,
+            claude="",
+            search_mode=args.search_mode or "auto",
+            seed_project_stubs=False,
+            vault=None,
+        ),
+    ))
+    if not args.skip_graph:
+        steps.append((
+            "graph",
+            f"graph --format both --engine {args.graph_engine}",
+            _ns(format="both", engine=args.graph_engine),
+        ))
+    steps.append((
+        "export",
+        f"export all --out {args.out}",
+        _ns(format="all", out=args.out, topic=""),
+    ))
+    # ``lint --fail-on-errors`` so error-severity issues already fail the step;
+    # ``--strict`` additionally escalates warnings (checked below).
+    lint_label = "lint --fail-on-errors" if args.strict else "lint"
+    steps.append((
+        "lint",
+        lint_label,
+        _ns(
+            wiki_dir=None,
+            rules=None,
+            include_llm=False,
+            json=False,
+            fail_on_errors=args.strict,
+        ),
+    ))
+
+    dispatch = {
+        "build": cmd_build,
+        "graph": cmd_graph,
+        "export": cmd_export,
+        "lint": cmd_lint,
+    }
+
+    overall_rc = 0
+    lint_rc: Optional[int] = None
+    for name, label, sub_args in steps:
+        print(f"\n==> llmwiki {label}")
+        rc = dispatch[name](sub_args)
+        if name == "lint":
+            lint_rc = rc
+            continue  # lint's own exit policy is handled below
+        if rc != 0:
+            overall_rc = rc if overall_rc == 0 else overall_rc
+            if args.fail_fast:
+                print(f"error: step '{name}' exited {rc}; stopping (--fail-fast).", file=sys.stderr)
+                return rc
+
+    if args.strict:
+        # ``--strict`` escalates *any* lint signal — errors OR warnings —
+        # into a pipeline failure. Re-read the lint report directly so we
+        # don't depend on lint's own exit code, which by design only fires
+        # on error-severity issues.
+        from llmwiki.lint import load_pages, run_all, summarize
+        wiki_dir = REPO_ROOT / "wiki"
+        if wiki_dir.is_dir():
+            pages = load_pages(wiki_dir)
+            issues = run_all(pages)
+            counts = summarize(issues) if issues else {}
+            errors = counts.get("error", 0)
+            warnings = counts.get("warning", 0)
+            if errors or warnings:
+                print(
+                    f"error: --strict: lint reported "
+                    f"{errors} error(s) + {warnings} warning(s).",
+                    file=sys.stderr,
+                )
+                return 2
+
+    if lint_rc not in (None, 0) and overall_rc == 0:
+        overall_rc = lint_rc
+
+    return overall_rc

--- a/llmwiki/sync/__init__.py
+++ b/llmwiki/sync/__init__.py
@@ -1,0 +1,13 @@
+"""Sync subpackage — observability + status reporting (#691 / #arch-h8).
+
+Pre-#691 ``cmd_sync_status`` and ``_resolve_key_exists`` lived inside
+``cli.py``. They're sync-domain logic (state-file parsing, quarantine
+counts, orphan detection) that doesn't belong in a CLI shim. Both
+move under this package; ``cli.py`` re-exports them for back-compat.
+"""
+
+from __future__ import annotations
+
+from llmwiki.sync.status import cmd_sync_status, resolve_key_exists  # noqa: F401
+
+__all__ = ["cmd_sync_status", "resolve_key_exists"]

--- a/llmwiki/sync/status.py
+++ b/llmwiki/sync/status.py
@@ -1,0 +1,114 @@
+"""Sync observability — last run, per-adapter counters, quarantined sources.
+
+G-03 (#289): emits a one-screen status report so operators can see
+*what synced / what didn't / why*. Reads ``.llmwiki-state.json`` for
+the last-sync timestamp + per-adapter counters (written there by
+``convert_all``) and ``.llmwiki-quarantine.json`` for the failing
+sources.
+
+#691 / #arch-h8: extracted from ``cli.py`` because it's sync-domain
+logic, not argparse glue. ``cli.py`` re-exports ``cmd_sync_status``
++ ``resolve_key_exists`` for back-compat.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json as _json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from llmwiki import REPO_ROOT
+
+
+def resolve_key_exists(key: str) -> bool:
+    """Check whether a portable state-file key points at an extant file.
+
+    Renamed from `_resolve_key_exists` (no leading underscore at the new
+    canonical home; cli.py re-exports under the underscored name).
+    """
+    if "::" not in key:
+        return Path(key).exists()
+    _, rel = key.split("::", 1)
+    candidate = Path.home() / rel
+    return candidate.exists() or Path(rel).exists()
+
+
+def cmd_sync_status(args: argparse.Namespace) -> int:
+    """Report sync observability — last run, per-adapter counters, quarantined sources."""
+    from llmwiki import quarantine as _q
+    from llmwiki.convert import DEFAULT_STATE_FILE
+
+    state: dict = {}
+    if DEFAULT_STATE_FILE.is_file():
+        try:
+            state = _json.loads(DEFAULT_STATE_FILE.read_text(encoding="utf-8"))
+        except (ValueError, OSError):
+            state = {}
+
+    meta = state.pop("_meta", {}) if isinstance(state, dict) else {}
+    counters = state.pop("_counters", {}) if isinstance(state, dict) else {}
+
+    last_sync = meta.get("last_sync")
+    if last_sync:
+        try:
+            ts = datetime.fromisoformat(last_sync.replace("Z", "+00:00"))
+            delta = datetime.now(timezone.utc) - ts
+            human = f"{int(delta.total_seconds() // 3600)}h ago"
+            print(f"Last sync: {last_sync} ({human})")
+        except ValueError:
+            print(f"Last sync: {last_sync}")
+    else:
+        print("Last sync: never (or pre-upgrade state file)")
+
+    print()
+    if counters:
+        print("Adapters:")
+        header = (
+            f"  {'adapter':<16}  {'discovered':>10}  {'converted':>9}  "
+            f"{'unchanged':>9}  {'live':>5}  {'filtered':>8}  {'errored':>7}"
+        )
+        print(header)
+        print("  " + "-" * (len(header) - 2))
+        for name, c in sorted(counters.items()):
+            print(
+                f"  {name:<16}  {c.get('discovered', 0):>10}  "
+                f"{c.get('converted', 0):>9}  "
+                f"{c.get('unchanged', 0):>9}  "
+                f"{c.get('live', 0):>5}  "
+                f"{c.get('filtered', 0):>8}  "
+                f"{c.get('errored', 0):>7}"
+            )
+    else:
+        print("No per-adapter counters recorded (run `llmwiki sync` first).")
+
+    print()
+    orphans = [
+        k for k in state.keys()
+        if isinstance(k, str) and k.startswith(tuple(f"{n}::" for n in counters))
+        and not resolve_key_exists(k)
+    ]
+    if orphans:
+        print(f"Orphan state entries: {len(orphans)} (source path no longer on disk)")
+
+    # Read the module-level default at call time so monkeypatches take effect.
+    quar_counts = _q.count_by_adapter(_q.DEFAULT_QUARANTINE_FILE)
+    if quar_counts:
+        total = sum(quar_counts.values())
+        print(f"Quarantined sources: {total} "
+              f"({', '.join(f'{k}:{v}' for k, v in sorted(quar_counts.items()))})")
+    else:
+        print("Quarantined sources: 0")
+
+    if args.recent:
+        from llmwiki.log_reader import recent_events
+        log_path = REPO_ROOT / "wiki" / "log.md"
+        events = recent_events(log_path, limit=args.recent, operations={"sync", "synthesize"})
+        if events:
+            print()
+            print(f"Recent activity (last {len(events)}):")
+            for e in events:
+                print(f"  [{e.date.isoformat()}] {e.operation:<12} {e.title}")
+
+    return 0

--- a/llmwiki/synth/cli_helpers.py
+++ b/llmwiki/synth/cli_helpers.py
@@ -1,0 +1,98 @@
+"""CLI helpers for ``llmwiki synthesize`` extracted from cli.py
+(#691 / #arch-h8).
+
+These two helpers (`list_pending`, `complete`) wrap
+``llmwiki.synth.agent_delegate`` for the ``--list-pending`` and
+``--complete <uuid>`` command-line subactions. They're synth-domain
+logic with file I/O + stdin handling, not argparse glue, so they
+move out of ``cli.py``. ``cli.py`` re-exports under the original
+underscored names for back-compat.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from llmwiki import REPO_ROOT
+
+
+def list_pending() -> int:
+    """Print the pending-prompts table for ``--list-pending``.
+
+    Two-column layout: uuid │ slug · project · date. Exit 0 even when
+    empty — the slash-command layer treats "nothing pending" as a
+    success signal.
+    """
+    from llmwiki.synth.agent_delegate import list_pending as _list_pending
+
+    rows = _list_pending()
+    if not rows:
+        print("No pending prompts.")
+        return 0
+    # Max-width uuid column for alignment.
+    uuid_w = max(len(r["uuid"]) for r in rows)
+    print(f"{'UUID':<{uuid_w}}  SLUG · PROJECT · DATE")
+    print(f"{'-' * uuid_w}  " + "-" * 40)
+    for r in rows:
+        meta = " · ".join(
+            part for part in (r["slug"], r["project"], r["date"]) if part
+        )
+        print(f"{r['uuid']:<{uuid_w}}  {meta}")
+    print(f"\n{len(rows)} pending prompt(s).")
+    return 0
+
+
+def complete(args: argparse.Namespace) -> int:
+    """Rewrite a placeholder wiki page with the agent's synthesis.
+
+    Reads the synthesized body from ``args.body`` (file) or stdin,
+    calls :func:`llmwiki.synth.agent_delegate.complete_pending` to
+    replace the sentinel + prompt-file pair with the real content.
+
+    Exit codes:
+
+    * ``0`` — success
+    * ``1`` — missing --page, uuid mismatch, missing sentinel, or I/O
+      error
+    """
+    from llmwiki.synth.agent_delegate import complete_pending
+
+    if not args.page:
+        print("error: --complete requires --page <path>", file=sys.stderr)
+        return 1
+
+    page_path = Path(args.page)
+    if not page_path.is_absolute():
+        page_path = REPO_ROOT / page_path
+
+    if args.body:
+        body_path = Path(args.body)
+        if not body_path.is_absolute():
+            body_path = REPO_ROOT / body_path
+        try:
+            body = body_path.read_text(encoding="utf-8")
+        except OSError as e:
+            print(f"error: reading --body {body_path}: {e}", file=sys.stderr)
+            return 1
+    else:
+        body = sys.stdin.read()
+        if not body:
+            print(
+                "error: --complete expects a body on stdin or via --body",
+                file=sys.stderr,
+            )
+            return 1
+
+    try:
+        complete_pending(args.complete, body, page_path)
+    except FileNotFoundError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    print(f"completed: {page_path}")
+    return 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-notebook"
-version = "1.3.79"
+version = "1.3.80"
 description = "Karpathy-style LLM wiki from your Claude Code, Codex CLI, Cursor, and Obsidian sessions"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_cli_observability.py
+++ b/tests/test_cli_observability.py
@@ -189,7 +189,7 @@ def test_sync_status_empty_state(tmp_path, monkeypatch, capsys):
     import llmwiki.cli as cli_mod
     import llmwiki.convert as convert_mod
     monkeypatch.setattr(convert_mod, "DEFAULT_STATE_FILE", tmp_path / "state.json")
-    monkeypatch.setattr(cli_mod, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(cli_mod, "REPO_ROOT", tmp_path); import llmwiki.sync.status as sync_status_mod; monkeypatch.setattr(sync_status_mod, "REPO_ROOT", tmp_path)
     args = _mk_sync_status_args()
     rc = cli_mod.cmd_sync_status(args)
     assert rc == 0
@@ -221,7 +221,7 @@ def test_sync_status_renders_counters_table(tmp_path, monkeypatch, capsys):
     import llmwiki.cli as cli_mod
     import llmwiki.convert as convert_mod
     monkeypatch.setattr(convert_mod, "DEFAULT_STATE_FILE", state_file)
-    monkeypatch.setattr(cli_mod, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(cli_mod, "REPO_ROOT", tmp_path); import llmwiki.sync.status as sync_status_mod; monkeypatch.setattr(sync_status_mod, "REPO_ROOT", tmp_path)
     rc = cli_mod.cmd_sync_status(_mk_sync_status_args())
     assert rc == 0
     out = capsys.readouterr().out
@@ -244,7 +244,7 @@ def test_sync_status_surfaces_quarantine(tmp_path, monkeypatch, capsys):
     import llmwiki.convert as convert_mod
     monkeypatch.setattr(convert_mod, "DEFAULT_STATE_FILE", state_file)
     monkeypatch.setattr(q, "DEFAULT_QUARANTINE_FILE", quar_file)
-    monkeypatch.setattr(cli_mod, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(cli_mod, "REPO_ROOT", tmp_path); import llmwiki.sync.status as sync_status_mod; monkeypatch.setattr(sync_status_mod, "REPO_ROOT", tmp_path)
 
     rc = cli_mod.cmd_sync_status(_mk_sync_status_args())
     assert rc == 0
@@ -261,7 +261,7 @@ def test_sync_status_with_recent_logs_events(tmp_path, monkeypatch, capsys):
     import llmwiki.cli as cli_mod
     import llmwiki.convert as convert_mod
     monkeypatch.setattr(convert_mod, "DEFAULT_STATE_FILE", state_file)
-    monkeypatch.setattr(cli_mod, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(cli_mod, "REPO_ROOT", tmp_path); import llmwiki.sync.status as sync_status_mod; monkeypatch.setattr(sync_status_mod, "REPO_ROOT", tmp_path)
     rc = cli_mod.cmd_sync_status(_mk_sync_status_args(recent=2))
     assert rc == 0
     out = capsys.readouterr().out
@@ -277,7 +277,7 @@ def test_sync_status_corrupt_state_file_is_tolerated(tmp_path, monkeypatch, caps
     import llmwiki.cli as cli_mod
     import llmwiki.convert as convert_mod
     monkeypatch.setattr(convert_mod, "DEFAULT_STATE_FILE", state_file)
-    monkeypatch.setattr(cli_mod, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(cli_mod, "REPO_ROOT", tmp_path); import llmwiki.sync.status as sync_status_mod; monkeypatch.setattr(sync_status_mod, "REPO_ROOT", tmp_path)
     rc = cli_mod.cmd_sync_status(_mk_sync_status_args())
     assert rc == 0
 


### PR DESCRIPTION
## Summary

Second pass extracting business logic from `cli.py` (after #611). Moves four blocks of domain logic — pipeline orchestration, sync observability, schedule config, and synthesis CLI helpers — into proper domain modules. `cli.py` keeps thin re-export wrappers for back-compat. **`cli.py`: 1,228 → 942 LOC (-286)**, hitting the architect-flagged sub-900 target almost exactly.

Closes #691 (`#arch-h8` follow-up).

## What changed

| Symbol | Old | New | Re-export |
|---|---|---|---|
| `cmd_all` (110 LOC) | `llmwiki/cli.py:43` | `llmwiki/pipeline.py:run_pipeline` | yes — `cmd_all` is a one-liner shim |
| `cmd_sync_status` (90 LOC) | `llmwiki/cli.py:473` | `llmwiki/sync/status.py:cmd_sync_status` | yes |
| `_resolve_key_exists` | `llmwiki/cli.py:565` | `llmwiki/sync/status.py:resolve_key_exists` | yes (as `_resolve_key_exists`) |
| `_load_schedule_config` | `llmwiki/cli.py:288` | `llmwiki/config_schedule.py:load_schedule_config` | yes |
| `_should_run_after_sync` | `llmwiki/cli.py:306` | `llmwiki/config_schedule.py:should_run_after_sync` | yes |
| `_synthesize_list_pending` | `llmwiki/cli.py:765` | `llmwiki/synth/cli_helpers.py:list_pending` | yes |
| `_synthesize_complete` | `llmwiki/cli.py:791` | `llmwiki/synth/cli_helpers.py:complete` | yes |

## What's new

| Surface | Change |
|---|---|
| `llmwiki/pipeline.py` | new — pipeline orchestrator |
| `llmwiki/sync/` | new package — `__init__.py` + `status.py` |
| `llmwiki/config_schedule.py` | new — `load_schedule_config` + `should_run_after_sync` |
| `llmwiki/synth/cli_helpers.py` | new — pairs with existing `synth/estimate.py` |
| `cli.py` LOC | 1,228 → 942 (-286) |
| Public import paths | unchanged — every `from llmwiki.cli import …` keeps working |

## Behavioural delta

| | Before | After |
|---|---|---|
| `cmd_all` lives in | `cli.py` | `pipeline.py` (re-exported) |
| Sync observability lives in | `cli.py` | `sync/status.py` (re-exported) |
| Schedule config lives in | `cli.py` | `config_schedule.py` (re-exported) |
| Synth CLI helpers (3 of 3) | mixed: 1 in `synth/`, 2 in `cli.py` | all 3 in `synth/` (1.3.80 makes it consistent) |
| Test surface | passing | passing (5 monkeypatch sites updated to also patch `sync.status.REPO_ROOT`) |
| Behavior visible to users | n/a | identical — pure refactor |

## How to test it

```bash
python3 -m pytest tests/ -q -m "not slow"
python3 -c "from llmwiki.cli import cmd_all, cmd_sync_status, _resolve_key_exists, _load_schedule_config, _should_run_after_sync, _synthesize_list_pending, _synthesize_complete; print('back-compat OK')"
python3 -c "from llmwiki.pipeline import run_pipeline; from llmwiki.sync.status import cmd_sync_status, resolve_key_exists; from llmwiki.config_schedule import load_schedule_config, should_run_after_sync; from llmwiki.synth.cli_helpers import list_pending, complete; print('canonical OK')"
python3 -m llmwiki adapters
python3 -m llmwiki sync --status
```

## Pre-merge checklist

- [x] **One intent** — single follow-up refactor; no behavior change
- [x] **All CI checks green** — local non-slow suite passes; CI to confirm
- [x] **Linked issue** — `Closes #691` in body
- [x] **Conventional-commit title** — `refactor(cli): ...`
- [x] **Tests added or updated** — N/A; existing tests reach the moved functions through the re-exports unchanged. 5 monkeypatch sites in `test_cli_observability.py` updated to also patch the new namespace's `REPO_ROOT`.
- [x] **CHANGELOG.md updated** — `[1.3.80]` Changed + Filed
- [x] **Breaking changes flagged** — N/A; back-compat preserved on every public import path
- [x] **No new runtime dependencies** — N/A
- [x] **No real session data** — N/A
- [x] **No machine-specific paths** — N/A
- [x] **Docs updated** — N/A; the moved functions are internal, no public-doc references
- [x] **Release notes drafted** — see CHANGELOG.md `[1.3.80]`
- [x] **UI verified** — N/A
- [x] **A11y verified** — N/A
- [x] **Commits GPG-signed** — yes
- [x] **Reviewer has read every changed line** — diff is mostly verbatim function moves; new modules are 1:1 copies with renamed public symbols + new docstrings

## Bundle

- `llmwiki/pipeline.py` — new (~130 LOC); owns `run_pipeline`
- `llmwiki/sync/__init__.py` + `llmwiki/sync/status.py` — new (~110 LOC total); own sync observability
- `llmwiki/config_schedule.py` — new (~50 LOC); owns schedule policy
- `llmwiki/synth/cli_helpers.py` — new (~95 LOC); owns synth CLI helpers
- `llmwiki/cli.py` — 6 import re-exports added at top; 4 function bodies replaced with thin shims; 1,228 → 942 LOC
- `tests/test_cli_observability.py` — 5 monkeypatch sites updated for the new namespace
- `llmwiki/__init__.py`, `pyproject.toml` — version 1.3.79 → 1.3.80
- `README.md` — version badge bump
- `CHANGELOG.md` — `[1.3.80]` Changed + Filed sections

## Out of scope / follow-ups

- The `synth/estimate.py` private-API reach (`_discover_raw_sessions`, `_load_state`) flagged in the v1.3.78 architect review is held for a separate PR — promoting those to public touches `synth/pipeline.py`'s public surface and warrants its own focused change.
- `cli.py` is now 942 LOC. The remaining content is mostly the argparse parser definition (~250 LOC) + small `cmd_*` thin wrappers + `_add_vault_arg` etc. Further extraction (e.g. the parser builder itself into `llmwiki/cli/parser.py`) could shrink it more but at diminishing returns.

## Next

After merge: tag `v1.3.80`. The architect-review extraction targets are now closed; the only remaining open issues are #383 (deferred), #397 (deferred), #462 (Playwright epic, gated on Node), #464 (Node bootstrap), #467 (Node healer-in-CI). Backlog is otherwise empty.