### PR TITLE
Adapters: OpenClaw + Cursor-CLI, load_records hook, verbatim opt-in, vault-overlay build/sync fixes

### DIFF
--- a/llmwiki/adapters/__init__.py
+++ b/llmwiki/adapters/__init__.py
@@ -34,7 +34,7 @@ REGISTRY_ALIASES: dict[str, str] = {}
 # Contrib adapters that can be loaded on demand.
 CONTRIB_ADAPTERS = {
     "chatgpt", "copilot_chat", "copilot_cli",
-    "cursor", "gemini_cli", "obsidian", "opencode",
+    "cursor", "cursor_cli", "gemini_cli", "obsidian", "opencode", "openclaw",
 }
 
 

--- a/llmwiki/adapters/base.py
+++ b/llmwiki/adapters/base.py
@@ -171,6 +171,27 @@ class BaseAdapter:
         """
         return False
 
+    def load_records(self, path: Path) -> list[dict[str, Any]]:
+        """Load raw records from one discovered session path.
+
+        Default: parse the path as line-delimited JSON (``parse_jsonl``) — the
+        format every built-in coding-agent store uses. Adapters whose store is
+        NOT line-delimited JSON (e.g. an SQLite content-addressed blob store
+        like the Cursor CLI's ``store.db``) override this to return records in
+        the same raw shape ``parse_jsonl`` would, *before* ``normalize_records``
+        translates them into the shared Claude-style schema.
+
+        Called by ``convert.convert_all`` instead of calling ``parse_jsonl``
+        directly, so non-JSONL session stores plug in without the renderer or
+        the main loop knowing about their on-disk format.
+
+        The import is local to avoid a circular import (``convert`` imports the
+        adapter registry at module load).
+        """
+        from llmwiki.convert import parse_jsonl
+
+        return parse_jsonl(path)
+
     def normalize_records(self, records: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Normalize agent-specific JSONL records into the shared Claude-style
         format that ``llmwiki.convert`` expects.

--- a/llmwiki/adapters/contrib/cursor_cli.py
+++ b/llmwiki/adapters/contrib/cursor_cli.py
@@ -1,0 +1,181 @@
+"""Cursor CLI (cursor-agent) session-store adapter.
+
+This is distinct from the Cursor *IDE* adapter (``cursor.py``), which reads the
+IDE's ``workspaceStorage/state.vscdb``. The Cursor **CLI** (``cursor-agent``)
+stores each chat under:
+
+    ~/.cursor/chats/<workspace-hash>/<chat-uuid>/store.db
+
+``store.db`` is a content-addressed blob store (git-like)::
+
+    meta(key, value)      -- value is hex-encoded JSON: {agentId, latestRootBlobId, ...}
+    blobs(id, data)       -- id = content hash; data = a JSON message OR a binary
+                             protobuf "tree" node that references child blob ids
+
+Message blobs are JSON: ``{"role": "system"|"user"|"assistant"|"tool",
+"content": str|list, ...}``. They carry no timestamp/sequence field — ordering
+lives in the binary tree. We recover order by reading the root tree blob
+(``latestRootBlobId``) and sorting message blobs by the byte offset at which
+their id first appears in the root blob's bytes. That reproduces the on-screen
+conversation order (validated against real transcripts).
+
+Fidelity notes:
+- User prompts are kept **verbatim** (full content, including any ``<user_info>``
+  context Cursor injects) so nothing the user typed is lost.
+- System prompts and tool-result turns are dropped (noise for a knowledge wiki).
+- Assistant ``reasoning`` blocks map to ``thinking`` (dropped by the shared
+  renderer by default); ``text`` is kept; ``tool-call`` maps to ``tool_use``.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from llmwiki.adapters import register
+from llmwiki.adapters.base import BaseAdapter
+
+
+@register("cursor_cli", aliases=["cursor-cli"])
+class CursorCliAdapter(BaseAdapter):
+    """Cursor CLI (cursor-agent) — reads ~/.cursor/chats/*/*/store.db"""
+
+    is_ai_session = True
+
+    session_store_path = Path.home() / ".cursor" / "chats"
+
+    def discover_sessions(self) -> list[Path]:
+        store = Path(self.session_store_path).expanduser()
+        if not store.exists():
+            return []
+        return sorted(store.rglob("store.db"))
+
+    def derive_project_slug(self, path: Path) -> str:
+        """Use the workspace-hash directory (first segment under chats/)."""
+        store = Path(self.session_store_path).expanduser()
+        try:
+            rel = path.relative_to(store)
+        except ValueError:
+            return path.parent.name
+        ws = rel.parts[0] if rel.parts else path.parent.name
+        return f"cursor-{ws[:12]}"
+
+    # ── non-JSONL load: parse the SQLite blob store into ordered messages ──
+
+    def load_records(self, path: Path) -> list[dict[str, Any]]:
+        con = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        con.text_factory = bytes
+        try:
+            blobs = dict(con.execute("SELECT id, data FROM blobs").fetchall())
+            meta_rows = con.execute("SELECT key, value FROM meta").fetchall()
+        finally:
+            con.close()
+
+        json_msgs: dict[str, dict[str, Any]] = {}
+        for bid, data in blobs.items():
+            try:
+                obj = json.loads(data.decode("utf-8"))
+            except Exception:
+                continue
+            if isinstance(obj, dict) and ("role" in obj or "content" in obj):
+                json_msgs[bid.decode()] = obj
+
+        root_id = self._root_blob_id(meta_rows)
+        ordered_ids = self._order_by_tree(root_id, blobs, set(json_msgs))
+        if ordered_ids:
+            return [json_msgs[i] for i in ordered_ids if i in json_msgs]
+        # Fallback: no recoverable tree — return messages in arbitrary store order.
+        return list(json_msgs.values())
+
+    @staticmethod
+    def _root_blob_id(meta_rows: list[tuple]) -> str | None:
+        for _key, value in meta_rows:
+            try:
+                raw = value.decode() if isinstance(value, bytes) else value
+                decoded = json.loads(bytes.fromhex(raw).decode("utf-8"))
+                rid = decoded.get("latestRootBlobId")
+                if rid:
+                    return rid
+            except Exception:
+                continue
+        return None
+
+    @staticmethod
+    def _order_by_tree(
+        root_id: str | None, blobs: dict, known_ids: set[str]
+    ) -> list[str]:
+        """Order known message ids by first byte-offset in the root tree blob."""
+        if not root_id:
+            return []
+        root = blobs.get(root_id.encode())
+        if root is None:
+            return []
+        hexs = root.hex()
+        offsets: list[tuple[int, str]] = []
+        for sid in known_ids:
+            i = hexs.find(sid)
+            if i >= 0:
+                offsets.append((i, sid))
+        offsets.sort()
+        return [sid for _i, sid in offsets]
+
+    # ── map Cursor records into the shared Claude-style schema ──
+
+    def normalize_records(self, records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        for rec in records:
+            if not isinstance(rec, dict):
+                continue
+            role = rec.get("role")
+            if role == "user":
+                content = rec.get("content")
+                text = content if isinstance(content, str) else _join_text(content)
+                out.append({"type": "user", "message": {"role": "user", "content": text}})
+            elif role == "assistant":
+                blocks = _map_assistant_blocks(rec.get("content"))
+                if blocks:
+                    out.append(
+                        {"type": "assistant", "message": {"role": "assistant", "content": blocks}}
+                    )
+            # system + tool roles are intentionally dropped.
+        return out
+
+
+def _join_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts = [
+        b.get("text", "")
+        for b in content
+        if isinstance(b, dict) and b.get("type") in ("text", "reasoning")
+    ]
+    return "\n".join(p for p in parts if p)
+
+
+def _map_assistant_blocks(content: Any) -> list[dict[str, Any]]:
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}] if content else []
+    if not isinstance(content, list):
+        return []
+    blocks: list[dict[str, Any]] = []
+    for b in content:
+        if not isinstance(b, dict):
+            continue
+        t = b.get("type")
+        if t == "text":
+            blocks.append({"type": "text", "text": b.get("text", "")})
+        elif t == "reasoning":
+            blocks.append({"type": "thinking", "thinking": b.get("text", "")})
+        elif t == "tool-call":
+            blocks.append(
+                {
+                    "type": "tool_use",
+                    "name": b.get("toolName", "tool"),
+                    "input": b.get("args") or b.get("input") or {},
+                }
+            )
+    return blocks

--- a/llmwiki/adapters/contrib/openclaw.py
+++ b/llmwiki/adapters/contrib/openclaw.py
@@ -1,0 +1,122 @@
+"""OpenClaw session-store adapter.
+
+OpenClaw (https://openclaw.ai) is a TypeScript AI-agent gateway. Each agent
+writes one transcript per session under:
+
+    ~/.openclaw/agents/<agent>/sessions/<session-uuid>.jsonl
+
+Alongside each transcript it writes ``<uuid>.trajectory.jsonl`` and
+``<uuid>.trajectory-path.json`` (tool-execution traces, 2026.6.1+); those are
+NOT conversation transcripts and are skipped here.
+
+On-disk record shape (one JSON object per line)::
+
+    {"type": "session", "version": ..., "id": ..., "cwd": ...}          # header
+    {"type": "model_change", ...}                                        # control
+    {"type": "message", "id": ..., "parentId": ..., "timestamp": ...,
+     "message": {"role": "user"|"assistant", "content": [...], ...}}     # turn
+
+Only ``type == "message"`` records carry conversation content. Their nested
+``message`` block is Anthropic-shaped (``content`` is a list of typed blocks
+for assistants; for users it is also a list, which we flatten to a string so
+the shared renderer — which expects a string user prompt — keeps it verbatim).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from llmwiki.adapters import register
+from llmwiki.adapters.base import BaseAdapter
+
+
+def _flatten_text_blocks(content: Any) -> str:
+    """Join the ``text`` of every text block in an Anthropic-style content list.
+
+    OpenClaw stores even user messages as ``[{"type": "text", "text": "..."}]``.
+    The shared ``render_user_prompt`` only renders string content, so user
+    prompts must be flattened or they render empty. Non-text blocks are dropped
+    (user turns are text in practice).
+    """
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "text":
+            text = block.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+        elif isinstance(block, str):
+            parts.append(block)
+    return "\n".join(parts)
+
+
+@register("openclaw")
+class OpenClawAdapter(BaseAdapter):
+    """OpenClaw — reads ~/.openclaw/agents/*/sessions/*.jsonl (skips trajectories)"""
+
+    is_ai_session = True
+
+    # The store root; discover_sessions() narrows to <agent>/sessions/*.jsonl.
+    session_store_path = Path.home() / ".openclaw" / "agents"
+
+    def discover_sessions(self) -> list[Path]:
+        """Find every conversation transcript, excluding trajectory sidecars.
+
+        Layout is ``<agent>/sessions/<uuid>.jsonl``; ``*.trajectory.jsonl`` are
+        tool-execution traces, not transcripts, and are filtered out.
+        """
+        store = Path(self.session_store_path).expanduser()
+        if not store.exists():
+            return []
+        return sorted(
+            p
+            for p in store.rglob("*.jsonl")
+            if not p.name.endswith(".trajectory.jsonl")
+        )
+
+    def derive_project_slug(self, jsonl_path: Path) -> str:
+        """Use the agent directory name (e.g. 'main') as the project slug."""
+        store = Path(self.session_store_path).expanduser()
+        try:
+            rel = jsonl_path.relative_to(store)
+        except ValueError:
+            return jsonl_path.parent.name
+        agent = rel.parts[0] if rel.parts else jsonl_path.parent.name
+        return f"openclaw-{agent}"
+
+    def normalize_records(self, records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Translate OpenClaw typed records into the shared Claude-style schema.
+
+        Keep only ``type == "message"`` records; re-key by the inner role
+        (``{"type": "user"|"assistant", "message": {...}}``) and flatten user
+        content to a string so the shared renderer keeps the prompt verbatim.
+        Control records (session/model_change/thinking_level_change/custom) are
+        dropped — they carry no conversation content.
+        """
+        out: list[dict[str, Any]] = []
+        for rec in records:
+            if not isinstance(rec, dict) or rec.get("type") != "message":
+                continue
+            msg = rec.get("message")
+            if not isinstance(msg, dict):
+                continue
+            role = msg.get("role")
+            if role not in ("user", "assistant"):
+                continue
+            new_msg = dict(msg)
+            if role == "user":
+                new_msg["content"] = _flatten_text_blocks(msg.get("content"))
+            out.append(
+                {
+                    "type": role,
+                    "uuid": rec.get("id"),
+                    "parentUuid": rec.get("parentId"),
+                    "timestamp": rec.get("timestamp"),
+                    "message": new_msg,
+                }
+            )
+        return out

--- a/llmwiki/build.py
+++ b/llmwiki/build.py
@@ -2338,16 +2338,22 @@ def build_site(
     claude_path: str = "",
     search_mode: str = "auto",
     seed_project_stubs: bool = False,
+    raw_sessions: Path = RAW_SESSIONS,
+    raw_dir: Path = RAW_DIR,
 ) -> int:
-    if not RAW_SESSIONS.exists():
+    # #54 vault-overlay: ``raw_sessions``/``raw_dir`` default to the repo
+    # constants so repo-mode builds are unchanged, but ``build --vault``
+    # passes the vault's raw/ so the site is built from vault sessions
+    # rather than the (often empty) repo checkout.
+    if not raw_sessions.exists():
         print(
-            f"error: {RAW_SESSIONS} does not exist. Run `llmwiki init` + `llmwiki sync` first.",
+            f"error: {raw_sessions} does not exist. Run `llmwiki init` + `llmwiki sync` first.",
             file=sys.stderr,
         )
         return 2
 
-    print(f"==> scanning {RAW_SESSIONS}")
-    sources = discover_sources(RAW_SESSIONS)
+    print(f"==> scanning {raw_sessions}")
+    sources = discover_sources(raw_sessions)
     if not sources:
         print("  no sources found.", file=sys.stderr)
         return 2
@@ -2406,11 +2412,11 @@ def build_site(
     sources_out = out_dir / "sources"
     if sources_out.exists():
         shutil.rmtree(sources_out)
-    shutil.copytree(RAW_SESSIONS, sources_out)
+    shutil.copytree(raw_sessions, sources_out)
     print(f"  copied raw .md sources to sources/")
 
     # v0.7 (#96): copy downloaded image assets into site/assets/
-    raw_assets = RAW_DIR / "assets"
+    raw_assets = raw_dir / "assets"
     if raw_assets.exists() and any(raw_assets.iterdir()):
         site_assets = out_dir / "assets"
         if site_assets.exists():

--- a/llmwiki/cli.py
+++ b/llmwiki/cli.py
@@ -179,10 +179,16 @@ def cmd_sync(args: argparse.Namespace) -> int:
         site_root = (vault.root / "site") if vault_path else (REPO_ROOT / "site")
         if args.auto_build and _should_run_after_sync(schedule.get("build", "on-sync")):
             print("  auto-build: regenerating site/...")
-            from llmwiki.build import build_site
+            from llmwiki.build import build_site, RAW_SESSIONS, RAW_DIR
+            # #54 vault-overlay: read the freshly-synced sessions from the
+            # vault, not the repo's empty raw/ (which makes auto-build fail
+            # with "RAW_SESSIONS does not exist" right after a vault sync).
+            raw_sessions = (vault.root / "raw" / "sessions") if vault_path else RAW_SESSIONS
+            raw_dir = (vault.root / "raw") if vault_path else RAW_DIR
             # #414: sync has explicit user opt-in to mutate wiki/, so it's
             # the right place to seed project stubs.
-            build_site(out_dir=site_root, seed_project_stubs=True)
+            build_site(out_dir=site_root, seed_project_stubs=True,
+                       raw_sessions=raw_sessions, raw_dir=raw_dir)
         if args.auto_lint and _should_run_after_sync(schedule.get("lint", "manual")):
             print("  auto-lint: running wiki lint...")
             from llmwiki.lint import load_pages, run_all, summarize
@@ -208,6 +214,8 @@ def cmd_build(args: argparse.Namespace) -> int:
 
     # v1.2 (#54): vault-overlay mode. Validate the path up front so a
     # typo fails fast before the build walks raw/.
+    from llmwiki.build import RAW_SESSIONS, RAW_DIR
+    raw_sessions, raw_dir, out_dir = RAW_SESSIONS, RAW_DIR, args.out
     if getattr(args, "vault", None):
         from llmwiki.vault import describe_vault, resolve_vault
         try:
@@ -216,13 +224,22 @@ def cmd_build(args: argparse.Namespace) -> int:
             print(f"error: {exc}", file=sys.stderr)
             return 2
         print(f"==> {describe_vault(vault)}")
+        # Read sessions from the vault, and (unless --out was overridden)
+        # write the site under the vault so a vault build doesn't silently
+        # populate the repo's site/.
+        raw_dir = vault.root / "raw"
+        raw_sessions = raw_dir / "sessions"
+        if args.out == REPO_ROOT / "site":
+            out_dir = vault.root / "site"
 
     return build_site(
-        out_dir=args.out,
+        out_dir=out_dir,
         synthesize=args.synthesize,
         claude_path=args.claude,
         search_mode=args.search_mode,
         seed_project_stubs=getattr(args, "seed_project_stubs", False),
+        raw_sessions=raw_sessions,
+        raw_dir=raw_dir,
     )
 
 

--- a/llmwiki/convert.py
+++ b/llmwiki/convert.py
@@ -1390,11 +1390,14 @@ def convert_all(
     discover_adapters()
     selected: list[type] = []
     if adapters:
-        # #v1378-review: aliases now live in REGISTRY_ALIASES, not
-        # REGISTRY itself, so resolve through resolve_adapter_name to
-        # support both canonical names and historical kebab-case
-        # aliases (e.g. `--adapter copilot-chat`).
-        from llmwiki.adapters import resolve_adapter_name
+        # Contrib adapters (cursor_cli, openclaw, gemini_cli, …) register
+        # lazily, so an explicit ``--adapter <contrib>`` must import them
+        # before we resolve names — otherwise the lookup fails with
+        # "unknown adapter" even though the adapter ships. Default-fire (the
+        # ``else`` branch) intentionally stays core-only to keep contrib
+        # adapters opt-in.
+        from llmwiki.adapters import resolve_adapter_name, discover_contrib
+        discover_contrib()
         for name in adapters:
             canonical = resolve_adapter_name(name)
             if canonical is None:

--- a/llmwiki/convert.py
+++ b/llmwiki/convert.py
@@ -722,6 +722,11 @@ def _close_open_fence(text: str) -> str:
 
 
 def truncate_chars(text: str, max_chars: int) -> str:
+    # max_chars <= 0 means "no limit" — used for verbatim capture (e.g.
+    # setting truncation.user_prompt_chars: 0 keeps user prompts byte-exact;
+    # redaction still applies). Without this, max_chars=0 truncated to "".
+    if max_chars <= 0:
+        return text
     if not text or len(text) <= max_chars:
         return text
     kept = _close_open_fence(text[:max_chars])
@@ -1532,13 +1537,17 @@ def convert_all(
             # failures through the quarantine + 'errored' bucket the same
             # way write failures do. Previously the helper swallowed them
             # and the file silently became 'filtered' (zero records).
+            # #adapter-load-records: adapters whose store is not line-delimited
+            # JSON (e.g. Cursor CLI's SQLite store.db) override load_records();
+            # the default delegates to parse_jsonl, so JSONL adapters are
+            # unchanged. Keeps non-JSONL session stores out of the main loop.
             try:
-                records = parse_jsonl(path)
+                records = adapter.load_records(path)
             except OSError as e:
                 print(f"  error: {path.name}: {e}", file=sys.stderr)
                 errors += 1
                 _bump(cls.name, "errored")
-                _quarantine_add(cls.name, str(path), f"parse_jsonl I/O failed: {e}")
+                _quarantine_add(cls.name, str(path), f"load_records I/O failed: {e}")
                 continue
             # v0.5 (#109): normalize agent-specific records into the shared
             # Claude-style format before filtering/rendering. This lets each

--- a/tests/test_openclaw_cursor_cli_adapters.py
+++ b/tests/test_openclaw_cursor_cli_adapters.py
@@ -103,3 +103,16 @@ def test_cursor_cli_loads_orders_and_normalizes(tmp_path: Path):
     assert norm[0]["message"]["content"] == "<user_query>what is 2+2</user_query>"
     kinds = [b["type"] for b in norm[1]["message"]["content"]]
     assert kinds == ["thinking", "text"]
+
+
+def test_build_site_honors_raw_sessions_param(tmp_path: Path):
+    # Regression (#54 vault build): build_site used the module-level
+    # RAW_SESSIONS constant, so `build --vault` silently read the repo's
+    # raw/ instead of the vault's. It must read the path it's given.
+    from llmwiki.build import build_site
+
+    missing = tmp_path / "vault" / "raw" / "sessions"
+    rc = build_site(out_dir=tmp_path / "site", raw_sessions=missing, raw_dir=missing.parent)
+    # Honors the passed path: reports it missing and bails (rc 2) rather
+    # than scanning the module constant.
+    assert rc == 2

--- a/tests/test_openclaw_cursor_cli_adapters.py
+++ b/tests/test_openclaw_cursor_cli_adapters.py
@@ -1,0 +1,105 @@
+"""Tests for the OpenClaw + Cursor-CLI adapters and the load_records hook."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from llmwiki.adapters import REGISTRY, discover_all
+from llmwiki.adapters.contrib.openclaw import OpenClawAdapter, _flatten_text_blocks
+from llmwiki.adapters.contrib.cursor_cli import CursorCliAdapter
+from llmwiki.convert import truncate_chars
+
+
+def test_adapters_register():
+    discover_all()
+    assert "openclaw" in REGISTRY
+    assert "cursor_cli" in REGISTRY
+
+
+def test_truncate_chars_zero_means_no_limit():
+    # The verbatim lever: max_chars <= 0 returns the text untouched.
+    big = "x" * 10000
+    assert truncate_chars(big, 0) == big
+    assert truncate_chars(big, -1) == big
+    assert "truncated" in truncate_chars(big, 100)
+
+
+def test_flatten_text_blocks():
+    assert _flatten_text_blocks("hello") == "hello"
+    assert _flatten_text_blocks([{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]) == "a\nb"
+    assert _flatten_text_blocks([{"type": "image"}]) == ""
+
+
+def test_openclaw_normalize_keeps_only_messages_and_flattens_user():
+    records = [
+        {"type": "session", "id": "s"},
+        {"type": "model_change", "id": "m"},
+        {"type": "message", "id": "1", "parentId": None, "timestamp": "t",
+         "message": {"role": "user", "content": [{"type": "text", "text": "hi there"}]}},
+        {"type": "message", "id": "2", "parentId": "1", "timestamp": "t",
+         "message": {"role": "assistant", "content": [{"type": "text", "text": "hello"}]}},
+    ]
+    out = OpenClawAdapter().normalize_records(records)
+    assert [r["type"] for r in out] == ["user", "assistant"]
+    # User content flattened to a string so the shared renderer keeps it verbatim.
+    assert out[0]["message"]["content"] == "hi there"
+    # Assistant content kept as blocks.
+    assert isinstance(out[1]["message"]["content"], list)
+
+
+def test_openclaw_discover_skips_trajectories(tmp_path: Path, monkeypatch):
+    store = tmp_path / ".openclaw" / "agents" / "main" / "sessions"
+    store.mkdir(parents=True)
+    (store / "a.jsonl").write_text("{}")
+    (store / "a.trajectory.jsonl").write_text("{}")
+    ad = OpenClawAdapter()
+    ad.session_store_path = tmp_path / ".openclaw" / "agents"
+    found = [p.name for p in ad.discover_sessions()]
+    assert found == ["a.jsonl"]
+    assert ad.derive_project_slug(store / "a.jsonl") == "openclaw-main"
+
+
+def _make_cursor_store(db_path: Path, messages: list[dict]) -> None:
+    """Build a minimal Cursor CLI store.db: JSON message blobs + a root tree
+    blob whose bytes reference the message ids in order."""
+    con = sqlite3.connect(db_path)
+    con.execute("CREATE TABLE blobs (id TEXT PRIMARY KEY, data BLOB)")
+    con.execute("CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT)")
+    ids = []
+    for i, msg in enumerate(messages):
+        bid = f"{i:064x}"  # deterministic 64-hex id
+        ids.append(bid)
+        con.execute("INSERT INTO blobs VALUES (?, ?)", (bid, json.dumps(msg).encode()))
+    # Root tree blob: raw bytes are the message ids concatenated (in order),
+    # so offset-ordering recovers the conversation order.
+    root_id = "f" * 64
+    root_bytes = ("".join(ids)).encode()
+    con.execute("INSERT INTO blobs VALUES (?, ?)", (root_id, root_bytes))
+    con.execute("INSERT INTO meta VALUES (?, ?)",
+                ("0", json.dumps({"latestRootBlobId": root_id}).encode().hex()))
+    con.commit()
+    con.close()
+
+
+def test_cursor_cli_loads_orders_and_normalizes(tmp_path: Path):
+    db = tmp_path / "store.db"
+    _make_cursor_store(db, [
+        {"role": "system", "content": "you are an assistant"},
+        {"role": "user", "content": "<user_query>what is 2+2</user_query>"},
+        {"id": "1", "role": "assistant",
+         "content": [{"type": "reasoning", "text": "think"}, {"type": "text", "text": "4"}]},
+        {"role": "tool", "content": [{"type": "tool-result", "result": "noise"}]},
+    ])
+    ad = CursorCliAdapter()
+    raw = ad.load_records(db)
+    # Ordered by appearance in the root tree: system, user, assistant, tool.
+    assert [r.get("role") for r in raw] == ["system", "user", "assistant", "tool"]
+
+    norm = ad.normalize_records(raw)
+    # system + tool dropped; user + assistant kept.
+    assert [r["type"] for r in norm] == ["user", "assistant"]
+    assert norm[0]["message"]["content"] == "<user_query>what is 2+2</user_query>"
+    kinds = [b["type"] for b in norm[1]["message"]["content"]]
+    assert kinds == ["thinking", "text"]


### PR DESCRIPTION
Adds two session adapters and the small engine plumbing needed to use them end-to-end (CLI discovery + vault-overlay build/sync). All changes are general — no downstream-specific code.

## Adapters
- **OpenClaw** (`adapters/contrib/openclaw.py`) — reads `~/.openclaw/agents/*/sessions/*.jsonl` (skips `.trajectory.jsonl`); `normalize_records` keeps only `type:"message"` records and flattens the Anthropic block-list user content to text.
- **Cursor-CLI** (`adapters/contrib/cursor_cli.py`, alias `cursor-cli`) — reads `~/.cursor/chats/*/store.db`. Cursor's CLI uses a content-addressed SQLite blob store (not the JSONL the existing `cursor` adapter expects); `load_records` parses the message blobs and recovers conversation order from the root tree blob; `normalize_records` maps reasoning→thinking / text→text / tool-call→tool_use and drops system/tool noise.

## Plumbing
- **`BaseAdapter.load_records()` hook** (`adapters/base.py`) — lets non-JSONL stores (like the Cursor blob DB) feed `convert_all` without it assuming `parse_jsonl`. Default delegates to `parse_jsonl`, so existing adapters are unchanged.
- **Verbatim opt-in** — `truncate_chars` now treats `max_chars <= 0` as "no limit", so `truncation.user_prompt_chars: 0` keeps user prompts byte-exact (secret-redaction still applies). Default stays 4000.
- **Contrib discovery for explicit `--adapter`** (`convert.py`) — `convert_all` only ran `discover_adapters()` (core), so `--adapter cursor_cli`/`openclaw` failed with "unknown adapter" even though the adapter ships. Now discovers contrib adapters when names are passed explicitly; default-fire stays core-only (contrib remains opt-in).
- **Vault-overlay build/sync honor `--vault`** (`build.py`, `cli.py`) — `build_site` hardcoded the repo's `RAW_SESSIONS`, so `build --vault` (and the auto-build after `sync --vault`) scanned the repo's empty `raw/` and failed. Thread `raw_sessions`/`raw_dir` params (default to the module constants → repo-mode unchanged); `cmd_build`/`cmd_sync` pass the vault's `raw/` and write the site under the vault.

## Tests
`tests/test_openclaw_cursor_cli_adapters.py` — adapter registration, OpenClaw normalize/flatten, Cursor blob ordering + normalize, the verbatim lever, and a `build_site` raw-sessions regression. All pass (`pytest` with `markdown` installed).