### PR TITLE
feat: add copilot-setup-steps workflow to enable Copilot remote coding agent

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,20 @@
+name: "Copilot Setup Steps"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install llmwiki and dev dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[dev]'


### PR DESCRIPTION
Adds `.github/workflows/copilot-setup-steps.yml` to enable the GitHub Copilot remote coding agent for this repository.

The `copilot-setup-steps` job installs Python 3.12 and the llmwiki dev dependencies so Copilot has a working environment when it picks up issues or tasks.