### PR TITLE
fix(convert): give Codex rollout stems a unique slug

### DIFF
--- a/llmwiki/convert.py
+++ b/llmwiki/convert.py
@@ -1040,6 +1040,17 @@ _UUID_LIKE = re.compile(
     re.IGNORECASE,
 )
 
+# A UUID anchored at the *end* of a stem. Codex CLI names every
+# transcript ``rollout-<ISO-timestamp>-<uuid>.jsonl``, so the stem
+# starts with ``rollout-2026`` for every session and ``stem[:12]``
+# collapses an entire project/day of Codex sessions onto one slug.
+# Detecting the trailing UUID lets those stems take the same stable
+# source-hash fallback that bare-UUID stems already use (#424).
+_UUID_TRAILING = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
 
 def derive_session_slug(records: list[dict[str, Any]], jsonl_path: Path) -> str:
     """Derive a slug from session records or fall back to the filename.
@@ -1073,6 +1084,13 @@ def derive_session_slug(records: list[dict[str, Any]], jsonl_path: Path) -> str:
         return _source_hash8(jsonl_path)
     if not stem:
         # Empty stem (rare — would require a literal ``.jsonl`` filename).
+        return _source_hash8(jsonl_path)
+    # Codex CLI stems carry a UUID at the *end* (``rollout-<ts>-<uuid>``)
+    # but a fixed ``rollout-2026`` prefix; the 12-char prefix would
+    # collapse every Codex session per project/day onto one slug. Treat
+    # a trailing UUID like a bare UUID — stable source hash, unique per
+    # source file — instead of leaning on the disambig pass.
+    if _UUID_TRAILING.search(stem):
         return _source_hash8(jsonl_path)
     return stem[:12]
 

--- a/tests/test_slug_fallback.py
+++ b/tests/test_slug_fallback.py
@@ -148,3 +148,41 @@ def test_hash_is_stable_across_calls():
     first = derive_session_slug([], p)
     second = derive_session_slug([], p)
     assert first == second
+
+
+def test_codex_rollout_stem_uses_hash_not_rollout_prefix():
+    """Codex CLI names every transcript ``rollout-<ts>-<uuid>.jsonl``.
+
+    The stem starts ``rollout-2026`` for every session, so the 12-char
+    prefix collapsed an entire project/day of Codex sessions onto the
+    single slug ``rollout-2026``. The trailing UUID must be detected so
+    these take the stable source-hash fallback instead.
+    """
+    p = Path(
+        "/c/2026/05/29/rollout-2026-05-29T09-43-52-"
+        "019e72e7-7672-79d1-a0d8-13d93cf93cd8.jsonl"
+    )
+    out = derive_session_slug([], p)
+    assert out == _source_hash8(p)
+    assert out != "rollout-2026"
+
+
+def test_two_codex_rollouts_same_day_produce_distinct_slugs():
+    """The point of the fix: two Codex sessions on the same project/day
+    no longer collide on ``rollout-2026``."""
+    a = Path(
+        "/c/2026/05/26/rollout-2026-05-26T13-03-44-"
+        "019e642b-5ddd-7762-85d2-b7c68a2a5835.jsonl"
+    )
+    b = Path(
+        "/c/2026/05/26/rollout-2026-05-26T14-11-34-"
+        "019e6469-7ad9-7460-aaaa-bbbbbbbbbbbb.jsonl"
+    )
+    assert derive_session_slug([], a) != derive_session_slug([], b)
+
+
+def test_trailing_uuid_only_matches_full_uuid_shape():
+    """A stem ending in a hyphenated-but-not-UUID token keeps the
+    12-char prefix — the trailing-UUID rule requires 8-4-4-4-12 hex."""
+    p = Path("/tmp/notes-2026-05-01-final-draft.jsonl")
+    assert derive_session_slug([], p) == "notes-2026-0"


### PR DESCRIPTION
## Problem

Every Codex CLI session collapses onto a single slug, `rollout-2026`, so
distinct sessions collide on their `raw/` filename and merge into one
`wiki/sources` page — silent data loss of the same class as #292 / #339.

## Root cause

`derive_session_slug` (`llmwiki/convert.py`) hashes UUID-named stems via
`_source_hash8` to avoid the shared-12-char-prefix collision that #448
(#424) fixed. But `_UUID_LIKE` is `^`-anchored:

```python
_UUID_LIKE = re.compile(r"^[0-9a-f]{8}-...-[0-9a-f]{12}", re.IGNORECASE)
```

so it only catches a UUID at the **start** of the stem. Codex CLI names
every transcript `rollout-<ISO-timestamp>-<uuid>.jsonl` (the `codex_cli`
adapter documents this naming). The UUID is at the **end**, behind a fixed
`rollout-` prefix, so the stem skips the hash branch and falls through to:

```python
return stem[:12]          # -> "rollout-2026" for ALL Codex sessions
```

## Fix

Detect a UUID anchored at the **end** of the stem and route it through the
same `_source_hash8` fallback — so each Codex session gets a distinct,
deterministic slug that's unique *without* leaning on the disambig pass
(the property #448 established for leading-UUID stems):

```python
_UUID_TRAILING = re.compile(
    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
    re.IGNORECASE,
)
# in derive_session_slug, before the stem[:12] fallback:
if _UUID_TRAILING.search(stem):
    return _source_hash8(jsonl_path)
```

## Tests

Adds regression coverage in `tests/test_slug_fallback.py`:
- a `rollout-<ts>-<uuid>` stem resolves to a hash, not `"rollout"`
- two same-day rollouts produce **distinct** slugs
- the trailing matcher only fires on a full UUID shape (no false positives
  on hex-ish tails)

## Lineage

Direct follow-on to #448 (#424), same files (`convert.py` +
`test_slug_fallback.py`), same design intent. Scoped to a supported adapter
(`codex_cli`). Low severity — the disambig pass partially masks it — but it
removes the latent slug/disambig coupling for Codex stems.
